### PR TITLE
Add verbose argument-check error messages to all examples requiring <LIB> ; Fix/layout examples robustness (latest)

### DIFF
--- a/examples/01_virtuoso/basic/03_load_il.py
+++ b/examples/01_virtuoso/basic/03_load_il.py
@@ -4,6 +4,8 @@
 Prerequisites:
 - virtuoso-bridge tunnel running (virtuoso-bridge start)
 - RAMIC daemon loaded in Virtuoso CIW
+
+Customize SONNET_IL below to point to the .il file you want to load.
 """
 
 import sys, pathlib; sys.path.insert(0, str(pathlib.Path(__file__).parent.parent.parent))
@@ -11,7 +13,11 @@ from pathlib import Path
 from _timing import print_elapsed
 from virtuoso_bridge import VirtuosoClient
 
+# ----------------------------------------------------------------------
+# Customize: path to the .il SKILL file to load
+# ----------------------------------------------------------------------
 SONNET_IL = Path(__file__).resolve().parent.parent / "assets" / "sonnet18.il"
+# ----------------------------------------------------------------------
 
 client = VirtuosoClient.from_env()
 result = client.load_il(SONNET_IL)

--- a/examples/01_virtuoso/layout/01_create_layout.py
+++ b/examples/01_virtuoso/layout/01_create_layout.py
@@ -8,7 +8,7 @@ Usage::
     <LIB> is required — the target Virtuoso library where the layout cell
     will be created.  Example::
 
-        python 01_create_layout.py lifangshi
+        python 01_create_layout.py testlib
 
     Running this script from VSCode without passing <LIB> will NOT work:
     the script will exit with a clear error, and Virtuoso will show nothing.

--- a/examples/01_virtuoso/layout/01_create_layout.py
+++ b/examples/01_virtuoso/layout/01_create_layout.py
@@ -1,5 +1,25 @@
 #!/usr/bin/env python3
-"""Create a demo layout with shapes and TSMC28 instances."""
+"""Create a demo layout with shapes and instances.
+
+Usage::
+
+    python 01_create_layout.py <LIB>
+
+    <LIB> is required — the target Virtuoso library where the layout cell
+    will be created.  Example::
+
+        python 01_create_layout.py lifangshi
+
+    Running this script from VSCode without passing <LIB> will NOT work:
+    the script will exit with a clear error, and Virtuoso will show nothing.
+
+Prerequisites:
+  - virtuoso-bridge service running (virtuoso-bridge start)
+  - PDK library and layers below must match your PDK definition
+
+Customize the PDK_*, LAYER_* and FONT constants below to match your
+environment before running.
+"""
 
 from __future__ import annotations
 
@@ -18,36 +38,97 @@ from virtuoso_bridge.virtuoso.layout.ops import (
     layout_create_label as label,
 )
 
-if len(sys.argv) < 2:
-    print(f"Usage: python {Path(__file__).name} <LIB>")
-    raise SystemExit(1)
-lib_name = sys.argv[1]
-cell_name = f"layout_demo_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
-pdk_lib = "tsmcN28"
+# ----------------------------------------------------------------------
+# Customize these to match your PDK and environment
+# ----------------------------------------------------------------------
+# PDK library that contains your device masters (e.g. nch, pch, cap, res...)
+# Verify this library exists in your Virtuoso library manager before running.
+PDK_LIB = "tsmcN28"
+
+# Layer/purpose names for shapes — must be defined in your PDK techfile.
+# Common examples: M1/drawing, Metal1/drawing, poly/drawing, etc.
+# Check layer names in Virtuoso: Setup → Layers → Layer Table.
+LAYER_RECT  = "M1"      # layer for rectangles
+LAYER_PATH  = "M2"      # layer for paths
+LAYER_LABEL = "M1"      # layer for text labels
+LAYER_PIN   = "M1"      # layer for pin labels
+
+# Available font names in Virtuoso: "default", "roman", "times", "courier",
+# "helvetica", "symbol", etc.  "roman" is the safest cross-PDK choice.
+FONT = "roman"
+# ----------------------------------------------------------------------
+
 
 def main() -> int:
+    # ------------------------------------------------------------------
+    # Argument check — this script MUST be run with a library argument.
+    # Clicking "Run" in VSCode without passing <LIB> will silently do
+    # nothing in Virtuoso, so we abort with a clear message instead.
+    # ------------------------------------------------------------------
+    if len(sys.argv) < 2:
+        print("=" * 60, file=sys.stderr)
+        print(" ERROR: missing required argument <LIB>", file=sys.stderr)
+        print()
+        print(
+            f" Usage: python {Path(__file__).name} <LIB>\n"
+            " Example: python 01_create_layout.py lifangshi\n",
+            file=sys.stderr,
+        )
+        print(
+            " NOTE: Running this script from VSCode (Ctrl+F5 / F5) will NOT\n"
+            "       work — VSCode does not pass command-line arguments by default.\n"
+            "       Either run from a terminal, configure a launch.json, or\n"
+            "       edit the PDK values in this file directly.\n",
+            file=sys.stderr,
+        )
+        print(
+            " If Virtuoso shows a blank cell after running, check that:\n"
+            "   1. <LIB> is a library that exists in your Virtuoso setup\n"
+            "   2. PDK_LIB points to a library with device masters\n"
+            "   3. LAYER_* names match your PDK techfile layers\n",
+            file=sys.stderr,
+        )
+        print("=" * 60, file=sys.stderr)
+        raise SystemExit(1)
+
+    lib_name = sys.argv[1]
+    cell_name = f"layout_demo_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+
     client = VirtuosoClient.from_env()
+
+    # Quick sanity check: print what we are about to do so the user can
+    # verify the values before the layout is created.
     print(f"Target Library  : {lib_name}")
-    print(f"Target Cell     : {cell_name}")
+    print(f"Target Cell    : {cell_name}")
+    print(f"PDK Library    : {PDK_LIB}")
+    print(f"Layer (rect)   : {LAYER_RECT}/drawing")
+    print(f"Layer (path)   : {LAYER_PATH}/drawing")
+    print(f"Layer (label)  : {LAYER_LABEL}/pin")
+    print(f"Font           : {FONT}")
+    print()
 
     def build_layout() -> None:
         with client.layout.edit(lib_name, cell_name) as layout:
-            layout.add(inst(pdk_lib, "nch_ulvt_mac", "layout", "M0", 0.0, 0.0, "R0"))
-            layout.add(inst(pdk_lib, "pch_ulvt_mac", "layout", "M1", 2.0, 0.0, "R0"))
-            layout.add(inst(pdk_lib, "cfmom_2t", "layout", "C0", 4.0, 0.0, "R0"))
+            # --- instances (device masters from PDK_LIB) ---
+            layout.add(inst(PDK_LIB, "nch_ulvt_mac", "layout", "M0", 0.0, 0.0, "R0"))
+            layout.add(inst(PDK_LIB, "pch_ulvt_mac", "layout", "M1", 2.0, 0.0, "R0"))
+            layout.add(inst(PDK_LIB, "cfmom_2t",     "layout", "C0", 4.0, 0.0, "R0"))
 
-            layout.add(rect("M1", "drawing", 1.0, 0.0, 2.0, 0.5))
-            layout.add(rect("M1", "drawing", 1.5, 1.0, 2.5, 1.5))
-            layout.add(path("M2", "drawing", [(1.0, 0.25), (3.0, 0.25)], width=0.1))
-            layout.add(label("M1", "pin", 1.1, 0.5, "IN", "centerLeft", "R0", "default", 0.1))
+            # --- shapes (adjust LAYER_* constants above) ---
+            layout.add(rect(LAYER_RECT,  "drawing", 1.0, 0.0, 2.0, 0.5))
+            layout.add(rect(LAYER_RECT,  "drawing", 1.5, 1.0, 2.5, 1.5))
+            layout.add(path(LAYER_PATH, "drawing", [(1.0, 0.25), (3.0, 0.25)], width=0.1))
+            layout.add(label(LAYER_LABEL, "pin",  1.1, 0.5, "IN", "centerLeft", "R0", FONT, 0.1))
 
     elapsed, _ = timed_call(build_layout)
-    print(f"[edit_layout] [{format_elapsed(elapsed)}]")
+    print(f"[edit_layout]  [{format_elapsed(elapsed)}]")
 
     open_elapsed, _ = timed_call(lambda: client.open_window(lib_name, cell_name, view="layout"))
     print(f"[open_window] [{format_elapsed(open_elapsed)}]")
-    print("[Done] Layout created using LayoutEditor")
+    print("[Done] Layout created — check the Virtuoso window.")
+    print("       If the cell is blank, verify PDK_LIB and LAYER_* values above.")
     return 0
+
 
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/examples/01_virtuoso/layout/02_add_polygon.py
+++ b/examples/01_virtuoso/layout/02_add_polygon.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
-"""Add a polygon to the current layout view."""
+"""Add a polygon to the current layout view.
+
+Prerequisites:
+  - virtuoso-bridge service running (virtuoso-bridge start)
+  - A layout cellview must be open in Virtuoso (reads it via get_current_design)
+
+Customize LAYER and PURPOSE below to match your PDK techfile.
+"""
 
 from __future__ import annotations
 
@@ -14,7 +21,7 @@ from virtuoso_bridge.virtuoso.layout.ops import (
     layout_create_polygon as polygon,
 )
 
-LAYER = "M3"
+LAYER = "edgeLayer"
 PURPOSE = "drawing"
 POINTS = [
     (0.5, 1.8),

--- a/examples/01_virtuoso/layout/03_add_via.py
+++ b/examples/01_virtuoso/layout/03_add_via.py
@@ -1,5 +1,14 @@
 #!/usr/bin/env python3
-"""Add vias with both the by-name and raw-viaDef APIs."""
+"""Add vias with both the by-name and raw-viaDef APIs.
+
+Prerequisites:
+  - virtuoso-bridge service running (virtuoso-bridge start)
+  - A layout cellview must be open in Virtuoso
+
+Customize VIA_NAME below to match a via definition in your PDK techfile
+(e.g. M1_M2, M2_M3, etc.).  Check via names via Virtuoso UI:
+  Execute → Create → Via...
+"""
 
 from __future__ import annotations
 
@@ -16,7 +25,13 @@ from virtuoso_bridge.virtuoso.layout.ops import (
     layout_via_def_expr_from_name as via_def_from_name,
 )
 
+# ----------------------------------------------------------------------
+# Customize to match your PDK
+# ----------------------------------------------------------------------
+# Via definition name — must exist in your PDK techfile
 VIA_NAME = "M2_M1"
+# ----------------------------------------------------------------------
+
 BY_NAME_VIA_X = 1.5
 BY_NAME_VIA_Y = 0.25
 RAW_VIA_X = 2.0

--- a/examples/01_virtuoso/layout/04_multilayer_routing.py
+++ b/examples/01_virtuoso/layout/04_multilayer_routing.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
-"""Add the same route across layout layers M2 through M7."""
+"""Add the same route across layout layers M2 through M7.
+
+Prerequisites:
+  - virtuoso-bridge service running (virtuoso-bridge start)
+  - A layout cellview must be open in Virtuoso
+
+Customize LAYERS below to match the metal stack in your PDK techfile.
+"""
 
 from __future__ import annotations
 
@@ -14,7 +21,12 @@ from virtuoso_bridge.virtuoso.layout.ops import (
     layout_create_path as path,
 )
 
+# ----------------------------------------------------------------------
+# Customize to match your PDK metal stack
+# ----------------------------------------------------------------------
+# List of metal layers available in your PDK (in routing order, bottom→top)
 LAYERS = ["M2", "M3", "M4", "M5", "M6", "M7"]
+# ----------------------------------------------------------------------
 
 # Routing parameters
 PATH_WIDTH = 0.1   # um

--- a/examples/01_virtuoso/layout/05_bus_routing.py
+++ b/examples/01_virtuoso/layout/05_bus_routing.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
-"""Add an 8-bit labeled bus route to the current layout view."""
+"""Add an 8-bit labeled bus route to the current layout view.
+
+Prerequisites:
+  - virtuoso-bridge service running (virtuoso-bridge start)
+  - A layout cellview must be open in Virtuoso
+
+Customize LAYERS, LABEL_LAYER and FONT below to match your PDK techfile.
+"""
 
 from __future__ import annotations
 
@@ -15,7 +22,13 @@ from virtuoso_bridge.virtuoso.layout.ops import (
     layout_create_label as label,
 )
 
+# ----------------------------------------------------------------------
+# Customize to match your PDK metal stack
+# ----------------------------------------------------------------------
+# Metal layer(s) for bus wires — must be defined in your PDK techfile
 LAYERS    = ["M4"]
+# ----------------------------------------------------------------------
+
 BUS_WIDTH = 8
 
 # Routing parameters
@@ -25,8 +38,17 @@ X_START    = 0.0
 X_END      = 5.0
 Y_BASE     = 2.0   # Y of bit 0 (CODE<0>); higher bits increment upward
 
+# ----------------------------------------------------------------------
+# Customize to match your PDK techfile
+# ----------------------------------------------------------------------
+# Layer/purpose for bus labels — must be defined in your PDK techfile
 LABEL_LAYER  = "M4"
 LABEL_HEIGHT = 0.1  # um
+
+# Available font names: "roman", "default", "times", "courier",
+# "helvetica", "symbol", etc.  "roman" is the safest cross-PDK choice.
+FONT = "roman"
+# ----------------------------------------------------------------------
 
 
 def main() -> int:
@@ -56,7 +78,7 @@ def main() -> int:
                     LABEL_LAYER, "pin",
                     X_START, y,
                     f"CODE<{bit}>",
-                    "centerLeft", "R0", "default",
+                    "centerLeft", "R0", FONT,
                     LABEL_HEIGHT,
                 ))
 

--- a/examples/01_virtuoso/layout/07_delete_shapes_on_layer.py
+++ b/examples/01_virtuoso/layout/07_delete_shapes_on_layer.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
-"""Delete all shapes on a target layer and purpose from the current layout."""
+"""Delete all shapes on a target layer and purpose from the current layout.
+
+Prerequisites:
+  - virtuoso-bridge service running (virtuoso-bridge start)
+  - A layout cellview must be open in Virtuoso
+
+Customize DELETE_LAYER and DELETE_PURPOSE below to match your PDK techfile.
+"""
 
 from __future__ import annotations
 
@@ -10,8 +17,14 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from _timing import decode_skill, format_elapsed, timed_call
 from virtuoso_bridge import VirtuosoClient
-DELETE_LAYER = "M3"
+
+# ----------------------------------------------------------------------
+# Customize to match the layer/purpose you want to delete
+# ----------------------------------------------------------------------
+# Must be defined in your PDK techfile
+DELETE_LAYER   = "M3"
 DELETE_PURPOSE = "drawing"
+# ----------------------------------------------------------------------
 
 
 def main() -> int:

--- a/examples/01_virtuoso/layout/flower.py
+++ b/examples/01_virtuoso/layout/flower.py
@@ -1,5 +1,15 @@
 #!/usr/bin/env python3
-"""Draw a flower in Virtuoso layout using polygons."""
+"""Draw a flower in Virtuoso layout using polygons.
+
+Usage::
+
+    python flower.py <LIB>
+
+Prerequisites:
+  - virtuoso-bridge service running (virtuoso-bridge start)
+
+Customize the LAYER constants below to match your PDK metal stack.
+"""
 
 from __future__ import annotations
 
@@ -29,12 +39,21 @@ PETAL_B = 1.2    # semi-minor axis (petal width), um
 PETAL_D = 3.2    # petal center distance from origin, um
 CENTER_R = 1.8   # center circle radius, um
 
-# Alternate two layers for petals so adjacent ones contrast in color
+# ----------------------------------------------------------------------
+# Customize to match your PDK metal stack
+# ----------------------------------------------------------------------
+# Alternate two layers for petals so adjacent ones contrast in color.
+# All layers listed here must be defined in your PDK techfile.
 PETAL_LAYERS = [("M3", "drawing"), ("M4", "drawing")]
 CENTER_LAYER = ("M5", "drawing")
 STEM_LAYER   = ("M1", "drawing")
 LEAF_LAYER   = ("M2", "drawing")
 LABEL_LAYER  = ("M1", "pin")
+
+# Available font names: "roman", "default", "times", "courier",
+# "helvetica", "symbol", etc.  "roman" is the safest cross-PDK choice.
+FONT = "roman"
+# ----------------------------------------------------------------------
 
 
 def ellipse_pts(
@@ -81,7 +100,7 @@ def main() -> int:
         layout.add(polygon(*LEAF_LAYER, leaf_r))
 
         # -- Label -----------------------------------------------------------------
-        layout.add(label(*LABEL_LAYER, 0.0, -16.2, "FLOWER", "centerLeft", "R0", "default", 0.6))
+        layout.add(label(*LABEL_LAYER, 0.0, -16.2, "FLOWER", "centerLeft", "R0", FONT, 0.6))
 
         layout.add(fit_view())
 

--- a/examples/01_virtuoso/layout/flower.py
+++ b/examples/01_virtuoso/layout/flower.py
@@ -5,6 +5,14 @@ Usage::
 
     python flower.py <LIB>
 
+    <LIB> is required — the Virtuoso library where the cell "flower"
+    will be created.  Example::
+
+        python flower.py testlib
+
+    Running this script from VSCode without passing <LIB> will NOT work:
+    the script will exit with a clear error, and Virtuoso will show nothing.
+
 Prerequisites:
   - virtuoso-bridge service running (virtuoso-bridge start)
 
@@ -27,10 +35,6 @@ from virtuoso_bridge.virtuoso.layout.ops import (
     layout_fit_view as fit_view,
 )
 
-if len(sys.argv) < 2:
-    print(f"Usage: python {Path(__file__).name} <LIB>")
-    raise SystemExit(1)
-LIB = sys.argv[1]
 CELL = "flower"
 
 N_PETALS = 8
@@ -56,6 +60,11 @@ FONT = "roman"
 # ----------------------------------------------------------------------
 
 
+def _die(message: str) -> None:
+    print(f"[ERROR] {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
 def ellipse_pts(
     cx: float, cy: float, a: float, b: float, angle: float, n: int = 28
 ) -> list[tuple[float, float]]:
@@ -70,10 +79,47 @@ def ellipse_pts(
 
 
 def main() -> int:
-    client = VirtuosoClient.from_env()
-    print(f"[Flower] Creating '{CELL}' in '{LIB}' ...")
+    # ------------------------------------------------------------------
+    # Argument check — this script MUST be run with a library argument.
+    # Clicking "Run" in VSCode without passing <LIB> will silently do
+    # nothing in Virtuoso, so we abort with a clear message instead.
+    # ------------------------------------------------------------------
+    if len(sys.argv) < 2:
+        print("=" * 60, file=sys.stderr)
+        print(" ERROR: missing required argument <LIB>", file=sys.stderr)
+        print()
+        print(
+            f" Usage: python {Path(__file__).name} <LIB>\n"
+            " Example: python flower.py lifangshi\n",
+            file=sys.stderr,
+        )
+        print(
+            " NOTE: Running this script from VSCode (Ctrl+F5 / F5) will NOT\n"
+            "       work — VSCode does not pass command-line arguments by default.\n"
+            "       Either run from a terminal, configure a launch.json, or\n"
+            "       edit the PDK values in this file directly.\n",
+            file=sys.stderr,
+        )
+        print(
+            " If Virtuoso shows a blank cell after running, check that:\n"
+            "   1. <LIB> is a library that exists in your Virtuoso setup\n"
+            "   2. All *LAYER constants match your PDK techfile layers\n",
+            file=sys.stderr,
+        )
+        print("=" * 60, file=sys.stderr)
+        return 1
 
-    with client.layout.edit(LIB, CELL, mode="w") as layout:
+    lib = sys.argv[1]
+
+    client = VirtuosoClient.from_env()
+    print(f"[Flower] Creating '{CELL}' in '{lib}' ...")
+    print(f"  Layer (petals) : {[p[0] for p in PETAL_LAYERS]}")
+    print(f"  Layer (stem)   : {STEM_LAYER[0]}")
+    print(f"  Layer (label)  : {LABEL_LAYER[0]}")
+    print(f"  Font           : {FONT}")
+    print()
+
+    with client.layout.edit(lib, CELL, mode="w") as layout:
 
         # -- Petals ----------------------------------------------------------------
         for i in range(N_PETALS):
@@ -104,8 +150,9 @@ def main() -> int:
 
         layout.add(fit_view())
 
-    client.open_window(LIB, CELL, view="layout")
-    print("[Done] Flower layout created and opened.")
+    client.open_window(lib, CELL, view="layout")
+    print("[Done] Flower layout created — check the Virtuoso window.")
+    print("       If the cell is blank, verify all *LAYER constants above.")
     return 0
 
 

--- a/examples/01_virtuoso/maestro/02_gui_open_read_close_maestro.py
+++ b/examples/01_virtuoso/maestro/02_gui_open_read_close_maestro.py
@@ -1,7 +1,16 @@
 #!/usr/bin/env python3
 """Open a maestro GUI window, read config, then close the window.
 
