### PR TITLE
fix: harden Windows SSH startup and unify env loading

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,12 +31,12 @@ uv pip install -e .
 **2. Generate config**
 
 ```bash
-virtuoso-bridge init        # creates .env template in current directory
+virtuoso-bridge init        # creates ~/.vblite/.env
 ```
 
 **3. Edit `.env`**
 
-> **Where to put `.env`:** Can live in the virtuoso-bridge-lite directory or your project root (both searched automatically). Project root is recommended when virtuoso-bridge-lite is a subdirectory.
+> **Where to put `.env`:** By default the bridge checks `./.env` first, then `~/.vblite/.env`. For CLI commands such as `virtuoso-bridge start`, `--env FILE` has the highest priority.
 
 ```dotenv
 VB_REMOTE_HOST=my-server              # SSH host alias from ~/.ssh/config
@@ -231,7 +231,7 @@ M0 (VOUT VIN VSS VSS) nch_ulvt_mac l=30n w=1u nf=1
 ## CLI reference
 
 ```bash
-virtuoso-bridge init      # create .env template
+virtuoso-bridge init      # create ~/.vblite/.env
 virtuoso-bridge start     # start SSH tunnel + deploy daemon
 virtuoso-bridge restart   # force-restart
 virtuoso-bridge status    # check tunnel + Virtuoso daemon + Spectre

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The divergence is in what's built on top: skillbridge stays thin — a Pythonic 
 
 ```bash
 pip install -e .              # install
-virtuoso-bridge init          # generate .env template — fill in your SSH host
+virtuoso-bridge init          # generate ~/.vblite/.env — fill in your SSH host
 virtuoso-bridge start         # start SSH tunnel
 virtuoso-bridge status        # verify connection
 ```

--- a/src/virtuoso_bridge/cli.py
+++ b/src/virtuoso_bridge/cli.py
@@ -11,8 +11,7 @@ from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
 
-from dotenv import load_dotenv
-
+from virtuoso_bridge.env import default_user_env_path, load_vb_env, set_runtime_env_file
 from virtuoso_bridge.transport.ssh import SSHRunner, remote_ssh_env_from_os
 
 
@@ -33,51 +32,8 @@ def _generate_env_template() -> str:
     return template.format(remote_port=remote_port, local_port=local_port)
 
 
-def _is_virtuoso_bridge_project(pyproject: Path) -> bool:
-    try:
-        head = pyproject.read_text(encoding="utf-8")[:4000]
-    except OSError:
-        return False
-    return 'name = "virtuoso-bridge"' in head
-
-
-def _repo_root() -> Path:
-    raw = os.environ.get("VIRTUOSO_BRIDGE_ROOT", "").strip()
-    if raw:
-        p = Path(raw).expanduser().resolve()
-        if _is_virtuoso_bridge_project(p / "pyproject.toml"):
-            return p
-    here = Path(__file__).resolve()
-    for parent in here.parents:
-        pm = parent / "pyproject.toml"
-        if pm.is_file() and _is_virtuoso_bridge_project(pm):
-            return parent
-    cwd = Path.cwd()
-    nested = cwd / "virtuoso-bridge" / "pyproject.toml"
-    if nested.is_file() and _is_virtuoso_bridge_project(nested):
-        return nested.parent
-    root_pm = cwd / "pyproject.toml"
-    if root_pm.is_file() and _is_virtuoso_bridge_project(root_pm):
-        return cwd
-    raise RuntimeError(
-        "Could not locate virtuoso-bridge project root. "
-        "Run from the repo directory or set VIRTUOSO_BRIDGE_ROOT."
-    )
-
-
-def _load_repo_env() -> None:
-    # Try repo root first
-    vb_env = _repo_root() / ".env"
-    if vb_env.is_file():
-        load_dotenv(vb_env, override=True)
-        return
-    # Search CWD and all parent directories for .env
-    cwd = Path.cwd().resolve()
-    for parent in [cwd, *cwd.parents]:
-        candidate = parent / ".env"
-        if candidate.is_file():
-            load_dotenv(candidate, override=True)
-            return
+def _load_cli_env() -> Path | None:
+    return load_vb_env()
 
 
 def _fmt(seconds: float) -> str:
@@ -87,7 +43,8 @@ def _fmt(seconds: float) -> str:
 # -- init -------------------------------------------------------------------
 
 def cli_init() -> int:
-    env_path = _repo_root() / ".env"
+    env_path = default_user_env_path()
+    env_path.parent.mkdir(parents=True, exist_ok=True)
     if env_path.exists():
         print(f".env already exists at {env_path}")
     else:
@@ -103,7 +60,11 @@ def _ssh_precheck(profile: str | None = None) -> int | None:
     """Quick SSH connectivity check. Returns exit code on failure, None on success."""
     ssh_env = remote_ssh_env_from_os(profile)
 
-    if ssh_env.jump_host:
+    # When a remote target is configured, prefer a single end-to-end probe.
+    # On some Windows/OpenSSH + remote-shell combinations, probing the jump
+    # host alone via ``ssh host -T exit 0`` can false-negative even though the
+    # actual proxied connection to the remote host succeeds.
+    if ssh_env.jump_host and not ssh_env.remote_host:
         user = ssh_env.jump_user or ssh_env.remote_user
         runner = SSHRunner(host=ssh_env.jump_host, user=user, connect_timeout=5, persistent_shell=False)
         if not runner.test_connection():
@@ -128,7 +89,10 @@ def _start_one_profile(profile: str | None) -> int:
     suffix = f"_{profile}" if profile else ""
     remote_host = os.getenv(f"VB_REMOTE_HOST{suffix}", "").strip()
     if not remote_host:
-        print(f"VB_REMOTE_HOST{suffix} is not set. Run: virtuoso-bridge init")
+        print(
+            f"VB_REMOTE_HOST{suffix} is not set. "
+            "Use --env FILE, create ./.env, or run `virtuoso-bridge init` to create ~/.vblite/.env."
+        )
         return 1
 
     from virtuoso_bridge.transport.tunnel import SSHClient, _is_localhost
@@ -151,39 +115,39 @@ def _start_one_profile(profile: str | None) -> int:
     else:
         print(f"Starting tunnel{label}...")
     ssh = SSHClient.from_env(keep_remote_files=True, profile=profile)
-    started = time.monotonic()
-    ssh.warm()
-    elapsed = time.monotonic() - started
-    print(f"tunnel.warm = {_fmt(elapsed)}")
+    try:
+        started = time.monotonic()
+        ssh.warm()
+        elapsed = time.monotonic() - started
+        print(f"tunnel.warm = {_fmt(elapsed)}")
 
