### PR TITLE
Add schematic_set_cdf_param helper for CDF updates

### DIFF
--- a/src/virtuoso_bridge/virtuoso/schematic/ops.py
+++ b/src/virtuoso_bridge/virtuoso/schematic/ops.py
@@ -266,3 +266,32 @@ def schematic_create_wire_between_instance_terms(
 def schematic_check(*, cv_expr: str = "cv") -> str:
     """Build SKILL to run schematic checking."""
     return f"schCheck({cv_expr})"
+
+def schematic_set_cdf_param(
+    lib: str,
+    cell: str,
+    inst: str,
+    param: str,
+    value: str,
+    *,
+    cv_expr: str = "cv",
+) -> str:
+    """Build SKILL to update a CDF parameter if the instance and parameter exist."""
+    escaped_lib = escape_skill_string(lib)
+    escaped_cell = escape_skill_string(cell)
+    escaped_inst = escape_skill_string(inst)
+    escaped_param = escape_skill_string(param)
+    escaped_value = escape_skill_string(value)
+    return (
+        "let((cv i cdfId p) "
+        f'cv = dbOpenCellViewByType("{escaped_lib}" "{escaped_cell}" "schematic" nil "a") '
+        f'i = car(setof(x {cv_expr}~>instances x~>name == "{escaped_inst}")) '
+        "when(i "
+        "cdfId = cdfGetInstCDF(i) "
+        "when(cdfId "
+        f'p = cdfFindParamByName(cdfId "{escaped_param}") '
+        "when(p "
+        f'p~>value = "{escaped_value}")))) '
+        f"schCheck({cv_expr}) "
+        f"dbSave({cv_expr}))"
+    )


### PR DESCRIPTION
## Summary
- Add a new schematic SKILL builder helper: `schematic_set_cdf_param(...)` in `src/virtuoso_bridge/virtuoso/schematic/ops.py`.
- The helper builds SKILL to:
  - open target schematic cellview in append mode,
  - find an instance by name,
  - find a CDF parameter by name,
  - set parameter value,
  - run `schCheck` and `dbSave`.

## Why
- Enables fast, reusable CDF parameter mapping for `(instance, parameter, value)`.
- Keeps naming aligned with existing `schematic_*` helper functions.
- Reduces ad-hoc inline SKILL snippets in scripts.

## Changes
- **File:** `src/virtuoso_bridge/virtuoso/schematic/ops.py`
- **Added:** `schematic_set_cdf_param(lib, cell, inst, param, value, *, cv_expr="cv") -> str`

## Validation
- `python -m py_compile src/virtuoso_bridge/virtuoso/schematic/ops.py`

## Notes
- This PR adds a low-level SKILL builder helper only.
- No behavior changes unless callers use the new helper.