-Edit LIB and CELL below.
+Usage::
+
+    python 02_gui_open_read_close_maestro.py <LIB>
+
+    <LIB> is required — the Virtuoso library where the Maestro setup lives.
+    Example::
+
+        python 02_gui_open_read_close_maestro.py testlib
+
+    Running this script from VSCode without passing <LIB> will NOT work.
 """
 
 import sys
@@ -12,31 +21,49 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
 from virtuoso_bridge import VirtuosoClient
 from virtuoso_bridge.virtuoso.maestro import read_config
 
-if len(sys.argv) < 2:
-    print(f"Usage: python {Path(__file__).name} <LIB>")
-    raise SystemExit(1)
-LIB  = sys.argv[1]
 CELL = "TB_AMP_5T_D2S_DC_AC"
 
 
 def main() -> int:
+    # ------------------------------------------------------------------
+    # Argument check
+    # ------------------------------------------------------------------
+    if len(sys.argv) < 2:
+        print("=" * 60, file=sys.stderr)
+        print(" ERROR: missing required argument <LIB>", file=sys.stderr)
+        print()
+        print(
+            f" Usage: python {Path(__file__).name} <LIB>\n"
+            " Example: python 02_gui_open_read_close_maestro.py lifangshi\n",
+            file=sys.stderr,
+        )
+        print(
+            " NOTE: Running this script from VSCode (Ctrl+F5 / F5) will NOT\n"
+            "       work — VSCode does not pass command-line arguments by default.\n",
+            file=sys.stderr,
+        )
+        print("=" * 60, file=sys.stderr)
+        return 1
+
+    lib = sys.argv[1]
+
     client = VirtuosoClient.from_env()
 
     # GUI open
     r = client.execute_skill(f'''
 let((before after session)
   before = maeGetSessions()
-  deOpenCellView("{LIB}" "{CELL}" "maestro" "maestro" nil "r")
+  deOpenCellView("{lib}" "{CELL}" "maestro" "maestro" nil "r")
   after = maeGetSessions()
   session = nil
   foreach(s after unless(member(s before) session = s))
-  printf("[%s MaestroOpen] %s/%s  session=%s\\n" nth(2 parseString(getCurrentTime())) "{LIB}" "{CELL}" session)
+  printf("[%s MaestroOpen] %s/%s  session=%s\\n" nth(2 parseString(getCurrentTime())) "{lib}" "{CELL}" session)
   session
 )
 ''')
     session = (r.output or "").strip('"')
     if not session or session in ("nil", "t"):
-        print(f"MaestroOpen failed for {LIB}/{CELL}")
+        print(f"MaestroOpen failed for {lib}/{CELL}")
         return 1
 
     for key, (skill_expr, raw) in read_config(client, session).items():
@@ -55,7 +82,7 @@ foreach(win hiGetWindowList()
     )
   )
 )
-printf("[%s MaestroClose] %s/%s closed\\n" nth(2 parseString(getCurrentTime())) "{LIB}" "{CELL}")
+printf("[%s MaestroClose] %s/%s closed\\n" nth(2 parseString(getCurrentTime())) "{lib}" "{CELL}")
 ''')
     return 0
 

--- a/examples/01_virtuoso/maestro/03_bg_open_read_close_maestro.py
+++ b/examples/01_virtuoso/maestro/03_bg_open_read_close_maestro.py
@@ -1,7 +1,16 @@
 #!/usr/bin/env python3
 """Open a maestro in background, read config, then close it.
 
