### PR TITLE
docs(maestro): document maeRunSimulation ?callback for non-blocking completion handling

### DIFF
--- a/skills/virtuoso/references/maestro-skill-api.md
+++ b/skills/virtuoso/references/maestro-skill-api.md
@@ -310,12 +310,32 @@ maeSaveSetup(?lib "myLib" ?cell "myCell" ?view "maestro" ?session "fnxSession4")
 ; GUI stays responsive, results appear automatically in Maestro window
 maeRunSimulation()
 maeRunSimulation(?session "fnxSession4")
+```
 
-; Wait separately (if async)
+#### Post-simulation callback (recommended)
+
+Use `?callback` to register a procedure that is called automatically when the simulation finishes. This is non-blocking — the SKILL channel and GUI remain responsive:
+
+```scheme
+; Define callback — receives session handle and run ID
+procedure(RunFinishedCallback(session runID)
+  printf("Run ID %L has finished\n" runID)
+)
+
+; Run with callback — returns immediately, callback fires on completion
+maeRunSimulation(?callback "RunFinishedCallback")
+```
+
+The callback receives two arguments: `session` (the maestro session) and `runID` (e.g. `"Interactive.3"`). This is the cleanest way to chain post-simulation actions (result reading, export, next optimization iteration, etc.) without blocking.
+
+#### Blocking wait (use with caution)
+
+```scheme
+; Blocks the SKILL channel until all simulations finish
 maeWaitUntilDone('All)
 ```
 
-**Important:** `maeRunSimulation(?waitUntilDone t)` blocks Virtuoso's event loop, which prevents the GUI from refreshing and can break the bridge connection. Use **async** `maeRunSimulation()` + `maeWaitUntilDone('All)` instead.
+**Important:** `maeRunSimulation(?waitUntilDone t)` blocks Virtuoso's entire event loop, which prevents the GUI from refreshing and can break the bridge connection. If you must wait synchronously, use `maeRunSimulation()` + `maeWaitUntilDone('All)` instead — it still blocks the SKILL channel but doesn't freeze the GUI. Prefer `?callback` for a fully non-blocking approach.
 
 **Important:** Results only appear automatically in the Maestro GUI when the maestro window was opened via `deOpenCellView` **before** running. If maestro was only opened as a backend session (`maeOpenSetup`), results won't display.
 
@@ -522,10 +542,16 @@ client.execute_skill(
     f'?signalName "/OUT" ?session "{session}")')
 client.execute_skill(f'maeSetVar("c_val" "1p,100f" ?session "{session}")')
 
-# 5. Save + run (async — never use ?waitUntilDone t, it blocks the event loop)
+# 5. Save + run
 client.execute_skill(
     f'maeSaveSetup(?lib "{lib}" ?cell "{cell}" '
     f'?view "maestro" ?session "{session}")')
+
+# Option A: use run_and_wait() from Python API (recommended — uses ?callback, non-blocking)
+# from virtuoso_bridge.virtuoso.maestro import run_and_wait
+# history, status = run_and_wait(client, session=session, timeout=300)
+
+# Option B: blocking wait via SKILL (simpler but blocks SKILL channel)
 client.execute_skill(f'maeRunSimulation(?session "{session}")')
 client.execute_skill("maeWaitUntilDone('All)", timeout=300)
 


### PR DESCRIPTION
## Summary

The current documentation recommends `maeWaitUntilDone('All)` after `maeRunSimulation()`, which blocks the SKILL channel until completion. `maeRunSimulation` actually supports a `?callback` parameter that registers a procedure to be called automatically when the simulation finishes — fully non-blocking.

### The callback approach

```scheme
;; Define callback — receives session handle and run ID
procedure(RunFinishedCallback(session runID)
  printf("Run ID %L has finished\n" runID)
)

;; Run with callback — returns immediately, callback fires on completion
maeRunSimulation(?callback "RunFinishedCallback")
```

This keeps both the SKILL channel and GUI fully responsive during simulation. It's the cleanest way to chain post-simulation actions (result reading, export, next iteration in an optimization loop, etc.).

### Changes

- **maestro-skill-api.md**: Add "Post-simulation callback (recommended)" section documenting `?callback`, restructure "Blocking wait" as a secondary option with clearer caveats, update quick-start example to mention `run_and_wait()` as the recommended Python approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)