### PR TITLE
Fix Save As smart policy context and remote env propagation

### DIFF
--- a/src/virtuoso_bridge/resources/x11_dismiss_dialog.py
+++ b/src/virtuoso_bridge/resources/x11_dismiss_dialog.py
@@ -210,8 +210,52 @@ def _find_app_child(display, frame_id_str):
     return frame_id_str  # fallback to frame itself
 
 
-def dismiss_window(display, win_id_str):
-    """Send Enter key to a window via XTest."""
+def _send_alt_n(dpy, xlib, xtst):
+    """Send Alt+N to trigger the No button mnemonic."""
+    keysym_alt_l = 0xffe9  # XK_Alt_L
+    keysym_n = 0x006e      # XK_n
+    kc_alt = xlib.XKeysymToKeycode(dpy, keysym_alt_l)
+    kc_n = xlib.XKeysymToKeycode(dpy, keysym_n)
+
+    xtst.XTestFakeKeyEvent(dpy, kc_alt, True, 0)
+    xtst.XTestFakeKeyEvent(dpy, kc_n, True, 0)
+    xtst.XTestFakeKeyEvent(dpy, kc_n, False, 0)
+    xtst.XTestFakeKeyEvent(dpy, kc_alt, False, 0)
+    xlib.XFlush(dpy)
+    return kc_alt, kc_n
+
+
+def _send_alt_y(dpy, xlib, xtst):
+    """Send Alt+Y to trigger the Yes button mnemonic."""
+    keysym_alt_l = 0xffe9  # XK_Alt_L
+    keysym_y = 0x0079      # XK_y
+    kc_alt = xlib.XKeysymToKeycode(dpy, keysym_alt_l)
+    kc_y = xlib.XKeysymToKeycode(dpy, keysym_y)
+
+    xtst.XTestFakeKeyEvent(dpy, kc_alt, True, 0)
+    xtst.XTestFakeKeyEvent(dpy, kc_y, True, 0)
+    xtst.XTestFakeKeyEvent(dpy, kc_y, False, 0)
+    xtst.XTestFakeKeyEvent(dpy, kc_alt, False, 0)
+    xlib.XFlush(dpy)
+    return kc_alt, kc_y
+
+
+def _send_escape(dpy, xlib, xtst):
+    """Send Escape key (maps to Cancel on most dialogs)."""
+    keysym_esc = 0xff1b  # XK_Escape
+    kc_esc = xlib.XKeysymToKeycode(dpy, keysym_esc)
+    xtst.XTestFakeKeyEvent(dpy, kc_esc, True, 0)
+    xtst.XTestFakeKeyEvent(dpy, kc_esc, False, 0)
+    xlib.XFlush(dpy)
+    return kc_esc
+
+
+def dismiss_window(display, win_id_str, title="", x=0, y=0, w=0, h=0):
+    """Dismiss a window via XTest.
+
+    Default behavior is Enter.
+    For Save As prompts, prefer 'n' (No) to avoid Save/Copy dialog loops.
+    """
     os.environ["DISPLAY"] = display
     xlib_path = ctypes.util.find_library("X11")
     xtst_path = ctypes.util.find_library("Xtst")
@@ -235,14 +279,98 @@ def dismiss_window(display, win_id_str):
 
     time.sleep(0.15)
 
-    keysym_return = 0xff0d  # XK_Return
-    keycode = xlib.XKeysymToKeycode(dpy, keysym_return)
+    title_l = (title or "").lower()
+    # Policy values:
+    # - smart   : choose action by explicit context (dedupe -> No, default -> Cancel)
+    # - discard : always choose No
+    # - save    : always choose Yes
+    # - cancel  : always choose Cancel
+    save_policy = (os.environ.get("VB_SAVE_DIALOG_POLICY", "smart") or "smart").lower()
+    save_context = (os.environ.get("VB_SAVE_DIALOG_CONTEXT", "") or "").lower()
+    if ("save as" in title_l) or ("save a copy" in title_l):
+        try:
+            if save_policy == "discard":
+                kc_alt, kc_n = _send_alt_n(dpy, xlib, xtst)
+                xlib.XCloseDisplay(dpy)
+                return {
+                    "dismissed": win_id_str,
+                    "child": child_id_str,
+                    "action": "alt_n_no",
+                    "title": title,
+                    "policy": save_policy,
+                    "keycode_alt": int(kc_alt),
+                    "keycode_n": int(kc_n),
+                }
+            elif save_policy == "save":
+                kc_alt, kc_y = _send_alt_y(dpy, xlib, xtst)
+                xlib.XCloseDisplay(dpy)
+                return {
+                    "dismissed": win_id_str,
+                    "child": child_id_str,
+                    "action": "alt_y_yes",
+                    "title": title,
+                    "policy": save_policy,
+                    "keycode_alt": int(kc_alt),
+                    "keycode_y": int(kc_y),
+                }
+            elif save_policy == "cancel":
+                kc_esc = _send_escape(dpy, xlib, xtst)
+                xlib.XCloseDisplay(dpy)
+                return {
+                    "dismissed": win_id_str,
+                    "child": child_id_str,
+                    "action": "esc_cancel",
+                    "title": title,
+                    "policy": save_policy,
+                    "keycode_esc": int(kc_esc),
+                }
+            else:
+                if save_context == "dedupe":
+                    kc_alt, kc_n = _send_alt_n(dpy, xlib, xtst)
+                    xlib.XCloseDisplay(dpy)
+                    return {
+                        "dismissed": win_id_str,
+                        "child": child_id_str,
+                        "action": "alt_n_no_dedupe",
+                        "title": title,
+                        "policy": "smart",
+                        "context": save_context,
+                        "keycode_alt": int(kc_alt),
+                        "keycode_n": int(kc_n),
+                    }
+
+                kc_esc = _send_escape(dpy, xlib, xtst)
+                xlib.XCloseDisplay(dpy)
+                return {
+                    "dismissed": win_id_str,
+                    "child": child_id_str,
+                    "action": "esc_cancel_smart",
+                    "title": title,
+                    "policy": "smart",
+                    "context": save_context,
+                    "keycode_esc": int(kc_esc),
+                }
+        except Exception:
+            # Fallback to keyboard mnemonic if click path fails.
+            keysym = 0x006e  # XK_n
+            action = "no"
+    else:
+        keysym = 0xff0d  # XK_Return
+        action = "enter"
+
+    keycode = xlib.XKeysymToKeycode(dpy, keysym)
     xtst.XTestFakeKeyEvent(dpy, keycode, True, 0)
     xtst.XTestFakeKeyEvent(dpy, keycode, False, 0)
     xlib.XFlush(dpy)
 
     xlib.XCloseDisplay(dpy)