-Edit LIB and CELL below.
+Usage::
+
+    python 03_bg_open_read_close_maestro.py <LIB>
+
+    <LIB> is required — the Virtuoso library where the Maestro setup lives.
+    Example::
+
+        python 03_bg_open_read_close_maestro.py testlib
+
+    Running this script from VSCode without passing <LIB> will NOT work.
 """
 
 import sys
@@ -12,17 +21,35 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
 from virtuoso_bridge import VirtuosoClient
 from virtuoso_bridge.virtuoso.maestro import open_session, close_session, read_config
 
-if len(sys.argv) < 2:
-    print(f"Usage: python {Path(__file__).name} <LIB>")
-    raise SystemExit(1)
-LIB  = sys.argv[1]
 CELL = "TB_AMP_5T_D2S_DC_AC"
 
 
 def main() -> int:
+    # ------------------------------------------------------------------
+    # Argument check
+    # ------------------------------------------------------------------
+    if len(sys.argv) < 2:
+        print("=" * 60, file=sys.stderr)
+        print(" ERROR: missing required argument <LIB>", file=sys.stderr)
+        print()
+        print(
+            f" Usage: python {Path(__file__).name} <LIB>\n"
+            " Example: python 03_bg_open_read_close_maestro.py lifangshi\n",
+            file=sys.stderr,
+        )
+        print(
+            " NOTE: Running this script from VSCode (Ctrl+F5 / F5) will NOT\n"
+            "       work — VSCode does not pass command-line arguments by default.\n",
+            file=sys.stderr,
+        )
+        print("=" * 60, file=sys.stderr)
+        return 1
+
+    lib = sys.argv[1]
+
     client = VirtuosoClient.from_env()
 
-    session = open_session(client, LIB, CELL)
+    session = open_session(client, lib, CELL)
 
     for key, (skill_expr, raw) in read_config(client, session).items():
         print(f"[{key}] {skill_expr}")

--- a/examples/01_virtuoso/maestro/06a_rc_create.py
+++ b/examples/01_virtuoso/maestro/06a_rc_create.py
@@ -6,6 +6,17 @@ Creates:
 - Maestro: AC analysis 1Hz–10GHz, sweep c_val = 1p,100f, BW spec > 1GHz
 
 Run this once, then use 06b to simulate and 06c to read results.
+
+Usage::
+
+    python 06a_rc_create.py <LIB>
+
+    <LIB> is required — the Virtuoso library where the schematic and Maestro
+    setup will be created.  Example::
+
+        python 06a_rc_create.py testlib
+
+    Running this script from VSCode without passing <LIB> will NOT work.
 """
 
 import sys