-    if is_local:
-        # For local mode, print setup_path for user to load in CIW
-        state = SSHClient.read_state(profile)
-        if state:
-            setup_path = state.get("setup_path")
-            if setup_path:
-                print(f"  Load in Virtuoso CIW: load(\"{setup_path}\")")
-        ssh.close()
+        if is_local:
+            # For local mode, print setup_path for user to load in CIW
+            state = SSHClient.read_state(profile)
+            if state:
+                setup_path = state.get("setup_path")
+                if setup_path:
+                    print(f"  Load in Virtuoso CIW: load(\"{setup_path}\")")
+            return 0
+
+        time.sleep(1.0)
+        if not SSHClient.is_running(profile):
+            print("[warning] Tunnel process exited shortly after start.")
+            print("Try starting the tunnel manually:")
+            ssh_env = remote_ssh_env_from_os(profile)
+            port = ssh.port
+            manual_cmd = f"ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o ExitOnForwardFailure=yes -N -L {port}:127.0.0.1:{port}"
+            if ssh_env.jump_host:
+                jump = f"{ssh_env.jump_user or ssh_env.remote_user}@{ssh_env.jump_host}" if (ssh_env.jump_user or ssh_env.remote_user) else ssh_env.jump_host
+                manual_cmd += f" -J {jump}"
+            target = f"{ssh_env.remote_user}@{ssh_env.remote_host}" if ssh_env.remote_user else ssh_env.remote_host
+            manual_cmd += f" {target}"
+            print(f"  {manual_cmd}")
+            return 1
+
         return 0
-
-    ssh.close()
-
-    time.sleep(1.0)
-    if not SSHClient.is_running(profile):
-        print("[warning] Tunnel process exited shortly after start.")
-        print("Try starting the tunnel manually:")
-        ssh_env = remote_ssh_env_from_os(profile)
-        port = ssh.port
-        manual_cmd = f"ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o ExitOnForwardFailure=yes -N -L {port}:127.0.0.1:{port}"
-        if ssh_env.jump_host:
-            jump = f"{ssh_env.jump_user or ssh_env.remote_user}@{ssh_env.jump_host}" if (ssh_env.jump_user or ssh_env.remote_user) else ssh_env.jump_host
-            manual_cmd += f" -J {jump}"
-        target = f"{ssh_env.remote_user}@{ssh_env.remote_host}" if ssh_env.remote_user else ssh_env.remote_host
-        manual_cmd += f" {target}"
-        print(f"  {manual_cmd}")
-        return 1
-
-    return 0
+    finally:
+        ssh.close()
 
 
 def _start_one() -> int:
@@ -192,7 +156,7 @@ def _start_one() -> int:
 
 
 def cli_start() -> int:
-    _load_repo_env()
+    _load_cli_env()
     profile = _get_cli_profile()
     if profile is None:
         profiles = _discover_profiles()
@@ -222,7 +186,7 @@ def _stop_one() -> int:
 
 
 def cli_stop() -> int:
-    _load_repo_env()
+    _load_cli_env()
     return _for_each_profile(_stop_one)
 
 
@@ -244,14 +208,14 @@ def _restart_one() -> int:
 
 
 def cli_restart() -> int:
-    _load_repo_env()
+    _load_cli_env()
     return _for_each_profile(_restart_one)
 
 
 # -- status -----------------------------------------------------------------
 
 def _print_status() -> int:
-    _load_repo_env()
+    _load_cli_env()
     profile = _get_cli_profile()
     from virtuoso_bridge.transport.tunnel import SSHClient, _is_localhost
     from virtuoso_bridge.virtuoso.basic.bridge import VirtuosoClient
@@ -386,6 +350,7 @@ def _print_spectre_status(profile: str | None, suffix: str) -> None:
         return
 
     # Remote mode — SSH-based check
+    ssh = None
     try:
         ssh = SSHClient.from_env(keep_remote_files=True, profile=profile)
         ssh._ssh_runner._verbose = False
@@ -419,8 +384,6 @@ def _print_spectre_status(profile: str | None, suffix: str) -> None:
                 result = ssh._ssh_runner.run_command(check_cmd, timeout=15)
                 stdout = result.stdout.strip()
 
-        ssh.close()
-
         spectre_path = None
         version = None
         for line in stdout.splitlines():
@@ -439,6 +402,9 @@ def _print_spectre_status(profile: str | None, suffix: str) -> None:
             print(f"\n[spectre] NOT FOUND")
     except Exception as e:
         print(f"\n[spectre] error: {e}")
+    finally:
+        if ssh is not None:
+            ssh.close()
 
 
 def _discover_profiles() -> list[str | None]:
@@ -480,14 +446,14 @@ def _for_each_profile(fn: Callable[[], int]) -> int:
 
 
 def cli_status() -> int:
-    _load_repo_env()
+    _load_cli_env()
     return _for_each_profile(_print_status)
 
 
 # -- license ----------------------------------------------------------------
 
 def cli_license() -> int:
-    _load_repo_env()
+    _load_cli_env()
     profile = _get_cli_profile()
     suffix = f"_{profile}" if profile else ""
     cadence_cshrc = os.getenv(f"VB_CADENCE_CSHRC{suffix}", "").strip() or os.getenv("VB_CADENCE_CSHRC", "").strip()
@@ -507,27 +473,31 @@ def cli_license() -> int:
     suffix = f"_{profile}" if profile else ""
     configured_host = os.getenv(f"VB_REMOTE_HOST{suffix}", "").strip()
 
-    if _is_localhost(configured_host):
-        sim = SpectreSimulator.from_env(profile=profile)
-    else:
-        # Create SSHRunner with verbose=False to suppress [cmd] output
-        ssh = SSHClient.from_env(keep_remote_files=True, profile=profile)
-        ssh._ssh_runner._verbose = False
-        sim = SpectreSimulator.from_env(profile=profile, ssh_runner=ssh._ssh_runner)
+    ssh = None
+    try:
+        if _is_localhost(configured_host):
+            sim = SpectreSimulator.from_env(profile=profile)
+        else:
+            # Create SSHRunner with verbose=False to suppress [cmd] output
+            ssh = SSHClient.from_env(keep_remote_files=True, profile=profile)
+            ssh._ssh_runner._verbose = False
+            sim = SpectreSimulator.from_env(profile=profile, ssh_runner=ssh._ssh_runner)
 
-    info = sim.check_license()
+        info = sim.check_license()
 
