### PR TITLE
fix(ssh): raise precheck connect_timeout to 30s, support VB_SSH_CONFIG

### DIFF
--- a/src/virtuoso_bridge/cli.py
+++ b/src/virtuoso_bridge/cli.py
@@ -78,7 +78,7 @@ def _ssh_precheck(profile: str | None = None) -> int | None:
         runner = SSHRunner(
             host=ssh_env.remote_host, user=ssh_env.remote_user,
             jump_host=ssh_env.jump_host, jump_user=jump_user,
-            connect_timeout=5, persistent_shell=False,
+            connect_timeout=30, persistent_shell=False,
         )
         if not runner.test_connection():
             print(f"SSH to {ssh_env.remote_host} failed.")

--- a/src/virtuoso_bridge/transport/ssh.py
+++ b/src/virtuoso_bridge/transport/ssh.py
@@ -175,7 +175,8 @@ class SSHRunner:
         self._jump_host = jump_host
         self._jump_user = jump_user or user
         self._ssh_key_path = ssh_key_path
-        self._ssh_config_path = ssh_config_path
+        env_ssh_config = _tool_override_from_env("VB_SSH_CONFIG")
+        self._ssh_config_path = Path(env_ssh_config) if env_ssh_config else ssh_config_path
         self._timeout = timeout
         self._connect_timeout = connect_timeout
         self._persistent_shell_enabled = persistent_shell and os.name != "nt"


### PR DESCRIPTION
The 5-second connect_timeout in _ssh_precheck is too aggressive for connections that traverse a jump host — the SSH handshake through the proxy adds several round-trips that easily exceed 5 s on high-latency paths.

Also wire up the VB_SSH_CONFIG environment variable so that users with non-ASCII home directories (e.g. CJK usernames on Windows) can explicitly point SSH at their config file via `VB_SSH_CONFIG=~/.ssh/config`.