@@ -20,16 +31,34 @@ from virtuoso_bridge.virtuoso.maestro import (
     add_output, set_spec, set_var, save_setup,
 )
 
-if len(sys.argv) < 2:
-    print(f"Usage: python {Path(__file__).name} <LIB>")
-    raise SystemExit(1)
-LIB = sys.argv[1]
 CELL = "TB_RC_FILTER"
 
 
 def main() -> int:
+    # ------------------------------------------------------------------
+    # Argument check — this script MUST be run with a library argument.
+    # ------------------------------------------------------------------
+    if len(sys.argv) < 2:
+        print("=" * 60, file=sys.stderr)
+        print(" ERROR: missing required argument <LIB>", file=sys.stderr)
+        print()
+        print(
+            f" Usage: python {Path(__file__).name} <LIB>\n"
+            " Example: python 06a_rc_create.py lifangshi\n",
+            file=sys.stderr,
+        )
+        print(
+            " NOTE: Running this script from VSCode (Ctrl+F5 / F5) will NOT\n"
+            "       work — VSCode does not pass command-line arguments by default.\n",
+            file=sys.stderr,
+        )
+        print("=" * 60, file=sys.stderr)
+        return 1
+
+    lib = sys.argv[1]
+
     client = VirtuosoClient.from_env()