-    print(f"[spectre] {info.get('spectre_path', 'NOT FOUND')}")
-    if info.get("version"):
-        print(f"  version: {info['version']}")
-    licenses = info.get("licenses", [])
-    if licenses:
-        print(f"\n[licenses in use] ({len(licenses)} features)")
-        for line in licenses:
-            print(f"  {line}")
+        print(f"[spectre] {info.get('spectre_path', 'NOT FOUND')}")
+        if info.get("version"):
+            print(f"  version: {info['version']}")
+        licenses = info.get("licenses", [])
+        if licenses:
+            print(f"\n[licenses in use] ({len(licenses)} features)")
+            for line in licenses:
+                print(f"  {line}")
 
-    ssh.close()
-    return 0 if info.get("ok") else 1
+        return 0 if info.get("ok") else 1
+    finally:
+        if ssh is not None:
+            ssh.close()
 
 
 # -- main -------------------------------------------------------------------
@@ -580,6 +550,7 @@ def _probe_remote_processes(running_jobs: list[dict]) -> dict[str, dict]:
 
 def cli_sim_jobs() -> int:
     """Show status of submitted Spectre simulations."""
+    _load_cli_env()
     from virtuoso_bridge.spectre.runner import read_all_jobs
 
     jobs = read_all_jobs()
@@ -669,6 +640,7 @@ def cli_sim_jobs() -> int:
 
 def cli_sim_cancel() -> int:
     """Cancel a running simulation by job ID."""
+    _load_cli_env()
     from virtuoso_bridge.spectre.runner import cancel_job
     job_id = _SIM_CANCEL_JOB_ID[0]
     if not job_id:
@@ -699,7 +671,7 @@ def _make_ssh_runner() -> "SSHRunner":
 
 def cli_dismiss_dialog() -> int:
     """Find and dismiss blocking Virtuoso GUI dialogs via X11."""
-    _load_repo_env()
+    _load_cli_env()
     from virtuoso_bridge.virtuoso import x11
     runner, user = _make_ssh_runner()
 
@@ -733,14 +705,22 @@ def build_parser() -> argparse.ArgumentParser:
         sp = subparsers.add_parser(name, help=hlp)
         sp.add_argument("-p", "--profile", default=None,
                         help="Connection profile (reads VB_*_<profile> env vars)")
-    subparsers.add_parser("sim-jobs", help="Show submitted simulation jobs")
+        sp.add_argument("--env", default=None,
+                        help="Explicit .env file path (highest priority)")
+    sp_jobs = subparsers.add_parser("sim-jobs", help="Show submitted simulation jobs")
+    sp_jobs.add_argument("--env", default=None,
+                         help="Explicit .env file path (highest priority)")
     sp_cancel = subparsers.add_parser("sim-cancel", help="Cancel a running simulation")
+    sp_cancel.add_argument("--env", default=None,
+                           help="Explicit .env file path (highest priority)")
     sp_cancel.add_argument("job_id", help="Job ID to cancel (from sim-jobs)")
 
     sp_dismiss = subparsers.add_parser(
         "dismiss-dialog", help="Find and dismiss blocking Virtuoso GUI dialogs")
     sp_dismiss.add_argument("-p", "--profile", default=None,
                             help="Connection profile")
+    sp_dismiss.add_argument("--env", default=None,
+                            help="Explicit .env file path (highest priority)")
 
     return parser
 
@@ -763,6 +743,7 @@ def main(argv: list[str] | None = None) -> int:
     profile = getattr(args, "profile", None)
     if profile is not None:
         _CLI_PROFILE[0] = profile
+    set_runtime_env_file(getattr(args, "env", None))
     job_id = getattr(args, "job_id", None)
     if job_id is not None:
         _SIM_CANCEL_JOB_ID[0] = job_id

--- a/src/virtuoso_bridge/env.py
+++ b/src/virtuoso_bridge/env.py
@@ -1,0 +1,61 @@
+"""Shared .env resolution for CLI and Python entry points."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+_RUNTIME_ENV_FILE: Path | None = None
+
+
+def default_user_env_path() -> Path:
+    return Path.home() / ".vblite" / ".env"
+
+
+def set_runtime_env_file(path: str | Path | None) -> Path | None:
+    global _RUNTIME_ENV_FILE
+    if path is None:
+        _RUNTIME_ENV_FILE = None
+        return None
+    _RUNTIME_ENV_FILE = _normalize_env_path(path)
+    return _RUNTIME_ENV_FILE
+
+
+def get_runtime_env_file() -> Path | None:
+    return _RUNTIME_ENV_FILE
+
+
+def _normalize_env_path(path: str | Path, *, cwd: Path | None = None) -> Path:
+    p = Path(path).expanduser()
+    if not p.is_absolute():
+        p = (cwd or Path.cwd()) / p
+    return p.resolve()
+
+
+def resolve_env_path(explicit: str | Path | None = None, *, cwd: Path | None = None) -> Path | None:
+    base_cwd = (cwd or Path.cwd()).resolve()
+    requested = explicit if explicit is not None else _RUNTIME_ENV_FILE
+    if requested is not None:
+        env_path = _normalize_env_path(requested, cwd=base_cwd)
+        if not env_path.is_file():
+            raise FileNotFoundError(f".env file not found: {env_path}")
+        return env_path
+
+    cwd_env = base_cwd / ".env"
+    if cwd_env.is_file():
+        return cwd_env
+
+    user_env = default_user_env_path()
+    if user_env.is_file():
+        return user_env
+
+    return None
+
+
+def load_vb_env(explicit: str | Path | None = None, *, override: bool = True, cwd: Path | None = None) -> Path | None:
+    env_path = resolve_env_path(explicit, cwd=cwd)
+    if env_path is None:
+        return None
+    load_dotenv(env_path, override=override)
+    return env_path

--- a/src/virtuoso_bridge/spectre/runner.py
+++ b/src/virtuoso_bridge/spectre/runner.py
@@ -17,6 +17,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, NamedTuple
 
+from virtuoso_bridge.env import load_vb_env
 from virtuoso_bridge.models import ExecutionStatus, SimulationResult
 from virtuoso_bridge.spectre.parsers import parse_psf_ascii_directory
 from virtuoso_bridge.transport.tunnel import _is_localhost
@@ -94,6 +95,7 @@ def cancel_job(job_id: str) -> str:
     Reads the job record to find the remote host, then SSH-kills the
     Spectre process using the PID file written at launch.
     """
+    load_vb_env()
     path = _job_path(job_id)
     if not path.exists():
         return f"Job {job_id} not found"
@@ -602,6 +604,7 @@ class SpectreSimulator:
         ssh_runner: SSHRunner | None = None,
         profile: str | None = None,
     ) -> None:
+        load_vb_env()
         self._spectre_cmd = spectre_cmd
         self._spectre_args = list(spectre_args or [])
         self._timeout = timeout
