### PR TITLE
fix: add stdbuf -oL to daemon launch for reliable IPC line buffering

### DIFF
--- a/core/ramic_bridge.il
+++ b/core/ramic_bridge.il
@@ -36,8 +36,10 @@ procedure(RBStart()
   else
     ; Use "env -u" to strip Virtuoso's LD_LIBRARY_PATH / LD_PRELOAD
     ; so the system Python links against its own libs.
+    ; Use "stdbuf -oL" to force line-buffered stdout so ipcBeginProcess
+    ; receives complete lines without waiting for Python's buffer to fill.
     RBIpc = ipcBeginProcess(
-      sprintf(nil "/usr/bin/env -u LD_LIBRARY_PATH -u LD_PRELOAD %s %L %s %d"
+      sprintf(nil "/usr/bin/env -u LD_LIBRARY_PATH -u LD_PRELOAD stdbuf -oL %s -u %L %s %d"
         RBPython RBDPath "127.0.0.1" RBPort)
       "" 'RBIpcDataHandler nil 'RBIpcFinishHandler "")
     printf("[RAMIC] started on port %d\n" RBPort)

--- a/src/virtuoso_bridge/virtuoso/basic/resources/ramic_bridge.il
+++ b/src/virtuoso_bridge/virtuoso/basic/resources/ramic_bridge.il
@@ -80,7 +80,7 @@ procedure(RBStart()
 			; Use "env -u" to strip Virtuoso's LD_LIBRARY_PATH / LD_PRELOAD
 			; so the system Python links against its own libs, not Virtuoso's
 			; bundled (and often incompatible) copies.
-			RBIpc = ipcBeginProcess(sprintf(nil "/usr/bin/env -u LD_LIBRARY_PATH -u LD_PRELOAD %s %L %L %L" RBPython RBDPath host RBPort) "" 'RBIpcDataHandler 'RBIpcErrHandler 'RBIpcFinishHandler logpath)
+			RBIpc = ipcBeginProcess(sprintf(nil "/usr/bin/env -u LD_LIBRARY_PATH -u LD_PRELOAD stdbuf -oL %s -u %L %L %L" RBPython RBDPath host RBPort) "" 'RBIpcDataHandler 'RBIpcErrHandler 'RBIpcFinishHandler logpath)
 		)
 		printf("[RAMIC Bridge (%L)] start at (%s)\n" RBIpc getCurrentTime())
 	)


### PR DESCRIPTION
## Summary

Python buffers stdout by default when it detects a pipe (as with `ipcBeginProcess`). Even with `-u` (unbuffered), the C runtime's stdio layer can still block-buffer. Adding `stdbuf -oL` forces line buffering at the libc level, ensuring `ipcBeginProcess` receives complete lines promptly.

This is especially important for the daemon's result writes (`ipcWriteProcess` response path) — without line buffering, Virtuoso's IPC data handler may experience delays waiting for the pipe buffer to fill or flush.

### Changes

- **core/ramic_bridge.il**: Add `stdbuf -oL` and Python `-u` flag to `ipcBeginProcess` command
- **src/.../ramic_bridge.il**: Same change in the packaged resource copy

### Before
```
/usr/bin/env -u LD_LIBRARY_PATH -u LD_PRELOAD python daemon.py host port
```

### After
```
/usr/bin/env -u LD_LIBRARY_PATH -u LD_PRELOAD stdbuf -oL python -u daemon.py host port
```

`stdbuf -oL` handles libc-level buffering, `-u` handles Python-level buffering — belt and suspenders for reliable IPC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)