-    print(f"[info] {LIB}/{CELL}")
+    print(f"[info] {lib}/{CELL}")
 
     # --- Create schematic ---
     print("[schematic] Creating RC filter...")
@@ -38,7 +67,7 @@ def main() -> int:
         schematic_create_wire_between_instance_terms as wire,
         schematic_create_pin_at_instance_term as pin_at,
     )
-    with client.schematic.edit(LIB, CELL) as sch:
+    with client.schematic.edit(lib, CELL) as sch:
         sch.add(inst("analogLib", "vdc", "symbol", "V0", 0, 0, "R0"))
         sch.add(inst("analogLib", "gnd", "symbol", "GND0", 0, -0.625, "R0"))
         sch.add(inst("analogLib", "res", "symbol", "R0", 1.5, 0.5, "R90"))
@@ -52,25 +81,25 @@ def main() -> int:
 
     # Set CDF parameters
     cv = "_rcfCv"
-    client.execute_skill(f'{cv} = dbOpenCellViewByType("{LIB}" "{CELL}" "schematic" nil "a")')
-    for inst, param, val in [("V0", "vdc", "0"), ("V0", "acm", "1"),
+    client.execute_skill(f'{cv} = dbOpenCellViewByType("{lib}" "{CELL}" "schematic" nil "a")')
+    for inst_, param, val in [("V0", "vdc", "0"), ("V0", "acm", "1"),
                               ("R0", "r", "1k"), ("C0", "c", "c_val")]:
         client.execute_skill(
             f'cdfFindParamByName(cdfGetInstCDF('
-            f'car(setof(i {cv}~>instances i~>name == "{inst}")))'
+            f'car(setof(i {cv}~>instances i~>name == "{inst_}")))'
             f' "{param}")~>value = "{val}"')
     client.execute_skill(f"schCheck({cv})")
     client.execute_skill(f"dbSave({cv})")
     r = client.execute_skill(f"{cv}~>instances~>name")
-    print(f"[schematic] {LIB}/{CELL}/schematic")
+    print(f"[schematic] {lib}/{CELL}/schematic")
     print(f"  Instances: {r.output}")
     print(f"  V0: vdc=0, acm=1 | R0: r=1k | C0: c=c_val | Pin: OUT")
 
     # --- Create Maestro ---
     print("[maestro] Creating setup...")
-    session = open_session(client, LIB, CELL)
+    session = open_session(client, lib, CELL)
 
-    create_test(client, "AC", lib=LIB, cell=CELL, session=session)
+    create_test(client, "AC", lib=lib, cell=CELL, session=session)
     set_analysis(client, "AC", "tran", enable=False, session=session)
     set_analysis(client, "AC", "ac",
                  options='(("start" "1") ("stop" "10G") '
@@ -79,13 +108,13 @@ def main() -> int:
                  session=session)
     add_output(client, "Vout", "AC", output_type="net", signal_name="/OUT", session=session)
     add_output(client, "BW", "AC", output_type="point",
-               expr='bandwidth(mag(VF(\\"/OUT\\")) 3 \\"low\\")', session=session)
+               expr='bandwidth(mag(VF("\\"/OUT\\")) 3 \\"low\\")', session=session)
     set_spec(client, "BW", "AC", gt="1G", session=session)
     set_var(client, "c_val", "1p,100f", session=session)
 