@@ -656,6 +659,7 @@ class SpectreSimulator:
         ControlMaster).  Raises RuntimeError if no remote connection is
         available.
         """
+        load_vb_env()
         # Check if we should run locally
         suffix = f"_{profile}" if profile else ""
         remote_host = os.environ.get(f"VB_REMOTE_HOST{suffix}", "") or os.environ.get("VB_REMOTE_HOST", "")

--- a/src/virtuoso_bridge/transport/remote_paths.py
+++ b/src/virtuoso_bridge/transport/remote_paths.py
@@ -7,6 +7,8 @@ import os
 import re
 from typing import TYPE_CHECKING
 
+from virtuoso_bridge.env import load_vb_env
+
 if TYPE_CHECKING:
     from virtuoso_bridge.transport.ssh import SSHRunner
 
@@ -14,6 +16,7 @@ REMOTE_SCRATCH_ROOT_ENV = "VB_REMOTE_SCRATCH_ROOT"
 
 def remote_scratch_root() -> str:
     """Base directory for remote scratch (default ``/tmp``)."""
+    load_vb_env()
     return os.environ.get(REMOTE_SCRATCH_ROOT_ENV, "/tmp").rstrip("/")
 
 def sanitize_username_for_path(username: str) -> str:

--- a/src/virtuoso_bridge/transport/ssh.py
+++ b/src/virtuoso_bridge/transport/ssh.py
@@ -20,6 +20,8 @@ import uuid
 from pathlib import Path
 from typing import Any, NamedTuple
 
+from virtuoso_bridge.env import load_vb_env
+
 logger = logging.getLogger(__name__)
 
 # ── Command log file ─────────────────────────────────────────────────────
@@ -60,16 +62,26 @@ def _mark_interpreter_shutdown() -> None:
 atexit.register(_mark_interpreter_shutdown)
 
 
-def _windows_no_window_kwargs() -> dict[str, Any]:
-    """Best-effort hidden console launch on Windows for CLI tools like ssh/scp/tar."""
+def _windows_no_window_kwargs(
+    *,
+    detached: bool = True,
+    new_process_group: bool = False,
+) -> dict[str, Any]:
+    """Best-effort Windows process flags for CLI tools like ssh/scp/tar."""
     if os.name != "nt":
         return {}
 
     startupinfo = subprocess.STARTUPINFO()  # type: ignore[attr-defined]
     startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW  # type: ignore[attr-defined]
     startupinfo.wShowWindow = 0  # SW_HIDE
+    creationflags = subprocess.CREATE_NO_WINDOW  # type: ignore[attr-defined]
+    if detached:
+        creationflags |= subprocess.DETACHED_PROCESS  # type: ignore[attr-defined]
+    if new_process_group:
+        creationflags |= subprocess.CREATE_NEW_PROCESS_GROUP  # type: ignore[attr-defined]
     return {
-        "creationflags": subprocess.CREATE_NO_WINDOW,  # type: ignore[attr-defined]
+        "creationflags": creationflags,
+        "close_fds": True,
         "startupinfo": startupinfo,
     }
 
@@ -87,6 +99,7 @@ def remote_ssh_env_from_os(profile: str | None = None) -> RemoteSshEnv:
     If *profile* is given (e.g. ``"gpu1"``), reads ``VB_REMOTE_HOST_GPU1``
     etc.  Otherwise reads the default unsuffixed variables.
     """
+    load_vb_env()
     suffix = f"_{profile}" if profile else ""
 
     def _strip(name: str) -> str | None:
@@ -110,6 +123,14 @@ class CommandResult(NamedTuple):
     stdout: str
     stderr: str
 
