### PR TITLE
Fix X11 dialog detection for wide ADE modal windows

### DIFF
--- a/src/virtuoso_bridge/resources/x11_dismiss_dialog.py
+++ b/src/virtuoso_bridge/resources/x11_dismiss_dialog.py
@@ -121,8 +121,12 @@ def find_dialogs(display):
         # Skip very tiny windows
         if geo_w < 20 or geo_h < 20:
             continue
-        # Skip windows too large to be dialogs (either dimension > 500)
-        if geo_w > 500 or geo_h > 500:
+        # Skip tall windows (typically editor/result panes, not modal dialogs).
+        # Keep wide-but-short modals such as ADE "Update and Run" prompts.
+        if geo_h > 420:
+            continue
+        # Skip windows that are very large in BOTH dimensions (likely main app frames).
+        if geo_w > 1000 and geo_h > 300:
             continue
 
         candidates.append(win_id)


### PR DESCRIPTION
## Summary\nThis PR fixes X11 dialog detection so wide-but-short modal dialogs (e.g. ADE Assembler "Update and Run") are no longer filtered out.\n\n## Problem\nThe previous filter dropped any candidate where either dimension exceeded 500, which excluded common ADE modal dialogs (wide but short). As a result, modal dialogs could block CIW and cause repeated socket timeouts.\n\n## Change\nIn src/virtuoso_bridge/resources/x11_dismiss_dialog.py:\n- keep wide-but-short candidates\n- filter out tall windows (likely editor/result panes)\n- keep filtering very large main frames\n\n## Validation\n- Reproduced ADE "Update and Run" modal\n- No dialog windows found. now detects and dismisses it\n- No false positives observed in no-dialog state\n\n## Scope\nSingle-file change only.