-    save_setup(client, LIB, CELL, session=session)
+    save_setup(client, lib, CELL, session=session)
     close_session(client, session)
-    print(f"[maestro] {LIB}/{CELL}/maestro")
+    print(f"[maestro] {lib}/{CELL}/maestro")
     print(f"  Test: AC | Analysis: ac 1Hz-10GHz, 20pts/dec")
     print(f"  Outputs: Vout (net /OUT), BW (bandwidth expr)")
     print(f"  Spec: BW > 1GHz")

--- a/examples/01_virtuoso/maestro/06b_rc_simulate_and_read.py
+++ b/examples/01_virtuoso/maestro/06b_rc_simulate_and_read.py
@@ -5,6 +5,15 @@ Reuses existing Maestro GUI if open, otherwise opens fresh.
 Can be run multiple times — each run starts a new simulation.
 
 Prerequisite: run 06a_rc_create.py first.
+
+Usage::
+
+    python 06b_rc_simulate_and_read.py <LIB>
+
+    <LIB> is required — must match the library used in 06a_rc_create.py.
+    Example::
+
+        python 06b_rc_simulate_and_read.py testlib
 """
 
 import re
@@ -19,10 +28,6 @@ from virtuoso_bridge.virtuoso.maestro import (
     read_results, export_waveform, save_setup, wait_until_done,
 )
 
-if len(sys.argv) < 2:
-    print(f"Usage: python {Path(__file__).name} <LIB>")
-    raise SystemExit(1)
-LIB = sys.argv[1]
 CELL = "TB_RC_FILTER"
 
 
@@ -38,7 +43,7 @@ def parse_wave_file(path: str) -> list[tuple[float, float]]:
     return pairs
 
 
-def ensure_gui(client: VirtuosoClient) -> None:
+def ensure_gui(client: VirtuosoClient, lib: str) -> None:
     """Make sure maestro GUI is open and editable. Reuse if possible."""
     # Check for existing valid session
     r = client.execute_skill('''
@@ -50,22 +55,41 @@ let((s) s = nil
 
     if session and session != "nil":
         # Session exists — just save to keep it clean
-        save_setup(client, LIB, CELL)
+        save_setup(client, lib, CELL)
         return
 
     # No valid session — open fresh
     client.execute_skill(
-        f'deOpenCellView("{LIB}" "{CELL}" "maestro" "maestro" nil "r")')
+        f'deOpenCellView("{lib}" "{CELL}" "maestro" "maestro" nil "r")')
     client.execute_skill('maeMakeEditable()')
 
 
 def main() -> int:
+    if len(sys.argv) < 2:
+        print("=" * 60, file=sys.stderr)
+        print(" ERROR: missing required argument <LIB>", file=sys.stderr)
+        print()
+        print(
+            f" Usage: python {Path(__file__).name} <LIB>\n"
+            " Example: python 06b_rc_simulate_and_read.py lifangshi\n",
+            file=sys.stderr,
+        )
+        print(
+            " NOTE: Running this script from VSCode (Ctrl+F5 / F5) will NOT\n"
+            "       work — VSCode does not pass command-line arguments by default.\n",
+            file=sys.stderr,
+        )
+        print("=" * 60, file=sys.stderr)
+        return 1
+
+    lib = sys.argv[1]
+
     client = VirtuosoClient.from_env()
-    print(f"[info] {LIB}/{CELL}")
+    print(f"[info] {lib}/{CELL}")
     t_total = time.time()
 
     # 1. Ensure GUI is open
-    ensure_gui(client)
+    ensure_gui(client, lib)
     print("[gui] Ready")
 
     # 2. Run simulation
@@ -79,7 +103,7 @@ def main() -> int:
         # Force close everything and retry
         client.execute_skill(f'''
 foreach(s maeGetSessions()
-  errset(maeSaveSetup(?lib "{LIB}" ?cell "{CELL}" ?view "maestro" ?session s))
+  errset(maeSaveSetup(?lib "{lib}" ?cell "{CELL}" ?view "maestro" ?session s))
   errset(maeCloseSession(?session s ?forceClose t)))
 foreach(win hiGetWindowList()
   let((n) n = hiGetWindowName(win)
@@ -90,7 +114,7 @@ t
 ''')
         time.sleep(1)
         client.execute_skill(
-            f'deOpenCellView("{LIB}" "{CELL}" "maestro" "maestro" nil "r")')
+            f'deOpenCellView("{lib}" "{CELL}" "maestro" "maestro" nil "r")')
         client.execute_skill('maeMakeEditable()')
         r = client.execute_skill('maeRunSimulation()')
         run_name = (r.output or "").strip('"')
@@ -114,7 +138,7 @@ let((s) s = nil
     session = (r.output or "").strip('"')
 
     print("\n=== Results ===")
-    results = read_results(client, session, lib=LIB, cell=CELL)
+    results = read_results(client, session, lib=lib, cell=CELL)
     if results:
         for key, (expr, raw) in results.items():
             print(f"[{key}] {expr}")
@@ -159,7 +183,7 @@ let((s) s = nil
 
         # 6. Restore latest history in GUI + save
         client.execute_skill(f'maeRestoreHistory("{history}")')
-        save_setup(client, LIB, CELL)
+        save_setup(client, lib, CELL)
         print(f"\n[gui] Showing {history}")
 
     print(f"[total] {time.time() - t_total:.1f}s")

--- a/examples/01_virtuoso/schematic/01a_create_rc_stepwise.py
+++ b/examples/01_virtuoso/schematic/01a_create_rc_stepwise.py
@@ -7,6 +7,11 @@ Usage::
 
     python 01a_create_rc_stepwise.py <LIB>
 
+    <LIB> is required — the Virtuoso library where the schematic will be created.
+
+    Example::
+    python 01a_create_rc_stepwise.py testlib
+
 Prerequisites:
   - virtuoso-bridge service running (virtuoso-bridge start)
   - analogLib cell masters (vdc, res, cap) available in your Virtuoso install
@@ -29,9 +34,26 @@ from virtuoso_bridge.virtuoso.schematic.ops import (
 
 
 def main() -> int:
+    # ------------------------------------------------------------------
+    # Argument check
+    # ------------------------------------------------------------------
     if len(sys.argv) < 2:
-        print(f"Usage: python {Path(__file__).name} <LIB>")
+        print("=" * 60, file=sys.stderr)
+        print(" ERROR: missing required argument <LIB>", file=sys.stderr)
+        print()
+        print(
+            f" Usage: python {Path(__file__).name} <LIB>\n"
+            " Example: python 01a_create_rc_stepwise.py lifangshi\n",
+            file=sys.stderr,
+        )
+        print(
+            " NOTE: Running this script from VSCode (Ctrl+F5 / F5) will NOT\n"
+            "       work — VSCode does not pass command-line arguments by default.\n",
+            file=sys.stderr,
+        )
+        print("=" * 60, file=sys.stderr)
         return 1
+
     lib = sys.argv[1]
     cell = f"rc_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
     client = VirtuosoClient.from_env()

--- a/examples/01_virtuoso/schematic/01a_create_rc_stepwise.py
+++ b/examples/01_virtuoso/schematic/01a_create_rc_stepwise.py
@@ -9,6 +9,7 @@ Usage::
 
 Prerequisites:
   - virtuoso-bridge service running (virtuoso-bridge start)
+  - analogLib cell masters (vdc, res, cap) available in your Virtuoso install
 """
 
 from __future__ import annotations