+
+def _tool_override_from_env(var_name: str) -> str | None:
+    raw = os.environ.get(var_name)
+    if raw is None:
+        return None
+    value = os.path.expandvars(os.path.expanduser(raw.strip()))
+    return value or None
+
 def _derive_tool(base_cmd: str, old_name: str, new_name: str) -> str:
     """Derive a sibling tool path from a known tool (e.g. ssh -> scp).
 
@@ -120,27 +141,7 @@ def _derive_tool(base_cmd: str, old_name: str, new_name: str) -> str:
             candidate = base_cmd[: -len(suffix)] + new_name + (".exe" if suffix.endswith(".exe") else "")
             if os.path.isfile(candidate):
                 return candidate
-    return shutil.which(new_name) or _find_git_tool(new_name) or new_name
-
-
-def _find_git_tool(name: str) -> str | None:
-    """Find a tool (ssh, scp, tar) in Git for Windows usr/bin.
-
-    On Windows, Python venvs inherit only the Windows system PATH, which
-    typically includes Git\\cmd (git.exe) but NOT Git\\usr\\bin (ssh, scp, tar).
-    Git Bash adds usr/bin via its own profile, but that's invisible to Python.
-    """
-    if os.name != "nt":
-        return None
-    for base in [
-        os.path.join(os.environ.get("ProgramFiles", ""), "Git", "usr", "bin"),
-        os.path.join(os.environ.get("ProgramFiles(x86)", ""), "Git", "usr", "bin"),
-        os.path.join(os.environ.get("LOCALAPPDATA", ""), "Programs", "Git", "usr", "bin"),
-    ]:
-        candidate = os.path.join(base, f"{name}.exe")
-        if os.path.isfile(candidate):
-            return candidate
-    return None
+    return shutil.which(new_name) or new_name
 
 
 class SSHRunner:
@@ -160,6 +161,7 @@ class SSHRunner:
         persistent_shell: bool = False,
         verbose: bool = False,
     ) -> None:
+        load_vb_env()
         self._host = host
         self._user = user
         self._jump_host = jump_host
@@ -168,11 +170,16 @@ class SSHRunner:
         self._ssh_config_path = ssh_config_path
         self._timeout = timeout
         self._connect_timeout = connect_timeout
-        self._persistent_shell_enabled = persistent_shell
+        self._persistent_shell_enabled = persistent_shell and os.name != "nt"
         self._verbose = verbose
 
-        self._ssh_cmd = ssh_cmd or shutil.which("ssh") or _find_git_tool("ssh") or "ssh"
-        self._tar_cmd = shutil.which("tar") or _find_git_tool("tar") or "tar"
+        env_ssh_cmd = _tool_override_from_env("VB_SSH_CMD")
+        env_scp_cmd = _tool_override_from_env("VB_SCP_CMD")
+        env_tar_cmd = _tool_override_from_env("VB_TAR_CMD")
+
+        self._ssh_cmd = ssh_cmd or env_ssh_cmd or shutil.which("ssh") or "ssh"
+        self._scp_cmd = env_scp_cmd or _derive_tool(self._ssh_cmd, "ssh", "scp")
+        self._tar_cmd = env_tar_cmd or shutil.which("tar") or "tar"
 
         # ControlMaster socket path for SSH connection multiplexing.
         # All ssh/scp calls to the same host reuse one TCP connection.
@@ -189,6 +196,8 @@ class SSHRunner:
 
         if not self._use_control_master:
             logger.debug("ControlMaster disabled (os=%s, env_override=%s)", os.name, _disable_cm)
+        if persistent_shell and not self._persistent_shell_enabled:
+            logger.debug("Persistent SSH shell disabled on Windows for host %s", host)
 
         self._shell_proc: subprocess.Popen[bytes] | None = None
         self._shell_queue: queue.Queue[str | None] | None = None
@@ -249,20 +258,38 @@ class SSHRunner:
             print(f"[cmd] {' '.join(cmd)}", flush=True)
 
         if os.name == "nt":
-            pid = self._start_hidden_windows_process(cmd)
+            proc = subprocess.Popen(
+                cmd,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                **_windows_no_window_kwargs(detached=True, new_process_group=True),
+            )
             jh_settle = max(settle, 3.0) if self._jump_host else settle
             deadline = time.monotonic() + jh_settle
             while time.monotonic() < deadline:
                 if self.can_reach_port(port):
-                    self._tunnel_pid = pid
-                    self._tunnel_using_external = True
-                    return None
+                    self._tunnel_proc = proc
+                    self._tunnel_pid = proc.pid
+                    self._tunnel_using_external = False
+                    return proc
+                if proc.poll() is not None:
+                    break
                 time.sleep(0.1)
+            if self.can_reach_port(port):
+                logger.info("Reusing existing tunnel at localhost:%d", port)
+                self._tunnel_using_external = True
+                return None
             try:
-                os.kill(pid, signal.SIGTERM)
+                proc.terminate()
+                proc.wait(timeout=2)
             except OSError:
                 pass
-            raise RuntimeError("SSH tunnel failed to start on Windows")
+            except subprocess.TimeoutExpired:
+                proc.kill()
+            rc = proc.poll()
+            detail = f" (rc={rc})" if rc is not None else ""
+            raise RuntimeError(f"SSH tunnel failed to start on Windows{detail}")
 
         popen_kwargs: dict[str, Any] = {
             "stdin": subprocess.DEVNULL,
@@ -360,7 +387,6 @@ class SSHRunner:
         if value is not None:
             self._tunnel_using_external = True
 
-    @staticmethod
     def can_reach_port(port: int) -> bool:
         """Check if localhost:port accepts TCP connections."""
         try:
@@ -369,34 +395,6 @@ class SSHRunner:
             return True
         except (ConnectionRefusedError, OSError):
             return False
-
-    @staticmethod
-    def _start_hidden_windows_process(cmd: list[str]) -> int:
-        """Start a process with hidden console on Windows."""
-        def _ps_quote(value: str) -> str:
-            return "'" + value.replace("'", "''") + "'"
-
-        file_path = _ps_quote(cmd[0])
-        args = ", ".join(_ps_quote(part) for part in cmd[1:])
-        script = (
-            f"$p = Start-Process -FilePath {file_path} "
-            f"-ArgumentList @({args}) -WindowStyle Hidden -PassThru; "
-            "$p.Id"
-        )
-        result = subprocess.run(
-            ["powershell.exe", "-NoProfile", "-NonInteractive", "-WindowStyle", "Hidden", "-Command", script],
-            capture_output=True,
-            text=True,
-            timeout=15,
-        )
-        if result.returncode != 0:
-            raise RuntimeError(f"Failed to launch hidden SSH tunnel: {result.stderr.strip()}")
-        try:
-            return int(result.stdout.strip().splitlines()[-1])
-        except (IndexError, ValueError) as exc:
-            raise RuntimeError(
-                f"Failed to parse hidden SSH tunnel PID: {result.stdout.strip()!r}"
-            ) from exc
 
     # -- connection test -------------------------------------------------------
 
@@ -621,8 +619,7 @@ class SSHRunner:
             return self._download_via_tar(remote_path, local_path, timeout=effective_timeout)
 
         local_path.parent.mkdir(parents=True, exist_ok=True)
-        scp_bin = _derive_tool(self._ssh_cmd, "ssh", "scp")
-        cmd = [scp_bin] + self._common_ssh_options()
+        cmd = [self._scp_cmd] + self._common_ssh_options()
         cmd += [self._remote_scp_target(remote_path), str(local_path)]
         self._print_cmd(cmd)
         logger.debug("Downloading via scp %s:%s -> %s", self._host, remote_path, local_path)
@@ -1049,6 +1046,11 @@ class SSHRunner:
                 proc.wait(timeout=5)
             except subprocess.TimeoutExpired:
                 proc.kill()
+        if proc is not None and proc.stdout is not None:
+            try:
+                proc.stdout.close()
+            except OSError:
+                pass
         if reader is not None and reader.is_alive():
             reader.join(timeout=1)
         self._shell_proc = None

--- a/src/virtuoso_bridge/transport/tunnel.py
+++ b/src/virtuoso_bridge/transport/tunnel.py
@@ -19,6 +19,7 @@ import time
 from pathlib import Path
 from typing import Any
 
+from virtuoso_bridge.env import load_vb_env, resolve_env_path
 from virtuoso_bridge.transport.remote_paths import default_virtuoso_bridge_dir, resolve_remote_username
 from virtuoso_bridge.transport.ssh import SSHRunner, CommandResult
 
@@ -38,30 +39,6 @@ def _is_localhost(host: str | None) -> bool:
 def _state_file(profile: str | None = None) -> Path:
     name = f"state_{profile}.json" if profile else "state.json"
     return _STATE_DIR / name
-
-
-def _load_env_from_repo_or_cwd(load_dotenv_fn) -> None:
-    """Load .env from the virtuoso-bridge repo root, or fall back to CWD search.
-
-    When virtuoso-bridge-lite is cloned inside a project (e.g.
-    ``my-project/virtuoso-bridge-lite/``), the user's ``.env`` may live in
-    either the virtuoso-bridge-lite directory or the project root.
-    This function tries the repo root first, then falls back to the default
-    ``load_dotenv()`` CWD-upward search so both placements work.
-    """
-    # Try to find the virtuoso-bridge repo root
-    here = Path(__file__).resolve()
-    for parent in here.parents:
-        if (parent / "pyproject.toml").is_file():
-            candidate = parent / ".env"
-            if candidate.is_file():
-                load_dotenv_fn(candidate, override=True)
-                return
-            break  # found repo root but no .env there — fall through
-
-    # Fall back: CWD-upward search (default load_dotenv behavior)
-    load_dotenv_fn()
-
 
 # ---------------------------------------------------------------------------
 # Resource helpers (moved from bridge.py)
@@ -121,22 +98,23 @@ def _generate_virtuoso_setup_il(daemon_path: str, il_path: str, python_cmd: str 
 
 
 def _update_env_file(key: str, value: str) -> bool:
-    here = Path.cwd()
-    for parent in [here, *here.parents]:
-        env_path = parent / ".env"
-        if env_path.is_file():
-            text = env_path.read_text(encoding="utf-8")
-            new_text = re.sub(
-                rf"^{re.escape(key)}\s*=.*$",
-                f"{key}={value}",
-                text,
-                flags=re.MULTILINE,
-            )
-            if new_text != text:
-                env_path.write_text(new_text, encoding="utf-8")
-                logger.info("Updated %s=%s in %s", key, value, env_path)
-                return True
-            return False
+    try:
+        env_path = resolve_env_path()
+    except FileNotFoundError:
+        return False
+    if env_path is not None and env_path.is_file():
+        text = env_path.read_text(encoding="utf-8")
+        new_text = re.sub(
+            rf"^{re.escape(key)}\s*=.*$",
+            f"{key}={value}",
+            text,
+            flags=re.MULTILINE,
+        )
+        if new_text != text:
+            env_path.write_text(new_text, encoding="utf-8")
+            logger.info("Updated %s=%s in %s", key, value, env_path)
+            return True
+        return False
     return False
 
 
@@ -197,18 +175,8 @@ class SSHClient:
 
         If *profile* is given (e.g. ``"gpu1"``), reads ``VB_REMOTE_HOST_gpu1``
         etc.  Otherwise reads the default unsuffixed variables.
-
-        Searches for ``.env`` in the following order:
-        1. The virtuoso-bridge-lite repo root (if detectable)
-        2. CWD and parent directories (default ``load_dotenv`` behavior)
-
-        This means ``.env`` can live in either the virtuoso-bridge-lite
-        directory or the project root that contains it as a subdirectory.
         """
