### PR TITLE
feat(maestro): variables now keep globals/per-test scope, decode sweeps

### DIFF
--- a/src/virtuoso_bridge/virtuoso/maestro/reader/_parse_sdb.py
+++ b/src/virtuoso_bridge/virtuoso/maestro/reader/_parse_sdb.py
@@ -100,49 +100,117 @@ def parse_parameters_from_sdb_xml(xml_text: str) -> list[dict]:
     return result
 
 
-def parse_variables_from_sdb_xml(xml_text: str) -> dict[str, str]:
-    """Extract variables from a ``maestro.sdb`` XML payload.
+# Cadence sweep encoding.  A plain scalar is just the literal; a sweep
+# shows up as one of:
+#   "start:step:stop"        -> range sweep
+#   "(v1 v2 v3 ...)"         -> enumerated list
+_RANGE_SWEEP_RE = re.compile(
+    r"^\s*(-?[0-9.eE+]+)\s*:\s*(-?[0-9.eE+]+)\s*:\s*(-?[0-9.eE+]+)\s*$"
+)
+_LIST_SWEEP_RE = re.compile(r"^\s*\((.+)\)\s*$")
 
-    Returns a flat ``name -> value`` dict.  Merges:
 
-      - ``<active><vars>`` (global, typical for ADE Assembler)
-      - ``<active><tests><test><tooloptions><vars>`` (per-test, typical
-        for ADE Explorer which has exactly one test per cellview)
+def _classify_var_value(text: str, enabled: bool) -> dict:
+    """Tag a raw ``<value>`` string as scalar / range-sweep / list-sweep.
 
-    Globals take precedence on name collisions.  This mirrors the flat
-    view the user sees in the Variables panel.
+    Keeps the original text verbatim under ``"raw"`` and records the
+    ``enabled`` flag from the ``<var enabled="...">`` attribute (defaults
+    to True when the attr is absent — that's Maestro's behavior).
+    Returns::
 