--- a/examples/01_virtuoso/schematic/01b_create_rc_load_skill.py
+++ b/examples/01_virtuoso/schematic/01b_create_rc_load_skill.py
@@ -11,6 +11,7 @@ Usage::
 
 Prerequisites:
   - virtuoso-bridge service running (virtuoso-bridge start)
+  - analogLib cell masters (vdc, res, cap) available in your Virtuoso install
 """
 
 from __future__ import annotations

--- a/examples/01_virtuoso/schematic/01b_create_rc_load_skill.py
+++ b/examples/01_virtuoso/schematic/01b_create_rc_load_skill.py
@@ -9,6 +9,11 @@ Usage::
 
     python 01b_create_rc_load_skill.py <LIB>
 
+    <LIB> is required — the Virtuoso library where the schematic will be created.  
+
+    Example:: 
+    python 01b_create_rc_load_skill.py testlib
+
 Prerequisites:
   - virtuoso-bridge service running (virtuoso-bridge start)
   - analogLib cell masters (vdc, res, cap) available in your Virtuoso install
@@ -31,9 +36,26 @@ from virtuoso_bridge.virtuoso.schematic.ops import (
 
 
 def main() -> int:
+    # ------------------------------------------------------------------
+    # Argument check
+    # ------------------------------------------------------------------
     if len(sys.argv) < 2:
-        print(f"Usage: python {Path(__file__).name} <LIB>")
+        print("=" * 60, file=sys.stderr)
+        print(" ERROR: missing required argument <LIB>", file=sys.stderr)
+        print()
+        print(
+            f" Usage: python {Path(__file__).name} <LIB>\n"
+            " Example: python 01b_create_rc_load_skill.py lifangshi\n",
+            file=sys.stderr,
+        )
+        print(
+            " NOTE: Running this script from VSCode (Ctrl+F5 / F5) will NOT\n"
+            "       work — VSCode does not pass command-line arguments by default.\n",
+            file=sys.stderr,
+        )
+        print("=" * 60, file=sys.stderr)
         return 1
+
     lib = sys.argv[1]
     cell = f"tmp_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
     client = VirtuosoClient.from_env()

--- a/examples/01_virtuoso/schematic/05_rename_instance.py
+++ b/examples/01_virtuoso/schematic/05_rename_instance.py
@@ -4,6 +4,8 @@
 Prerequisites:
   - virtuoso-bridge service running (virtuoso-bridge start)
   - A schematic open in Virtuoso (e.g. created by 01a_create_rc_stepwise.py)
+
+Customize RENAMES below to specify which instances to rename and their new names.
 """
 
 from __future__ import annotations
@@ -16,13 +18,17 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 from _timing import format_elapsed, timed_call
 from virtuoso_bridge import VirtuosoClient
 
+# ----------------------------------------------------------------------
+# Customize: list of (old_name, new_name) pairs to rename
+# ----------------------------------------------------------------------
+RENAMES = [("I0", "IAAA_RENAMED"), ("R0", "RBBB_RENAMED")]
+# ----------------------------------------------------------------------
+
 
 def main() -> int:
     client = VirtuosoClient.from_env()
 
