### PR TITLE
docs(virtuoso): define runtime script storage convention for agent-generated files

### DIFF
--- a/skills/virtuoso/SKILL.md
+++ b/skills/virtuoso/SKILL.md
@@ -133,6 +133,15 @@ Constraints:
 > `python -c "..."` has three layers of quoting (shell + Python + SKILL). `\\n` easily becomes `\\\\n`, causing `printf` to silently produce no output.
 > Always write code to a `.py` file and run `python script.py` -- only two quoting layers (Python + SKILL), matching the examples.
 
+### Runtime script storage
+
+When the agent needs to generate temporary runtime scripts, always use a fixed workspace folder instead of scattering files.
+
+- **Local runtime Python scripts**: write to `output/runtime_scripts/`
+- **Remote temporary files for Virtuoso/SKILL**: write to `/tmp/vb_runtime_scripts/`
+- **Filename format**: `<timestamp>_<task>.<ext>` (example: `20260409_154210_ciw_print.py`)
+- **Cleanup**: delete temporary runtime scripts after successful execution unless user asks to keep them for debugging
+
 Full example: `examples/01_virtuoso/basic/02_ciw_print.py`
 
 ## References


### PR DESCRIPTION

Summary  
This PR adds a clear runtime script storage policy to the Virtuoso skill documentation to prevent generated scripts from being scattered across the workspace and remote host.

Changes  
- Added a new Runtime script storage section in SKILL.md.  
- Defined fixed locations for generated runtime scripts:
  - Local Python runtime scripts go to output/runtime_scripts/
  - Remote Virtuoso or SKILL temporary files go to /tmp/vb_runtime_scripts/
- Added a filename convention: timestamp_task.ext
- Added cleanup guidance: remove temporary runtime scripts after successful execution unless the user requests retention for debugging

Why this change  
- Improves workspace hygiene and reduces file clutter
- Makes generated artifacts easier to locate during troubleshooting
- Lowers risk of filename collisions in repeated or concurrent runs
- Establishes a consistent behavior for agent-generated files

Impact  
Documentation-only change. No runtime code paths were modified.

Validation  
Reviewed the documentation update for clarity and consistency with existing Virtuoso workflow guidance.