-        from dotenv import load_dotenv
-
-        # Try repo-root .env first (same logic as CLI)
-        _load_env_from_repo_or_cwd(load_dotenv)
+        load_vb_env()
 
         suffix = f"_{profile}" if profile else ""
 
@@ -464,11 +432,18 @@ class SSHClient:
             self.ensure_local_setup()
             self.save_state()
             return
-        self.ensure_remote_setup()
-        if self._ssh_runner.persistent_shell_enabled:
-            self._ssh_runner.ensure_persistent_shell(timeout=timeout)
-        self.ensure_tunnel()
-        self.save_state()
+        try:
+            self.ensure_remote_setup()
+            if self._ssh_runner.persistent_shell_enabled:
+                self._ssh_runner.ensure_persistent_shell(timeout=timeout)
+            self.ensure_tunnel()
+            self.save_state()
+        except Exception:
+            try:
+                self.close()
+            except Exception:
+                pass
+            raise
 
     def stop(self) -> None:
         """Kill the tunnel and clean up."""

--- a/src/virtuoso_bridge/virtuoso/basic/bridge.py
+++ b/src/virtuoso_bridge/virtuoso/basic/bridge.py
@@ -12,8 +12,7 @@ import time
 from pathlib import Path
 from typing import Any
 
-from dotenv import load_dotenv
-
+from virtuoso_bridge.env import load_vb_env
 from virtuoso_bridge.virtuoso.basic.composition import compose_skill_script
 from virtuoso_bridge.models import ExecutionStatus, VirtuosoInterface, VirtuosoResult
 from virtuoso_bridge.virtuoso.ops import (
@@ -110,7 +109,7 @@ class VirtuosoClient(VirtuosoInterface):
         etc.  If an SSH tunnel is already running (via ``virtuoso-bridge start``),
         connects to its port.  Otherwise creates a new SSHClient.
         """
-        load_dotenv()
+        load_vb_env()
         from virtuoso_bridge.transport.tunnel import SSHClient
 
         # Check if tunnel is already running
@@ -124,7 +123,11 @@ class VirtuosoClient(VirtuosoInterface):
         suffix = f"_{profile}" if profile else ""
         remote_host = os.getenv(f"VB_REMOTE_HOST{suffix}", "").strip()
         if not remote_host:
-            raise RuntimeError(f"VB_REMOTE_HOST{suffix} must be set. Run: virtuoso-bridge init")
+            raise RuntimeError(
+                f"VB_REMOTE_HOST{suffix} must be set. "
+                "Use an explicit env file, create ./.env, or run `virtuoso-bridge init` "
+                "to create ~/.vblite/.env."
+            )
 
         ssh = SSHClient.from_env(keep_remote_files=True, profile=profile)
         return cls(host="127.0.0.1", port=ssh.port, timeout=timeout, tunnel=ssh, log_to_ciw=log_to_ciw)
@@ -441,11 +444,12 @@ class VirtuosoClient(VirtuosoInterface):
         Use when execute_skill() times out due to a modal dialog blocking CIW.
         Works via direct SSH + X11, independent of the SKILL channel.
         """
+        load_vb_env()
         from virtuoso_bridge.virtuoso import x11
         runner = self.ssh_runner
         if runner is None:
             raise RuntimeError("No SSH connection (tunnel not started?)")
-        user = os.getenv("VB_REMOTE_USER", "")
+        user = runner.user or os.getenv("VB_REMOTE_USER", "")
         return x11.dismiss_dialogs(runner, user, display)
 
     # -- file transfer (delegates to tunnel) --------------------------------

--- a/src/virtuoso_bridge/virtuoso/x11.py
+++ b/src/virtuoso_bridge/virtuoso/x11.py
@@ -14,6 +14,7 @@ import shlex
 from pathlib import Path
 from typing import Any
 
+from virtuoso_bridge.env import load_vb_env
 from virtuoso_bridge.transport.ssh import SSHRunner
 
 logger = logging.getLogger(__name__)
@@ -23,6 +24,7 @@ _HELPER_SCRIPT = Path(__file__).parent.parent / "resources" / "x11_dismiss_dialo
 
 def _get_display(display: str | None) -> str | None:
     """Resolve display: explicit arg > VB_DISPLAY env var > auto-detect (None)."""
+    load_vb_env()
     if display:
         return display
     return os.getenv("VB_DISPLAY") or None
@@ -46,6 +48,7 @@ def find_dialogs(
 
     Returns list of dicts: [{"window_id", "title", "x", "y", "w", "h"}, ...]
     """
+    load_vb_env()
     script = _ensure_helper(runner, user)
     resolved = _get_display(display)
     cmd = f"python3 {script}"
@@ -64,6 +67,7 @@ def dismiss_dialogs(
 
     Returns list of result dicts (found dialogs + dismissal results).
     """
+    load_vb_env()
     script = _ensure_helper(runner, user)
     resolved = _get_display(display)
     env_prefix = ""

--- a/tests/test_cli_env_behavior.py
+++ b/tests/test_cli_env_behavior.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+from virtuoso_bridge import cli
+from virtuoso_bridge import env as env_mod
+
+
+def test_cli_init_creates_user_env(monkeypatch, tmp_path, capsys):
+    env_path = tmp_path / ".vblite" / ".env"
+    monkeypatch.setattr(cli, "default_user_env_path", lambda: env_path)
+    monkeypatch.setattr(cli, "_generate_env_template", lambda: "VB_REMOTE_HOST=test-host\n")
+
+    rc = cli.cli_init()
+
+    assert rc == 0
+    assert env_path.read_text(encoding="utf-8") == "VB_REMOTE_HOST=test-host\n"
+    assert f".env created at {env_path}" in capsys.readouterr().out
+
+
+def test_main_sets_runtime_env_file_for_start(monkeypatch, tmp_path):
+    explicit = tmp_path / "config.env"
+    explicit.write_text("VB_REMOTE_HOST=test-host\n", encoding="utf-8")
+
+    observed: dict[str, Path | None] = {}
+
+    def fake_start() -> int:
+        observed["env"] = env_mod.get_runtime_env_file()
+        return 0
+
+    monkeypatch.setattr(cli, "cli_start", fake_start)
+    env_mod.set_runtime_env_file(None)
+    try:
+        rc = cli.main(["start", "--env", str(explicit)])
+    finally:
+        env_mod.set_runtime_env_file(None)
+
+    assert rc == 0
+    assert observed["env"] == explicit.resolve()
+
+
+def test_main_sets_runtime_env_file_for_sim_jobs(monkeypatch, tmp_path):
+    explicit = tmp_path / "config.env"
+    explicit.write_text("VB_REMOTE_HOST=test-host\n", encoding="utf-8")
+
+    observed: dict[str, Path | None] = {}
+
+    def fake_sim_jobs() -> int:
+        observed["env"] = env_mod.get_runtime_env_file()
+        return 0
+
+    monkeypatch.setattr(cli, "cli_sim_jobs", fake_sim_jobs)
+    env_mod.set_runtime_env_file(None)
+    try:
+        rc = cli.main(["sim-jobs", "--env", str(explicit)])
+    finally:
+        env_mod.set_runtime_env_file(None)
+
+    assert rc == 0
+    assert observed["env"] == explicit.resolve()

--- a/tests/test_env_resolution.py
+++ b/tests/test_env_resolution.py
@@ -1,0 +1,87 @@
+from pathlib import Path
+
+import pytest
+
+from virtuoso_bridge import env as env_mod
+
+
+def _write_env(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_explicit_env_has_highest_priority(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    cwd = tmp_path / "cwd"
+    explicit = tmp_path / "custom.env"
+
+    cwd.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(env_mod.Path, "home", lambda: home)
+    monkeypatch.chdir(cwd)
+    env_mod.set_runtime_env_file(None)
+
+    _write_env(home / ".vblite" / ".env", "VB_REMOTE_HOST=user-host\n")
+    _write_env(cwd / ".env", "VB_REMOTE_HOST=cwd-host\n")
+    _write_env(explicit, "VB_REMOTE_HOST=explicit-host\n")
+
+    loaded = env_mod.load_vb_env(explicit)
+
+    assert loaded == explicit.resolve()
+    assert env_mod.resolve_env_path(explicit) == explicit.resolve()
+
+
+def test_cwd_env_beats_user_env(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    cwd = tmp_path / "cwd"
+
+    cwd.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(env_mod.Path, "home", lambda: home)
+    monkeypatch.chdir(cwd)
+    env_mod.set_runtime_env_file(None)
+
+    _write_env(home / ".vblite" / ".env", "VB_REMOTE_HOST=user-host\n")
+    _write_env(cwd / ".env", "VB_REMOTE_HOST=cwd-host\n")
+
+    assert env_mod.resolve_env_path() == (cwd / ".env").resolve()
+
+
+def test_user_env_is_fallback(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    cwd = tmp_path / "cwd"
+
+    cwd.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(env_mod.Path, "home", lambda: home)
+    monkeypatch.chdir(cwd)
+    env_mod.set_runtime_env_file(None)
+
+    _write_env(home / ".vblite" / ".env", "VB_REMOTE_HOST=user-host\n")
+
+    assert env_mod.resolve_env_path() == (home / ".vblite" / ".env").resolve()
+
+
+def test_runtime_env_file_beats_cwd_and_user(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    cwd = tmp_path / "cwd"
+    runtime = tmp_path / "runtime.env"
+
+    cwd.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(env_mod.Path, "home", lambda: home)
+    monkeypatch.chdir(cwd)
+
+    _write_env(home / ".vblite" / ".env", "VB_REMOTE_HOST=user-host\n")
+    _write_env(cwd / ".env", "VB_REMOTE_HOST=cwd-host\n")
+    _write_env(runtime, "VB_REMOTE_HOST=runtime-host\n")
+
+    env_mod.set_runtime_env_file(runtime)
+    try:
+        assert env_mod.resolve_env_path() == runtime.resolve()
+    finally:
+        env_mod.set_runtime_env_file(None)
+
+
+def test_missing_explicit_env_raises(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    env_mod.set_runtime_env_file(None)
+
+    with pytest.raises(FileNotFoundError):
+        env_mod.resolve_env_path(tmp_path / "missing.env")

--- a/tests/test_windows_ssh_flags.py
+++ b/tests/test_windows_ssh_flags.py
@@ -1,0 +1,117 @@
+from virtuoso_bridge import env as env_mod
+from virtuoso_bridge.transport import ssh as ssh_mod
+
+
+def test_windows_no_window_kwargs_default_is_detached(monkeypatch):
+    class FakeStartupInfo:
+        def __init__(self):
+            self.dwFlags = 0
+            self.wShowWindow = 1
+
+    monkeypatch.setattr(ssh_mod.os, "name", "nt", raising=False)
+    monkeypatch.setattr(ssh_mod.subprocess, "STARTUPINFO", FakeStartupInfo, raising=False)
+    monkeypatch.setattr(ssh_mod.subprocess, "STARTF_USESHOWWINDOW", 0x00000001, raising=False)
+    monkeypatch.setattr(ssh_mod.subprocess, "CREATE_NO_WINDOW", 0x08000000, raising=False)
+    monkeypatch.setattr(ssh_mod.subprocess, "DETACHED_PROCESS", 0x00000008, raising=False)
+    monkeypatch.setattr(ssh_mod.subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200, raising=False)
+
+    kwargs = ssh_mod._windows_no_window_kwargs()
+
+    assert kwargs["close_fds"] is True
+    assert kwargs["creationflags"] & ssh_mod.subprocess.CREATE_NO_WINDOW
+    assert kwargs["creationflags"] & ssh_mod.subprocess.DETACHED_PROCESS
+    assert not (kwargs["creationflags"] & ssh_mod.subprocess.CREATE_NEW_PROCESS_GROUP)
+    assert kwargs["startupinfo"].dwFlags & ssh_mod.subprocess.STARTF_USESHOWWINDOW
+    assert kwargs["startupinfo"].wShowWindow == 0
+
+
+def test_windows_no_window_kwargs_can_request_new_process_group(monkeypatch):
+    class FakeStartupInfo:
+        def __init__(self):
+            self.dwFlags = 0
+            self.wShowWindow = 1
+
+    monkeypatch.setattr(ssh_mod.os, "name", "nt", raising=False)
+    monkeypatch.setattr(ssh_mod.subprocess, "STARTUPINFO", FakeStartupInfo, raising=False)
+    monkeypatch.setattr(ssh_mod.subprocess, "STARTF_USESHOWWINDOW", 0x00000001, raising=False)
+    monkeypatch.setattr(ssh_mod.subprocess, "CREATE_NO_WINDOW", 0x08000000, raising=False)
+    monkeypatch.setattr(ssh_mod.subprocess, "DETACHED_PROCESS", 0x00000008, raising=False)
+    monkeypatch.setattr(ssh_mod.subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200, raising=False)
+
+    kwargs = ssh_mod._windows_no_window_kwargs(new_process_group=True)
+
+    assert kwargs["creationflags"] & ssh_mod.subprocess.CREATE_NEW_PROCESS_GROUP
+
+
+def test_windows_disables_persistent_shell(monkeypatch):
+    monkeypatch.setattr(ssh_mod.os, "name", "nt", raising=False)
+
+    runner = ssh_mod.SSHRunner(host="example.com", user="tester", persistent_shell=True)
+
+    assert runner.persistent_shell_enabled is False
+
+
+def test_env_overrides_ssh_scp_and_tar(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    cwd = tmp_path / "cwd"
+    cwd.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(env_mod.Path, "home", lambda: home)
+    monkeypatch.chdir(cwd)
+    monkeypatch.setenv("VB_SSH_CMD", r"C:\custom\ssh.exe")
+    monkeypatch.setenv("VB_SCP_CMD", r"C:\custom\scp.exe")
+    monkeypatch.setenv("VB_TAR_CMD", r"C:\custom\tar.exe")
+    monkeypatch.setattr(ssh_mod.shutil, "which", lambda name: rf"C:\path\{name}.exe")
+
+    runner = ssh_mod.SSHRunner(host="example.com", user="tester")
+
+    assert runner._ssh_cmd == r"C:\custom\ssh.exe"
+    assert runner._scp_cmd == r"C:\custom\scp.exe"
+    assert runner._tar_cmd == r"C:\custom\tar.exe"
+
+
+def test_default_windows_tools_come_from_path(monkeypatch, tmp_path):
+    tools = {
+        "ssh": r"C:\Windows\System32\OpenSSH\ssh.exe",
+        "scp": r"C:\Windows\System32\OpenSSH\scp.exe",
+        "tar": r"C:\Windows\System32\tar.exe",
+    }
+
+    home = tmp_path / "home"
+    cwd = tmp_path / "cwd"
+    cwd.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(env_mod.Path, "home", lambda: home)
+    monkeypatch.chdir(cwd)
+    monkeypatch.setattr(ssh_mod.os, "name", "nt", raising=False)
+    monkeypatch.delenv("VB_SSH_CMD", raising=False)
+    monkeypatch.delenv("VB_SCP_CMD", raising=False)
+    monkeypatch.delenv("VB_TAR_CMD", raising=False)
+    monkeypatch.setattr(ssh_mod.shutil, "which", lambda name: tools.get(name))
+
+    runner = ssh_mod.SSHRunner(host="example.com", user="tester")
+
+    assert runner._ssh_cmd == tools["ssh"]
+    assert runner._scp_cmd == tools["scp"]
+    assert runner._tar_cmd == tools["tar"]
+
+
+def test_ssh_runner_loads_tool_overrides_from_dotenv(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    cwd = tmp_path / "cwd"
+    cwd.mkdir(parents=True, exist_ok=True)
+    (cwd / ".env").write_text(
+        "VB_SSH_CMD=C:\\custom\\ssh.exe\n"
+        "VB_TAR_CMD=C:\\custom\\tar.exe\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(env_mod.Path, "home", lambda: home)
+    monkeypatch.chdir(cwd)
+    monkeypatch.delenv("VB_SSH_CMD", raising=False)
+    monkeypatch.delenv("VB_SCP_CMD", raising=False)
+    monkeypatch.delenv("VB_TAR_CMD", raising=False)
+    monkeypatch.setattr(ssh_mod.shutil, "which", lambda name: rf"C:\path\{name}.exe")
+
+    runner = ssh_mod.SSHRunner(host="example.com", user="tester")
+
+    assert runner._ssh_cmd == r"C:\custom\ssh.exe"
+    assert runner._tar_cmd == r"C:\custom\tar.exe"


### PR DESCRIPTION
## Summary

This PR fixes two reliability issues in `virtuoso-bridge-lite`.

1. Windows SSH/tunnel stability
- detach background SSH tunnel processes cleanly on Windows
- disable persistent SSH shells on Windows
- improve cleanup on failure paths so orphaned `ssh.exe` processes are less likely
- keep `start` / `status` / `license` / related SSH helpers on the same safe launch path

2. Unified env loading
- add shared `.env` resolution with priority: `--env` > `./.env` > `~/.vblite/.env`
- remove repo-root / project-root `.env` assumptions
- update CLI, SSH, Virtuoso, Spectre, and X11 entry points to use the shared loader
- make `virtuoso-bridge init` create `~/.vblite/.env`

## Why

On Windows, running `virtuoso-bridge` could leave long-lived `ssh.exe` processes attached to the current command environment, which could cause later Codex/PowerShell commands to hang or pop up visible SSH windows.

Separately, the previous `.env` lookup logic assumed a project/repo layout that does not fit installed-skill usage. This PR moves config resolution to a user/tool-oriented model.

## Validation

- verified `.env` precedence with unit tests
- verified Windows SSH flag / tool override behavior with unit tests
- verified CLI `--env` wiring with unit tests
- manually exercised the real `thu-jump -> thu-yuan` bridge flow during debugging