-    Pure function — does no I/O.  Returns ``{}`` on parse error.
+        {"raw": "<original>",
+         "enabled": True|False,
+         "kind": "scalar" | "range_sweep" | "list_sweep",
+         # range_sweep only: start / step / stop / points_count
+         # list_sweep  only: values
+        }
     """
+    raw = (text or "").strip()
+    out: dict = {"raw": raw, "enabled": enabled, "kind": "scalar"}
+    if not raw:
+        return out
+    m = _RANGE_SWEEP_RE.match(raw)
+    if m:
+        try:
+            start, step, stop = float(m.group(1)), float(m.group(2)), float(m.group(3))
+        except ValueError:
+            return out
+        if step <= 0:
+            return out
+        count = int(round((stop - start) / step)) + 1 if stop >= start else 0
+        out.update(kind="range_sweep", start=m.group(1), step=m.group(2),
+                   stop=m.group(3), points_count=count)
+        return out
+    m = _LIST_SWEEP_RE.match(raw)
+    if m:
+        parts = [p for p in re.split(r"[\s,]+", m.group(1).strip()) if p]
+        if parts:
+            out.update(kind="list_sweep", values=parts)
+            return out
+    return out
+
+
+def _var_enabled(v) -> bool:
+    """Read the ``enabled`` attribute — defaults to True when absent."""
+    attr = v.get("enabled")
+    if attr is None:
+        return True
+    return attr != "0"
+
+
+def parse_variables_from_sdb_xml(xml_text: str) -> dict:
+    """Extract variables from a ``maestro.sdb`` XML payload, keeping the
+    per-test vs. global scope separation the Maestro GUI exposes.
+
+    Returns::
+
+        {"globals":  {var_name: value_info, ...},
+         "per_test": {test_name: {var_name: value_info, ...}, ...}}
+
+    Each ``value_info`` is the dict produced by :func:`_classify_var_value`
+    — always carries the original ``raw`` text plus a ``kind`` tag
+    (``scalar`` / ``range_sweep`` / ``list_sweep``) and, for sweeps, the
+    parsed fields.
+
+    Pure function — does no I/O.  Returns ``{"globals": {}, "per_test":
+    {}}`` on parse error.
+    """
+    empty: dict = {"globals": {}, "per_test": {}}
     try:
         root = ET.fromstring(xml_text)
     except ET.ParseError:
-        return {}
+        return empty
 
-    result: dict[str, str] = {}
+    globals_out: dict[str, dict] = {}
+    per_test_out: dict[str, dict[str, dict]] = {}
+
     for active in root.findall("active"):
-        # Per-test vars first; globals overwrite below.
-        # <vars> is a direct child of <test> (sibling of <tooloptions>).
+        # Per-test vars — <vars> is a direct child of <test> (sibling of
+        # <tooloptions>).  Typical for ADE Explorer (one test per cellview).
         tests_elem = active.find("tests")
         if tests_elem is not None:
             for test in tests_elem.findall("test"):
+                test_name = (test.text or "").strip()
                 vars_e = test.find("vars")
-                if vars_e is None:
+                if vars_e is None or not test_name:
                     continue
+                scope = per_test_out.setdefault(test_name, {})
                 for v in vars_e.findall("var"):
                     name = (v.text or "").strip()
-                    if name and name not in result:
-                        result[name] = v.findtext("value", "").strip()
+                    if name:
+                        scope[name] = _classify_var_value(
+                            v.findtext("value", ""), _var_enabled(v))
 
-        # Global vars under <active> directly
+        # Global vars — <vars> directly under <active>.  Typical for ADE Assembler.
         vars_elem = active.find("vars")
         if vars_elem is not None:
             for v in vars_elem.findall("var"):
                 name = (v.text or "").strip()
                 if name:
-                    result[name] = v.findtext("value", "").strip()
+                    globals_out[name] = _classify_var_value(
+                        v.findtext("value", ""), _var_enabled(v))
 
-    return result
+    return {"globals": globals_out, "per_test": per_test_out}
 
 
 def parse_tests_from_sdb_xml(xml_text: str) -> set[str]:

--- a/src/virtuoso_bridge/virtuoso/maestro/reader/probes.py
+++ b/src/virtuoso_bridge/virtuoso/maestro/reader/probes.py
@@ -161,29 +161,49 @@ def read_env(client: VirtuosoClient, session: str) -> dict:
 def read_variables(client: VirtuosoClient, session: str, *,
                    sdb_path: str | None = None,
                    local_sdb_path: str | None = None,
-                   reuse_local: bool = False) -> dict[str, str]:
-    """Read design variables with values.
+                   reuse_local: bool = False) -> dict:
+    """Read design variables with values, split by scope.
 
-    Prefers parsing ``maestro.sdb`` XML (works for both ADE Assembler and
+    Returns::
+
+        {"globals":  {var_name: value_info, ...},
+         "per_test": {test_name: {var_name: value_info, ...}, ...}}
+
+    Each ``value_info`` is a dict carrying the raw ``<value>`` text plus a
+    ``kind`` tag (``scalar`` / ``range_sweep`` / ``list_sweep``) and — for
+    sweeps — the parsed ``start``/``step``/``stop``/``points_count`` or
+    ``values`` fields.
+
+    Prefers parsing ``maestro.sdb`` XML (works for ADE Assembler and
     Explorer, no dependence on ``asiGetCurrentSession``'s shifting state).
-    Falls back to ``asiGetDesignVarList`` only if the sdb path is unknown.
+    Falls back to ``asiGetDesignVarList`` only when ``sdb_path`` is
+    unknown; that fallback yields ``globals`` only (the per-test split is
+    not reachable from SKILL).
     """
+    empty: dict = {"globals": {}, "per_test": {}}
     if sdb_path:
-        vars_ = parse_variables_from_sdb_xml(
+        parsed = parse_variables_from_sdb_xml(
             _read_sdb_xml(client, sdb_path,
                           local_path=local_sdb_path, reuse=reuse_local))
-        if vars_:
-            return vars_
+        if parsed.get("globals") or parsed.get("per_test"):
+            return parsed
 
     # Fallback: ask asi* (may return wrong session's vars when the ADE
     # current session differs from the maestro session we want).
     r = client.execute_skill('asiGetDesignVarList(asiGetCurrentSession())')
     pairs = _parse_pair_alist(r.output or "")
     if pairs:
-        return dict(pairs)
+        return {"globals": {k: {"raw": v, "enabled": True, "kind": "scalar"}
+                            for k, v in pairs},
+                "per_test": {}}
     r = client.execute_skill(
         f'maeGetSetup(?session "{session}" ?typeName "variables")')
-    return dict(_parse_pair_alist(r.output or ""))
+    pairs = _parse_pair_alist(r.output or "")
+    if not pairs:
+        return empty
+    return {"globals": {k: {"raw": v, "enabled": True, "kind": "scalar"}
+                        for k, v in pairs},
+            "per_test": {}}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

Maestro exposes variables in **two scopes** — per-test and global — and the GUI shows both separately in Data View.  `parse_variables_from_sdb_xml` was flattening to `{name: value}` with a "globals win on collision" rule, which silently:

1. Dropped per-test values when a same-named global exists.
2. Threw away the `<var enabled="...">` attribute (so the GUI's checkbox state was invisible).
3. Returned Cadence sweep syntax (`start:step:stop` / `(v1 v2 v3)`) as an opaque string — downstream had no way to know `VDC="1.2:0.1:2.5"` was a 14-point range sweep.

Concrete example that surfaced this (ADE Explorer `_EXP_CAP`):
- per-test `VDC = 1`
- global `VDC = 1.2:0.1:2.5`  (range sweep, 14 points)
- disabled global `CONFIG/SAR_11B_ZZS/L5_CAP_ARRAY = "calibre_new schematic"`

All three needed representation.

## What changed

### `parse_variables_from_sdb_xml` return shape

```python
{
  "globals":  {name: value_info, ...},
  "per_test": {test_name: {name: value_info, ...}, ...},
}
```

Each `value_info`:
- `raw`     — the original `<value>` text (lossless)
- `enabled` — from the `<var enabled="...">` attribute (default `True` when absent)
- `kind`    — `"scalar"` / `"range_sweep"` / `"list_sweep"`
- range_sweep adds: `start`, `step`, `stop`, `points_count`
- list_sweep  adds: `values`

### `read_variables()` follows suit

Same shape.  The SKILL fallback (when no `sdb_path`) only returns `globals` — per-test scope isn't reachable through `asiGetDesignVarList`.

### `snap["variables"]` shape

Reflects the new shape directly — no flattening anywhere in the pipeline.

## Breaking changes

- `snap["variables"]` was `dict[str, str]`; now `{"globals": {...}, "per_test": {...}}` with nested `value_info` dicts.
- `read_variables()` return type changed to match.
- `parse_variables_from_sdb_xml` return type changed to match.

No gradual deprecation — the old shape hid real bugs, and there are no external callers beyond the examples in this repo (all updated).

## Test plan

- [x] Parser classifies `1.2:0.1:2.5` -> `range_sweep(start=1.2, step=0.1, stop=2.5, points_count=14)`
- [x] Parser classifies space-separated strings like `"calibre_new schematic"` as scalar (not as a list sweep — Cadence list sweeps require parens)
- [x] `enabled="0"` attribute carries through as `enabled: false`
- [x] Same-named var in per-test + global scopes is preserved in both (no overwrite)
- [x] End-to-end `snapshot()` returns the new shape matching the live Maestro GUI Data View state

🤖 Generated with [Claude Code](https://claude.com/claude-code)