### PR TITLE
fix: hide Windows SSH consoles and keep RAMIC daemon alive

### DIFF
--- a/src/virtuoso_bridge/transport/ssh.py
+++ b/src/virtuoso_bridge/transport/ssh.py
@@ -15,7 +15,7 @@ import threading
 import time
 import uuid
 from pathlib import Path
-from typing import NamedTuple
+from typing import Any, NamedTuple
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +55,20 @@ def _mark_interpreter_shutdown() -> None:
     _INTERPRETER_SHUTTING_DOWN = True
 
 atexit.register(_mark_interpreter_shutdown)
+
+
+def _windows_no_window_kwargs() -> dict[str, Any]:
+    """Best-effort hidden console launch on Windows for CLI tools like ssh/scp/tar."""
+    if os.name != "nt":
+        return {}
+
+    startupinfo = subprocess.STARTUPINFO()  # type: ignore[attr-defined]
+    startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW  # type: ignore[attr-defined]
+    startupinfo.wShowWindow = 0  # SW_HIDE
+    return {
+        "creationflags": subprocess.CREATE_NO_WINDOW,  # type: ignore[attr-defined]
+        "startupinfo": startupinfo,
+    }
 
 class RemoteSshEnv(NamedTuple):
     """SSH settings read from environment variables."""
@@ -150,6 +164,7 @@ class SSHRunner:
                 capture_output=True,
                 text=True,
                 timeout=effective_timeout,
+                **_windows_no_window_kwargs(),
             )
             success = result.returncode == 0
             if success:
@@ -205,6 +220,7 @@ class SSHRunner:
             capture_output=True,
             text=True,
             timeout=effective_timeout,
+            **_windows_no_window_kwargs(),
         )
         logger.debug(
             "Remote command returned %d (stdout=%d bytes, stderr=%d bytes)",
@@ -260,9 +276,18 @@ class SSHRunner:
                 tar_cmd += ["-C", str(local_path.resolve().parent), local_path.name]
 
             logger.debug("Batch tar upload: %d file(s) -> %s:%s", len(entries), self._host, remote_dir)
-            tar_proc = subprocess.Popen(tar_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            tar_proc = subprocess.Popen(
+                tar_cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                **_windows_no_window_kwargs(),
+            )
             ssh_proc = subprocess.Popen(
-                ssh_cmd, stdin=tar_proc.stdout, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                ssh_cmd,
+                stdin=tar_proc.stdout,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                **_windows_no_window_kwargs(),
             )
             if tar_proc.stdout:
                 tar_proc.stdout.close()
@@ -321,7 +346,14 @@ class SSHRunner:
         if self._verbose:
             print(f"[cmd] {' '.join(cmd)}  # upload -> {remote_path}", flush=True)
         logger.debug("Uploading text payload (%d chars) -> %s:%s", len(text), self._host, remote_path)
-        result = subprocess.run(cmd, input=text, capture_output=True, text=True, timeout=effective_timeout)
+        result = subprocess.run(
+            cmd,
+            input=text,
+            capture_output=True,
+            text=True,
+            timeout=effective_timeout,
+            **_windows_no_window_kwargs(),
+        )
         if result.returncode != 0:
             logger.warning("SSH text upload failed (rc=%d): %s", result.returncode, result.stderr.strip())
         else:
@@ -362,7 +394,13 @@ class SSHRunner:
         cmd += [self._remote_scp_target(remote_path), str(local_path)]
         self._print_cmd(cmd)
         logger.debug("Downloading via scp %s:%s -> %s", self._host, remote_path, local_path)
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=effective_timeout)
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=effective_timeout,
+            **_windows_no_window_kwargs(),
+        )
         if result.returncode != 0:
             logger.warning("download (scp) failed (rc=%d): %s", result.returncode, result.stderr.strip())
         else:
@@ -396,9 +434,18 @@ class SSHRunner:
             print(f"[cmd] {' '.join(ssh_cmd)} | {' '.join(tar_cmd)}  # download {remote_path} -> {local_path}", flush=True)
         logger.debug("Downloading via tar pipe %s:%s -> %s", self._host, remote_path, local_path)
 
