### PR TITLE
fix: harvest scripts handle multiple session views and nil metadata (#7)

### DIFF
--- a/examples/01_virtuoso/assets/harvest_library.il
+++ b/examples/01_virtuoso/assets/harvest_library.il
@@ -1,0 +1,198 @@
+; harvest_library.il
+;
+; Procedures for harvesting library metadata with robust view detection,
+; nil normalization, and reliable library-path resolution.
+;
+; Fixes three problems from issue #7:
+;   1. Hardcoded "maestro" view name — now probes all session-like views
+;   2. Literal "nil" from SKILL treated as real data — now normalized
+;   3. ddGetObj(lib)->libPath unreliable — falls back to writePath/readPath
+;
+; Procedures:
+;   HarvestGetLibRoot(libName)          - resolve library root path
+;   HarvestGetSessionViews(cellViewList) - filter session-like views from a list
+;   HarvestGetSchematicViews(cellViewList) - filter schematic-like views
+;   HarvestNormNil(val)                 - normalize SKILL nil to empty string
+;   HarvestNormNilList(val)             - normalize SKILL nil to empty list
+;   HarvestCellInfo(libName cellName)   - harvest one cell's metadata
+;   HarvestLibrary(libName)             - harvest entire library metadata
+
+; --- Known session-like view prefixes ---
+; Views that contain Maestro/ADE session state and simulation results.
+; Matched as prefixes so "maestro2", "spectre_post" etc. are caught.
+procedure(HarvestIsSessionView(viewName)
+  let((prefixes found)
+    prefixes = '("maestro" "adexl" "normVim" "topsim" "spectre")
+    found = nil
+    foreach(pfx prefixes
+      when(rexMatchp(strcat("^" pfx) viewName)
+        found = t))
+    found))
+
+; --- Known schematic-like view prefixes ---
+procedure(HarvestIsSchematicView(viewName)
+  rexMatchp("^schematic" viewName))
+
+; --- Known config-like view prefixes ---
+procedure(HarvestIsConfigView(viewName)
+  rexMatchp("^config" viewName))
+
+; --- Normalize a SKILL value: nil or literal string "nil" -> "" ---
+procedure(HarvestNormNil(val)
+  if(or(null(val) equal(val "nil") equal(val nil))
+    then ""
+    else val))
+
+; --- Normalize a SKILL list value: nil -> '() ---
+procedure(HarvestNormNilList(val)
+  if(or(null(val) equal(val "nil") equal(val nil))
+    then '()
+    else val))
+
+; --- Resolve library root path with fallback chain ---
+; libPath -> writePath -> readPath
+procedure(HarvestGetLibRoot(libName)
+  let((libObj root)
+    libObj = ddGetObj(libName)
+    unless(libObj
+      printf("[harvest] ERROR: library '%s' not found\n" libName)
+      return(""))
+    root = libObj~>libPath
+    when(or(null(root) equal(root nil))
+      root = libObj~>writePath)
+    when(or(null(root) equal(root nil))
+      root = libObj~>readPath)
+    when(or(null(root) equal(root nil))
+      printf("[harvest] WARNING: no path resolved for '%s'\n" libName)
+      root = "")
+    root))
+
+; --- Filter session-like views from a view name list ---
+procedure(HarvestGetSessionViews(viewNames)
+  let((result)
+    result = '()
+    foreach(vn viewNames
+      when(HarvestIsSessionView(vn)
+        result = cons(vn result)))
+    reverse(result)))
+
+; --- Filter schematic-like views from a view name list ---
+procedure(HarvestGetSchematicViews(viewNames)
+  let((result)
+    result = '()
+    foreach(vn viewNames
+      when(HarvestIsSchematicView(vn)
+        result = cons(vn result)))
+    reverse(result)))
+
+; --- Probe Maestro setups for a given cell and session view ---
+; Returns a list of setup info strings, or '() if none.
+procedure(HarvestProbeSetups(libName cellName viewName)
+  let((rawSetups setups result)
+    rawSetups = errset(maeGetSetupNames(libName cellName viewName))
+    ; errset returns list(value) on success, nil on error
+    when(rawSetups
+      rawSetups = car(rawSetups))
+    setups = HarvestNormNilList(rawSetups)
+    result = '()
+    foreach(setup setups
+      ; Skip literal "nil" setup names
+      unless(or(null(setup) equal(setup "nil"))
+        let((analyses)
+          analyses = HarvestNormNilList(
+            errset(maeGetEnabledAnalysis(libName cellName viewName setup))
+            )
+          when(analyses analyses = car(analyses))
+          analyses = HarvestNormNilList(analyses)
+          result = cons(
+            sprintf(nil "setup=%s analyses=%L" setup analyses)
+            result))))
+    reverse(result)))
+
+; --- Check if result directories exist for a cell/view ---
+procedure(HarvestProbeResults(libRoot cellName viewName)
+  let((resultsPath hasResults)
+    resultsPath = sprintf(nil "%s/%s/%s/results" libRoot cellName viewName)
+    hasResults = isDir(resultsPath)
+    when(hasResults
+      printf("[harvest]   results: %s\n" resultsPath))
+    hasResults))
+
+; --- Harvest metadata for a single cell ---
+; Returns a formatted string with cell info.
+procedure(HarvestCellInfo(libName cellName)
+  let((cellObj viewNames sessionViews schematicViews configViews
+       libRoot out)
+    cellObj = ddGetObj(libName cellName)
+    unless(cellObj
+      printf("[harvest] WARNING: cell '%s/%s' not found\n" libName cellName)
+      return(""))
+
+    ; Enumerate actual views
+    viewNames = '()
+    foreach(v cellObj~>views
+      viewNames = cons(v~>name viewNames))
+    viewNames = reverse(viewNames)
+
+    ; Classify views
+    sessionViews = HarvestGetSessionViews(viewNames)
+    schematicViews = HarvestGetSchematicViews(viewNames)
+    configViews = '()
+    foreach(vn viewNames
+      when(HarvestIsConfigView(vn)
+        configViews = cons(vn configViews)))
+    configViews = reverse(configViews)
+
+    libRoot = HarvestGetLibRoot(libName)
+
+    ; Format output
+    out = sprintf(nil "cell=%s\n" cellName)
+    out = strcat(out sprintf(nil "  all_views=%L\n" viewNames))
+    out = strcat(out sprintf(nil "  session_views=%L\n" sessionViews))
+    out = strcat(out sprintf(nil "  schematic_views=%L\n" schematicViews))
+    out = strcat(out sprintf(nil "  config_views=%L\n" configViews))
+
+    ; Probe each session view
+    foreach(sv sessionViews
+      let((setups hasResults)
+        out = strcat(out sprintf(nil "  [%s]\n" sv))
+
+        ; Probe setups (only for maestro/adexl views)
+        setups = HarvestProbeSetups(libName cellName sv)
+        if(setups
+          then foreach(s setups
+                 out = strcat(out sprintf(nil "    %s\n" s)))
+          else out = strcat(out "    (no setups)\n"))
+
+        ; Probe result directories
+        when(nequal(libRoot "")
+          hasResults = HarvestProbeResults(libRoot cellName sv)
+          out = strcat(out sprintf(nil "    has_results=%L\n" hasResults)))))
+
+    out))
+
+; --- Harvest entire library ---
+; Returns a newline-separated summary string suitable for Python consumption.
+procedure(HarvestLibrary(libName)
+  let((libObj libRoot cells out)
+    libObj = ddGetObj(libName)
+    unless(libObj
+      printf("[harvest] ERROR: library '%s' not found\n" libName)
+      return(""))
+
+    libRoot = HarvestGetLibRoot(libName)
+
+    out = ""
+    out = strcat(out "========================================\n")
+    out = strcat(out sprintf(nil "[harvest] %s\n" libName))
+    out = strcat(out sprintf(nil "[harvest] root=%s\n" libRoot))
+    out = strcat(out "========================================\n")
+
+    foreach(cell libObj~>cells
+      let((info)
+        info = HarvestCellInfo(libName cell~>name)
+        printf("%s" info)
+        out = strcat(out info)))
+
+    out = strcat(out "========================================\n")
+    out))

--- a/examples/01_virtuoso/assets/maestro_utils.il
+++ b/examples/01_virtuoso/assets/maestro_utils.il
@@ -1,0 +1,169 @@
+; maestro_utils.il
+;
+; Utility procedures for managing Maestro sessions via bridge.
+;
+; Procedures:
+;   MaestroGetLibPath(libName)         - resolve lib path (writePath->readPath->libPath)
+;   MaestroFindSessionViews(lib cell)  - find session views (maestro/adexl/maestro2/...)
+;   MaestroOpen(lib cell [view])       - open session, ensure editable, return session
+;   MaestroClose(lib cell [view])      - save and close session cleanly
+;   MaestroCloseAll()                  - close all maestro windows and sessions
+;   MaestroClearLocks(lib cell)        - remove stale .cdslck files (all session views)
+;   MaestroDismissDialog()             - dismiss any blocking dialog
+
+; --- Dismiss any current dialog (Overwrite, Save, etc.) ---
+procedure(MaestroDismissDialog()
+  let((form)
+    form = hiGetCurrentForm()
+    when(form
+      hiFormDone(form)
+      printf("[MaestroDismissDialog] Dismissed dialog\n")
+      t
+    )
+  )
+)
+
+; --- Resolve library path with fallback: writePath -> readPath -> libPath ---
+procedure(MaestroGetLibPath(libName)
+  let((obj path)
+    obj = ddGetObj(libName)
+    when(obj
+      path = obj~>writePath
+      when(or(null(path) equal(path nil))
+        path = obj~>readPath)
+      when(or(null(path) equal(path nil))
+        path = obj~>libPath))
+    path))
+
+; --- Find session-like views for a cell (maestro, adexl, maestro2, ...) ---
+procedure(MaestroFindSessionViews(libName cellName)
+  let((cellObj views result)
+    cellObj = ddGetObj(libName cellName)
+    result = '()
+    when(cellObj
+      foreach(v cellObj~>views
+        let((vn)
+          vn = v~>name
+          when(or(rexMatchp("^maestro" vn)
+                  rexMatchp("^adexl" vn)
+                  rexMatchp("^normVim" vn)
+                  rexMatchp("^topsim" vn))
+            result = cons(vn result)))))
+    reverse(result)))
+
+; --- Clear stale lock files for a maestro/adexl cellview ---
+; Probes all session-like views, not just "maestro".
+procedure(MaestroClearLocks(libName cellName)
+  let((libPath views lockPath)
+    libPath = MaestroGetLibPath(libName)
+    when(libPath
+      views = MaestroFindSessionViews(libName cellName)
+      ; Fall back to '("maestro") if no views found (cell may not exist yet)
+      unless(views views = '("maestro"))
+      foreach(viewName views
+        lockPath = sprintf(nil "%s/%s/%s/%s.sdb.cdslck" libPath cellName viewName viewName)
+        when(isFile(lockPath)
+          deleteFile(lockPath)
+          printf("[MaestroClearLocks] Removed %s\n" lockPath))))
+    t))
+
+; --- Open maestro: check existing, make editable, return session ---
+; viewName defaults to "maestro" but accepts "adexl", "maestro2", etc.
+procedure(MaestroOpen(libName cellName @optional (viewName "maestro"))
+  let((existingWin session result)
+
+    ; 1. Check if a window already open for this cell and view
+    existingWin = nil
+    foreach(win hiGetWindowList()
+      let((name)
+        name = hiGetWindowName(win)
+        when(and(name
+                 rexMatchp(cellName name)
+                 rexMatchp(viewName name))
+          existingWin = win
+        )
+      )
+    )
+
+    ; 2. If not open, clear stale locks then open
+    unless(existingWin
+      MaestroClearLocks(libName cellName)
+      existingWin = deOpenCellView(libName cellName viewName viewName nil "r")
+      printf("[MaestroOpen] Opened %s/%s/%s\n" libName cellName viewName)
+    )
+
+    ; 3. Try make editable; dismiss dialog if it pops up
+    result = maeMakeEditable()
+    MaestroDismissDialog()  ; handle "Change Mode Confirmation" / "Overwrite" dialog
+    unless(result
+      ; Retry after dismissing dialog
+      result = maeMakeEditable()
+      MaestroDismissDialog()
+    )
+
+    ; 4. Get first available session
+    session = nil
+    foreach(s maeGetSessions()
+      unless(session session = s)
+    )
+
+    printf("[MaestroOpen] Session: %s  Editable: %L\n" session result)
+    session
+  )
+)
+
+; --- Close maestro for a specific cell: save then close ---
+; viewName defaults to "maestro" but accepts "adexl", "maestro2", etc.
+procedure(MaestroClose(libName cellName @optional (viewName "maestro"))
+  let((found)
+    ; Save first (prevents "save changes?" dialog on close)
+    foreach(s maeGetSessions()
+      maeSaveSetup(?lib libName ?cell cellName ?view viewName ?session s)
+    )
+
+    ; Find and close only this cell's windows for the given view
+    found = nil
+    foreach(win hiGetWindowList()
+      let((name)
+        name = hiGetWindowName(win)
+        when(and(name
+                 rexMatchp(cellName name)
+                 rexMatchp(viewName name))
+          hiCloseWindow(win)
+          MaestroDismissDialog()  ; handle any save dialog
+          found = t
+        )
+      )
+    )
+
+    printf("[MaestroClose] %s/%s/%s closed\n" libName cellName viewName)
+    found
+  )
+)
+
+; --- Close all maestro windows and sessions ---
+procedure(MaestroCloseAll()
+  let((count)
+    count = 0
+
+    ; Save all then close
+    foreach(win hiGetWindowList()
+      let((name)
+        name = hiGetWindowName(win)
+        when(and(name rexMatchp("maestro" name))
+          hiCloseWindow(win)
+          MaestroDismissDialog()
+          count = count + 1
+        )
+      )
+    )
+
+    ; Close all sessions
+    foreach(s maeGetSessions()
+      maeCloseSession(?session s ?forceClose t)
+    )
+
+    printf("[MaestroCloseAll] Closed %d maestro windows\n" count)
+    count
+  )
+)

--- a/examples/01_virtuoso/basic/05_harvest_library.py
+++ b/examples/01_virtuoso/basic/05_harvest_library.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Harvest library metadata: cells, views, Maestro setups, and result paths.
+
+Handles libraries that use non-standard session views (adexl, maestro2, etc.),
+normalizes nil SKILL responses, and resolves library paths via fallback chain.
+
+Usage::
+
+    python 05_harvest_library.py NEX_ADC_export        # harvest one library
+    python 05_harvest_library.py NEX_ADC_export -o out  # save JSON to out/
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from _timing import format_elapsed
+from virtuoso_bridge import VirtuosoClient
+
+IL_FILE = Path(__file__).resolve().parent.parent / "assets" / "harvest_library.il"
+
+
+def _decode(raw: str) -> str:
+    text = (raw or "").strip().strip('"')
+    return text.replace("\\n", "\n").replace('\\"', '"')
+
+
+def _skill_list(raw: str) -> list[str]:
+    """Parse a SKILL list like '("maestro" "adexl")' into Python list.
+
+    Also normalizes nil / empty to [].
+    """
+    text = (raw or "").strip().strip('"')
+    if not text or text == "nil":
+        return []
+    # Remove outer parens and split quoted items
+    text = text.strip("()")
+    return [m.group(1) for m in re.finditer(r'"([^"]*)"', text)]
+
+
+def harvest_library(client: VirtuosoClient, lib_name: str) -> dict:
+    """Harvest library metadata and return structured dict."""
+
+    # Get library root
+    r = client.execute_skill(f'HarvestGetLibRoot("{lib_name}")', timeout=20)
+    lib_root = _decode(r.output)
+    print(f"[harvest] Library root: {lib_root or '(not resolved)'}")
+
+    # Get cells
+    r = client.execute_skill(
+        f'mapcar(lambda((c) c~>name) ddGetObj("{lib_name}")~>cells)', timeout=20
+    )
+    cells = _skill_list(r.output)
+    print(f"[harvest] Found {len(cells)} cells")
+
+    result = {"library": lib_name, "root": lib_root, "cells": {}}
+
+    for cell_name in cells:
+        # Get all views
+        r = client.execute_skill(
+            f'mapcar(lambda((v) v~>name) ddGetObj("{lib_name}" "{cell_name}")~>views)',
+            timeout=20,
+        )
+        all_views = _skill_list(r.output)
+
+        # Classify views
+        r = client.execute_skill(
+            f"HarvestGetSessionViews('{_skill_list_literal(all_views)})", timeout=20
+        )
+        session_views = _skill_list(r.output)
+
+        r = client.execute_skill(
+            f"HarvestGetSchematicViews('{_skill_list_literal(all_views)})", timeout=20
+        )
+        schematic_views = _skill_list(r.output)
+
+        cell_info: dict = {
+            "all_views": all_views,
+            "session_views": session_views,
+            "schematic_views": schematic_views,
+            "sessions": {},
+        }
+
+        # Probe each session view for setups
+        for sv in session_views:
+            r = client.execute_skill(
+                f'HarvestProbeSetups("{lib_name}" "{cell_name}" "{sv}")', timeout=30
+            )
+            raw = _decode(r.output)
+            setups_info = [line for line in raw.splitlines() if line.strip()] if raw else []
+            cell_info["sessions"][sv] = {
+                "setups": setups_info,
+                "has_results": False,
+            }
+
+            # Check result directory
+            if lib_root:
+                r = client.execute_skill(
+                    f'HarvestProbeResults("{lib_root}" "{cell_name}" "{sv}")', timeout=10
+                )
+                cell_info["sessions"][sv]["has_results"] = "t" in (r.output or "")
+
+        result["cells"][cell_name] = cell_info
+        view_summary = ", ".join(session_views) if session_views else "(none)"
+        print(f"  {cell_name:<30} sessions: {view_summary}")
+
+    return result
+
+
+def _skill_list_literal(items: list[str]) -> str:
+    """Convert Python list to SKILL list literal: '("a" "b")."""
+    if not items:
+        return "()"
+    return "(" + " ".join(f'"{item}"' for item in items) + ")"
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("Usage: python 05_harvest_library.py <library_name> [-o <output_dir>]")
+        return 1
+
+    lib_name = sys.argv[1]
+    output_dir = None
+    if "-o" in sys.argv:
+        idx = sys.argv.index("-o")
+        if idx + 1 < len(sys.argv):
+            output_dir = Path(sys.argv[idx + 1])
+
+    client = VirtuosoClient.from_env()
+
+    # Load harvest SKILL procedures
+    load_result = client.load_il(IL_FILE)
+    upload_tag = "uploaded" if load_result.metadata.get("uploaded") else "cache hit"
+    print(f"[load_il] {upload_tag}  [{format_elapsed(load_result.execution_time or 0.0)}]")
+
+    # Harvest
+    data = harvest_library(client, lib_name)
+
+    # Summary
+    total_cells = len(data["cells"])
+    cells_with_sessions = sum(
+        1 for c in data["cells"].values() if c["session_views"]
+    )
+    cells_with_results = sum(
+        1
+        for c in data["cells"].values()
+        for s in c["sessions"].values()
+        if s["has_results"]
+    )
+    print(f"\n[summary] {total_cells} cells, {cells_with_sessions} with sessions, "
+          f"{cells_with_results} with results")
+
+    # Save JSON
+    if output_dir:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        out_file = output_dir / f"{lib_name}_harvest.json"
+        out_file.write_text(json.dumps(data, indent=2))
+        print(f"[output] Saved to {out_file}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add `harvest_library.il` SKILL script that probes all session-like views (`maestro*`, `adexl`, `normVim`, `topsim`, `spectre*`), normalizes SKILL `nil` to empty values, and resolves library root via `libPath → writePath → readPath` fallback
- Update `maestro_utils.il`: `MaestroClearLocks` now probes all session views; `MaestroOpen`/`MaestroClose` accept optional `viewName` parameter (backward compatible)
- Add `05_harvest_library.py` Python example with structured JSON output

Closes #7

## Test plan
- [ ] Run `05_harvest_library.py NEX_ADC_export` against live Virtuoso — verify adexl/maestro2 views are discovered
- [ ] Verify nil setups are normalized to empty lists in JSON output
- [ ] Verify library root resolves via writePath when libPath is nil
- [ ] Verify existing `MaestroOpen(lib, cell)` calls still work (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)