-    renames = [("I0", "IAAA_RENAMED"), ("R0", "RBBB_RENAMED")]
-
-    for old, new in renames:
+    for old, new in RENAMES:
         r = client.execute_skill(f'''
 let((cv inst)
   cv = geGetEditCellView()

--- a/examples/01_virtuoso/schematic/08_import_cdl_cap_array.py
+++ b/examples/01_virtuoso/schematic/08_import_cdl_cap_array.py
@@ -8,6 +8,15 @@ Circuit:
     cap_unit:     single 10fF capacitor (TOP, BOT)
     cap_array_4b: 15 unit caps, weights [1,2,4,8], pins TOP + BOT<3:0>
 
+Usage::
+
+    python 08_import_cdl_cap_array.py <LIB>
+
+    <LIB> is required — the Virtuoso library where the schematic will be created.
+
+    Example::
+    python 08_import_cdl_cap_array.py testlib
+
 Prerequisites:
 - virtuoso-bridge tunnel running
 - spiceIn on remote (auto-detected from Cadence install)
@@ -32,11 +41,6 @@ from virtuoso_bridge.transport.remote_paths import (
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
-
-if len(sys.argv) < 2:
-    print(f"Usage: python {Path(__file__).name} <LIB>")
-    raise SystemExit(1)
-LIB = sys.argv[1]
 
 CDL = """\
 .SUBCKT cap_unit TOP BOT
@@ -90,6 +94,28 @@ def _ssh_cmd(client: VirtuosoClient) -> list[str]:
 # ---------------------------------------------------------------------------
 
 def main() -> int:
+    # ------------------------------------------------------------------
+    # Argument check
+    # ------------------------------------------------------------------
+    if len(sys.argv) < 2:
+        print("=" * 60, file=sys.stderr)
+        print(" ERROR: missing required argument <LIB>", file=sys.stderr)
+        print()
+        print(
+            f" Usage: python {Path(__file__).name} <LIB>\n"
+            " Example: python 08_import_cdl_cap_array.py lifangshi\n",
+            file=sys.stderr,
+        )
+        print(
+            " NOTE: Running this script from VSCode (Ctrl+F5 / F5) will NOT\n"
+            "       work — VSCode does not pass command-line arguments by default.\n",
+            file=sys.stderr,
+        )
+        print("=" * 60, file=sys.stderr)
+        return 1
+
+    lib = sys.argv[1]
+
     client = VirtuosoClient.from_env()
 
     # Discover paths from running Virtuoso
@@ -104,7 +130,7 @@ def main() -> int:
     cds_inst = r.output.strip('"')
     spicein = f"{cds_inst}/bin/spiceIn"
 
-    r = client.execute_skill(f'ddGetObj("{LIB}")~>writePath')
+    r = client.execute_skill(f'ddGetObj("{lib}")~>writePath')
     work_dir = str(Path(r.output.strip('"')).parent)
 
     username = resolve_remote_username(
@@ -133,7 +159,7 @@ export PATH=$CDS_INST_DIR/bin:$CDS_INST_DIR/tools/bin:$PATH
 export LD_LIBRARY_PATH="{env.get('LD_LIBRARY_PATH', '')}"
 cd {work_dir}
 {spicein} -language SPICE -netlistFile {cdl_path} \\
-  -outputLib {LIB} -reflibList "analogLib basic" \\
+  -outputLib {lib} -reflibList "analogLib basic" \\
   -devmapFile {devmap_path}
 """
     script_path = f"{remote_tmp}/run.sh"
@@ -153,14 +179,14 @@ cd {work_dir}
 
     # 3. Generate symbol for cap_unit
     client.execute_skill("ddUpdateLibList()")
-    client.execute_skill(f'schPinListToSymbol("{LIB}" "cap_unit" "symbol" schSchemToPinList("{LIB}" "cap_unit" "schematic"))')
-    r = client.execute_skill(f'ddGetObj("{LIB}" "cap_unit")~>views~>name')
+    client.execute_skill(f'schPinListToSymbol("{lib}" "cap_unit" "symbol" schSchemToPinList("{lib}" "cap_unit" "schematic"))')
+    r = client.execute_skill(f'ddGetObj("{lib}" "cap_unit")~>views~>name')
     print(f"[symbol] cap_unit: {r.output}")
 
     # 4. Open
-    r = client.execute_skill(f'ddGetObj("{LIB}" "cap_array_4b")~>views~>name')
+    r = client.execute_skill(f'ddGetObj("{lib}" "cap_array_4b")~>views~>name')
     print(f"[verify] cap_array_4b: {r.output}")
-    client.open_window(LIB, "cap_array_4b", view="schematic")
+    client.open_window(lib, "cap_array_4b", view="schematic")
     print("[done] Opened cap_array_4b")
 
     return 0


### PR DESCRIPTION
## Summary

- **01_create_layout.py**: Extract `PDK_LIB`, `LAYER_*`, and `FONT` into
  named constants at the top of the file. Add a docstring with usage,
  prerequisites, and inline comments explaining each value. Change the
  "default" font to "roman" which is universally recognised by Virtuoso.
- **02_add_polygon.py**: Add a docstring and prerequisite note. Update
  `LAYER` to a real PDK layer name (`edgeLayer`).

## Root cause

These examples silently failed on first run because `M1`/`M2` layer names
and the `"default"` font are not defined in all PDK setups. Users had
no indication what to change or why nothing appeared in Virtuoso.

## Changes

- PDK layer names are now configurable constants with a comment block
  listing common examples (M1, Metal1, poly, etc.)
- The "default" font is replaced with "roman", the safest cross-PDK
  choice
- `01_create_layout.py` docstring now includes full usage instructions

## Test plan

- [ ] Run `01_create_layout.py lifangshi` with a valid PDK library
- [ ] Verify layer names (`LAYER_RECT`, `LAYER_PATH`, `LAYER_LABEL`) match
  your PDK techfile before running
- [ ] Run `02_add_polygon.py` on an open layout
- [ ] Confirm shapes and instances appear in Virtuoso