-    return {"dismissed": win_id_str, "child": child_id_str, "keycode": int(keycode)}
+    return {
+        "dismissed": win_id_str,
+        "child": child_id_str,
+        "keycode": int(keycode),
+        "action": action,
+        "title": title,
+    }
 
 
 def main():
@@ -276,7 +404,15 @@ def main():
     if do_dismiss:
         for d in dialogs:
             if "window_id" in d:
-                result = dismiss_window(display, d["window_id"])
+                result = dismiss_window(
+                    display,
+                    d["window_id"],
+                    d.get("title", ""),
+                    d.get("x", 0),
+                    d.get("y", 0),
+                    d.get("w", 0),
+                    d.get("h", 0),
+                )
                 print(json.dumps(result))
 
     sys.exit(0)

--- a/src/virtuoso_bridge/virtuoso/x11.py
+++ b/src/virtuoso_bridge/virtuoso/x11.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import shlex
 from pathlib import Path
 from typing import Any
 
@@ -65,7 +66,13 @@ def dismiss_dialogs(
     """
     script = _ensure_helper(runner, user)
     resolved = _get_display(display)
-    cmd = f"python2 {script} --dismiss"
+    env_prefix = ""
+    for key in ("VB_SAVE_DIALOG_POLICY", "VB_SAVE_DIALOG_CONTEXT"):
+        val = os.getenv(key)
+        if val is not None and val != "":
+            env_prefix += f"{key}={shlex.quote(val)} "
+
+    cmd = f"{env_prefix}python2 {script} --dismiss"
     if resolved:
         cmd += f" {resolved}"
     result = runner.run_command(cmd, timeout=15)


### PR DESCRIPTION
## Summary
This PR fixes Save As and Save a Copy dialog handling so automated recovery does not make unsafe decisions in normal sessions and does not lose policy context over SSH.

## What Changed
- Update X11 dialog helper policy logic in src/virtuoso_bridge/resources/x11_dismiss_dialog.py
  - Support policy modes: smart, discard, save, cancel
  - In smart mode, decision is context-driven:
    - VB_SAVE_DIALOG_CONTEXT=dedupe -> choose No
    - default context -> choose Cancel
  - Keep explicit actions for Yes, No, Cancel via keyboard shortcuts
- Propagate policy and context env vars to remote helper in src/virtuoso_bridge/virtuoso/x11.py
  - Forward VB_SAVE_DIALOG_POLICY and VB_SAVE_DIALOG_CONTEXT through SSH command prefix

## Why
Previously, smart behavior depended on global ADE window count and could select No in non-dedupe workflows. Also, local context variables were not propagated to the remote X11 helper, so context-aware policy could silently degrade.

## Validation
- Syntax check passed:
  - python3 -m py_compile src/virtuoso_bridge/virtuoso/x11.py src/virtuoso_bridge/resources/x11_dismiss_dialog.py
- Runtime probe passed:
  - python scripts/cp23_check_dialog_dismiss.py returns an empty list when no dialog is present
- Functional behavior validated in Virtuoso integration runs:
  - Dedupe flow now reports action=alt_n_no_dedupe with context=dedupe
  - Non-dedupe flow defaults to cancel in smart mode

## Scope
This PR intentionally includes only two files:
- src/virtuoso_bridge/resources/x11_dismiss_dialog.py
- src/virtuoso_bridge/virtuoso/x11.py
