### PR TITLE
fix(ssh): use login shell and auto-disable ControlMaster on Windows

### DIFF
--- a/src/virtuoso_bridge/transport/ssh.py
+++ b/src/virtuoso_bridge/transport/ssh.py
@@ -194,7 +194,12 @@ class SSHRunner:
         # to opt out if a specific platform trips mux errors.
         _disable_cm = os.environ.get("VB_DISABLE_CONTROL_MASTER", "").strip().lower() in ("1", "true", "yes")
         _force_cm = os.environ.get("VB_FORCE_CONTROL_MASTER", "").strip().lower() in ("1", "true", "yes")
-        self._use_control_master = _force_cm or (not _disable_cm)
+        # Windows OpenSSH does not support ControlMaster — auto-disable unless
+        # the user explicitly forces it (e.g. MSYS2/Git-for-Windows SSH).
+        if os.name == "nt" and not _force_cm:
+            self._use_control_master = False
+        else:
+            self._use_control_master = _force_cm or (not _disable_cm)
 
         _user_part = user or "default"
         _tmp = tempfile.gettempdir()
@@ -531,11 +536,13 @@ class SSHRunner:
 
     def _run_command_once(self, command: str, timeout: int | None = None) -> CommandResult:
         effective_timeout = timeout or self._timeout
-        # Pipe the command to `ssh host sh` via stdin so it always runs in sh
-        # regardless of the remote user's login shell (which may be csh).
+        # Pipe the command to `ssh host sh -l` via stdin so it always runs in
+        # a POSIX login shell regardless of the remote user's login shell
+        # (which may be csh).  Using -l (login) sources /etc/profile and
+        # ~/.profile, making tools like python3 visible via PATH.
         # Passing the command as an SSH argument would have the login shell
         # interpret it, breaking sh syntax (&&, ${VAR:-}, etc.) if login=csh.
-        cmd = self._build_ssh_base() + ["sh"]
+        cmd = self._build_ssh_base() + ["sh", "-l"]
         self._print_cmd(cmd)
         logger.info("[server] %s", command)
         # Use bytes (text=False) to bypass Windows universal-newlines translation
@@ -869,7 +876,7 @@ class SSHRunner:
                 return
 
             self._close_persistent_shell_locked()
-            cmd = self._build_ssh_base() + ["sh", "-s"]
+            cmd = self._build_ssh_base() + ["sh", "-l", "-s"]
             logger.info("Starting persistent SSH shell: %s", " ".join(cmd))
             self._print_cmd(cmd)
             proc = subprocess.Popen(


### PR DESCRIPTION
Remote commands were run via `ssh host sh` which starts a non-login, non-interactive shell.  This meant ~/.profile and /etc/profile were never sourced, so $PATH, $CDSHOME and other environment variables were missing. Python detection on the remote host would then return empty output and fail with "No Python interpreter found".

Fix: use `sh -l` (login shell) so /etc/profile and ~/.profile are sourced, making tools like python3 discoverable via PATH.  Also applied to the persistent shell (`sh -l -s`).

Additionally, ControlMaster was not actually auto-disabled on Windows despite the .env comment claiming so.  Windows OpenSSH does not support ControlMaster, and the non-ASCII ControlPath (e.g. C:\Users\华为\...) causes silent failures.  Now disabled by default on Windows unless VB_FORCE_CONTROL_MASTER=true is set.