### PR TITLE
feat(models): add VirtuosoResult.is_nil property

### DIFF
--- a/src/virtuoso_bridge/models.py
+++ b/src/virtuoso_bridge/models.py
@@ -32,6 +32,24 @@ class VirtuosoResult(BaseModel):
         """True if execution succeeded."""
         return self.status == ExecutionStatus.SUCCESS
 
+    @property
+    def is_nil(self) -> bool:
+        """True if SKILL returned ``nil``.
+
+        In SKILL, ``nil`` is simultaneously boolean false, the empty list,
+        and the "no value" sentinel.  Many Maestro/ADE functions (e.g.
+        ``maeEnableTests``, ``maeSetVar``) return ``t`` on success and
+        ``nil`` on failure or no-op — indistinguishable from a void return
+        unless the caller checks explicitly.
+
+        This property makes that check idiomatic::
+
+            r = client.execute_skill('maeEnableTests()')
+            if r.ok and not r.is_nil:
+                ...  # something was actually enabled
+        """
+        return self.ok and (self.output or "").strip().strip('"') in ("nil", "")
+
     def save_json(self, path: Path, *, indent: int = 2, encoding: str = "utf-8") -> None:
         """Write result to a JSON file."""
         path = Path(path)


### PR DESCRIPTION
## Problem

`execute_skill()` returns `status=SUCCESS, output="nil"` for any SKILL expression that evaluates to `nil`. In SKILL, `nil` is simultaneously boolean false, the empty list, and the "no value" sentinel — so callers cannot tell the difference between a genuine nil result and a function that silently did nothing (e.g. wrong arguments, no session state).

This already bites in Maestro automation. For example:

```python
r = client.execute_skill('maeEnableTests()')
# r.ok == True, r.errors == []  ← looks like success
# but maeEnableTests returned nil because no tests were selected
# next maeRunSimulation() → ASSEMBLER-1700, 240 s timeout
```

The nil checks already exist in the codebase (`run_shell_command`, `get_current_design`) but are buried inside each method.

## Fix

Add a single `is_nil` property to `VirtuosoResult` that surfaces this check idiomatically:

```python
r = client.execute_skill('maeEnableTests()')
if r.ok and not r.is_nil:
    ...  # something was actually enabled
```

## Scope

- **1 file changed**, `src/virtuoso_bridge/models.py`
- **Purely additive** — no existing behaviour changes
- Property is consistent with nil guards already in `run_shell_command()` and `get_current_design()`