-        ssh_proc = subprocess.Popen(ssh_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        ssh_proc = subprocess.Popen(
+            ssh_cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            **_windows_no_window_kwargs(),
+        )
         tar_proc = subprocess.Popen(
-            tar_cmd, stdin=ssh_proc.stdout, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            tar_cmd,
+            stdin=ssh_proc.stdout,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            **_windows_no_window_kwargs(),
         )
         if ssh_proc.stdout:
             ssh_proc.stdout.close()
@@ -444,9 +491,18 @@ class SSHRunner:
         if self._verbose:
             print(f"[cmd] {' '.join(tar_cmd)} | {' '.join(ssh_cmd)}  # upload {local_path} -> {remote_path}", flush=True)
         logger.debug("Uploading via tar pipe %s -> %s:%s", local_path, self._host, remote_path)
-        tar_proc = subprocess.Popen(tar_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        tar_proc = subprocess.Popen(
+            tar_cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            **_windows_no_window_kwargs(),
+        )
         ssh_proc = subprocess.Popen(
-            ssh_cmd, stdin=tar_proc.stdout, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            ssh_cmd,
+            stdin=tar_proc.stdout,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            **_windows_no_window_kwargs(),
         )
         if tar_proc.stdout:
             tar_proc.stdout.close()
@@ -483,6 +539,7 @@ class SSHRunner:
                 stderr=subprocess.STDOUT,
                 text=False,
                 bufsize=0,
+                **_windows_no_window_kwargs(),
             )
             if proc.stdin is None or proc.stdout is None:
                 proc.terminate()

--- a/src/virtuoso_bridge/transport/tunnel.py
+++ b/src/virtuoso_bridge/transport/tunnel.py
@@ -317,46 +317,86 @@ class SSHClient:
         print(f"[cmd] {' '.join(cmd)}", flush=True)
 
         # Platform-specific detach: tunnel must survive parent process exit
-        popen_kwargs: dict[str, Any] = {
-            "stdin": subprocess.DEVNULL,
-            "stdout": subprocess.DEVNULL,
-        }
         if os.name == "nt":
-            # Windows: DETACHED_PROCESS + CREATE_NEW_PROCESS_GROUP
-            popen_kwargs["creationflags"] = (
-                subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP  # type: ignore[attr-defined]
-            )
-            # stderr must NOT be PIPE on Windows — pipe breaks when parent exits
-            popen_kwargs["stderr"] = subprocess.DEVNULL
+            # On Windows, launching ssh.exe directly can still show a console
+            # window, especially when ProxyJump causes ssh to spawn another ssh.
+            # Start it from a hidden PowerShell process instead.
+            pid = self._start_hidden_windows_process(cmd)
+
+            settle = _TUNNEL_STARTUP_SETTLE_SECONDS
+            if self._jump_host:
+                settle = max(settle, 3.0)
+            deadline = time.monotonic() + settle
+            while time.monotonic() < deadline:
+                if self._can_reach_port(port):
+                    self._saved_tunnel_pid = pid
+                    self._using_external_tunnel = True
+                    return None
+                time.sleep(0.1)
+
+            try:
+                os.kill(pid, signal.SIGTERM)
+            except OSError:
+                pass
+            raise RuntimeError("SSH tunnel failed to start on Windows")
         else:
-            popen_kwargs["start_new_session"] = True
-            popen_kwargs["stderr"] = subprocess.PIPE
+            popen_kwargs: dict[str, Any] = {
+                "stdin": subprocess.DEVNULL,
+                "stdout": subprocess.DEVNULL,
+                "start_new_session": True,
+                "stderr": subprocess.PIPE,
+            }
+            proc = subprocess.Popen(cmd, **popen_kwargs)
 
-        proc = subprocess.Popen(cmd, **popen_kwargs)
+            # Wait for tunnel to settle (longer for jump-host paths)
+            settle = _TUNNEL_STARTUP_SETTLE_SECONDS
+            if self._jump_host:
+                settle = max(settle, 3.0)
+            deadline = time.monotonic() + settle
+            while time.monotonic() < deadline:
+                if proc.poll() is not None:
+                    break
+                time.sleep(0.1)
 
-        # Wait for tunnel to settle (longer for jump-host paths)
-        settle = _TUNNEL_STARTUP_SETTLE_SECONDS
-        if self._jump_host:
-            settle = max(settle, 3.0)
-        deadline = time.monotonic() + settle
-        while time.monotonic() < deadline:
             if proc.poll() is not None:
-                break
-            time.sleep(0.1)
+                err_msg = ""
+                if proc.stderr and proc.stderr.readable():
+                    try:
+                        err_msg = proc.stderr.read().decode("utf-8", errors="ignore")
+                    except (OSError, ValueError):
+                        pass
+                if "address already in use" in err_msg.lower() and self._can_reach_port(port):
+                    logger.info("Reusing existing tunnel at localhost:%d", port)
+                    self._using_external_tunnel = True
+                    return None
+                return proc  # failed
+            return proc  # running
 
-        if proc.poll() is not None:
-            err_msg = ""
-            if proc.stderr and proc.stderr.readable():
-                try:
-                    err_msg = proc.stderr.read().decode("utf-8", errors="ignore")
-                except (OSError, ValueError):
-                    pass
-            if "address already in use" in err_msg.lower() and self._can_reach_port(port):
-                logger.info("Reusing existing tunnel at localhost:%d", port)
-                self._using_external_tunnel = True
-                return None
-            return proc  # failed
-        return proc  # running
+    def _start_hidden_windows_process(self, cmd: list[str]) -> int:
+        def _ps_quote(value: str) -> str:
+            return "'" + value.replace("'", "''") + "'"
+
+        file_path = _ps_quote(cmd[0])
+        args = ", ".join(_ps_quote(part) for part in cmd[1:])
+        script = (
+            f"$p = Start-Process -FilePath {file_path} "
+            f"-ArgumentList @({args}) -WindowStyle Hidden -PassThru; "
+            "$p.Id"
+        )
+        result = subprocess.run(
+            ["powershell.exe", "-NoProfile", "-NonInteractive", "-WindowStyle", "Hidden", "-Command", script],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"Failed to launch hidden SSH tunnel: {result.stderr.strip()}")
+        try:
+            return int(result.stdout.strip().splitlines()[-1])
+        except (IndexError, ValueError) as exc:
+            raise RuntimeError(
+                f"Failed to parse hidden SSH tunnel PID: {result.stdout.strip()!r}"
+            ) from exc
 
     def _can_reach_port(self, port: int) -> bool:
         """Check if localhost:port accepts TCP connections."""

--- a/src/virtuoso_bridge/virtuoso/basic/resources/ramic_bridge_daemon_27.py
+++ b/src/virtuoso_bridge/virtuoso/basic/resources/ramic_bridge_daemon_27.py
@@ -75,6 +75,24 @@ fcntl.fcntl(stdout_fd, fcntl.F_SETFL, stdout_fl & ~os.O_NONBLOCK)  # Ensure bloc
 # Global watchdog timer reference
 watchdog_timer = None
 
+
+def _safe_sendall(conn, data):
+    try:
+        conn.sendall(data)
+    except socket.error:
+        pass
+
+
+def _safe_close_connection(conn):
+    try:
+        conn.shutdown(socket.SHUT_RDWR)
+    except socket.error:
+        pass
+    try:
+        conn.close()
+    except socket.error:
+        pass
+
 def watchdog_callback():
     """Watchdog callback function that sends SIGINT signal to Virtuoso process when timeout occurs."""
     global timeout_flag
@@ -202,32 +220,31 @@ def handle_external_connection(conn, addr):
 
         # Python 2.7 compatibility: handle returnData properly
         if isinstance(returnData, bytearray):
-            conn.sendall(str(returnData))
+            _safe_sendall(conn, str(returnData))
         elif hasattr(returnData, 'encode'):  # Check if it's unicode
-            conn.sendall(returnData.encode('utf-8'))
+            _safe_sendall(conn, returnData.encode('utf-8'))
         else:
-            conn.sendall(returnData)
+            _safe_sendall(conn, returnData)
 
     except ValueError as e:
         # Python 2.7 compatibility: handle JSON decode errors
         error_msg = "\x15JSONDecodeError: {0}".format(str(e))
         if hasattr(error_msg, 'encode'):  # Check if it's unicode
             error_msg = error_msg.encode('utf-8')
-        conn.sendall(error_msg)
+        _safe_sendall(conn, error_msg)
     except Exception as e:
         # Python 2.7 compatibility: except Exception, e syntax
         traceback.print_exc()
         error_msg = "\x15{0}".format(str(e))
         if hasattr(error_msg, 'encode'):  # Check if it's unicode
             error_msg = error_msg.encode('utf-8')
-        conn.sendall(error_msg)
+        _safe_sendall(conn, error_msg)
     finally:
         # Ensure watchdog timer is cleaned up
         timeout_flag = True
         if watchdog_timer:
             watchdog_timer.cancel()
-        conn.shutdown(socket.SHUT_RDWR)
-        conn.close()
+        _safe_close_connection(conn)
 
 def start_server():
     """Start the TCP server to accept client connections."""
@@ -252,7 +269,11 @@ def start_server():
         s.listen(1)
         while True:
             conn, addr = s.accept()
-            handle_external_connection(conn, addr)
+            try:
+                handle_external_connection(conn, addr)
+            except Exception:
+                traceback.print_exc()
+                _safe_close_connection(conn)
     finally:
         s.close()
 

--- a/src/virtuoso_bridge/virtuoso/basic/resources/ramic_bridge_daemon_3.py
+++ b/src/virtuoso_bridge/virtuoso/basic/resources/ramic_bridge_daemon_3.py
@@ -40,6 +40,24 @@ fcntl.fcntl(stdout_fd, fcntl.F_SETFL, stdout_fl & ~os.O_NONBLOCK)
 
 watchdog_timer = None
 
+
+def _safe_sendall(conn, data):
+    try:
+        conn.sendall(data)
+    except OSError:
+        pass
+
+
+def _safe_close_connection(conn):
+    try:
+        conn.shutdown(socket.SHUT_RDWR)
+    except OSError:
+        pass
+    try:
+        conn.close()
+    except OSError:
+        pass
+
 def watchdog_callback():
     global timeout_flag
     if not timeout_flag:
@@ -140,19 +158,18 @@ def handle_external_connection(conn, addr):
             timeout_flag = True
         watchdog_timer.cancel()
 
-        conn.sendall(returnData)
+        _safe_sendall(conn, returnData)
 
     except json.JSONDecodeError as e:
-        conn.sendall(f"\x15JSONDecodeError: {e}".encode("utf-8"))
+        _safe_sendall(conn, f"\x15JSONDecodeError: {e}".encode("utf-8"))
     except Exception as e:
         traceback.print_exc()
-        conn.sendall(f"\x15{e}".encode("utf-8"))
+        _safe_sendall(conn, f"\x15{e}".encode("utf-8"))
     finally:
         timeout_flag = True
         if watchdog_timer:
             watchdog_timer.cancel()
-        conn.shutdown(socket.SHUT_RDWR)
-        conn.close()
+        _safe_close_connection(conn)
 
 def start_server():
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
@@ -167,7 +184,11 @@ def start_server():
         s.listen(1)
         while True:
             conn, addr = s.accept()
-            handle_external_connection(conn, addr)
+            try:
+                handle_external_connection(conn, addr)
+            except Exception:
+                traceback.print_exc()
+                _safe_close_connection(conn)
 
 if __name__ == "__main__":
     start_server()


### PR DESCRIPTION
 ## Summary

  This PR fixes two Windows-side usability/stability issues in `virtuoso-bridge`:

  1. Hide local `ssh`/`scp` console windows on Windows, including the long-lived tunnel process and the short-lived
  precheck/upload SSH processes.
  2. Make the RAMIC daemon resilient to connection teardown so stopping the local tunnel does not accidentally kill
  the remote daemon.

  ## Changes

  ### Windows SSH process handling

  - add a shared Windows `no-window` launch helper in `transport/ssh.py`
  - apply it to:
    - SSH precheck
    - one-shot remote commands
    - text upload
    - scp download
    - tar-over-ssh upload/download
    - persistent SSH shell
  - launch the Windows tunnel from a hidden process path in `transport/tunnel.py` so the long-lived `ssh -N -L ...`
  tunnel does not leave a visible console window open, including ProxyJump cases

  ### RAMIC daemon robustness

  Apply the same fix to both daemon variants:

  - `ramic_bridge_daemon_3.py`
  - `ramic_bridge_daemon_27.py`

  Changes:
  - wrap `sendall()` in a safe helper

  ## Why

  On Windows, the upstream tunnel-stability fix solved premature tunnel exit, but `ssh.exe` console windows were
  still visible, especially with `ProxyJump`.

    - `test_connection() == True`
    - `execute_skill("1+2") == "3"`
  - after `virtuoso-bridge stop`, restarting with `virtuoso-bridge start` no longer requires reloading CIW just
  because the previous tunnel was stopped