### PR TITLE
fix(examples): add view-type guard and pre-flight checks to layout examples

### DIFF
--- a/examples/01_virtuoso/layout/01_create_layout.py
+++ b/examples/01_virtuoso/layout/01_create_layout.py
@@ -89,7 +89,7 @@ def main() -> int:
             file=sys.stderr,
         )
         print("=" * 60, file=sys.stderr)
-        raise SystemExit(1)
+        return 1
 
     lib_name = sys.argv[1]
     cell_name = f"layout_demo_{datetime.now().strftime('%Y%m%d_%H%M%S')}"

--- a/examples/01_virtuoso/layout/02_add_polygon.py
+++ b/examples/01_virtuoso/layout/02_add_polygon.py
@@ -37,9 +37,9 @@ def main() -> int:
 
     elapsed, design = timed_call(client.get_current_design)
     print(f"[get_current_design] [{format_elapsed(elapsed)}]")
-    lib, cell, _ = design
-    if not lib or not cell:
-        print("Open a layout in Virtuoso first.")
+    lib, cell, view = design
+    if not lib or not cell or view != "layout":
+        print("Open a layout cellview in Virtuoso first.")
         return 1
 
     print(f"Target Library  : {lib}")

--- a/examples/01_virtuoso/layout/03_add_via.py
+++ b/examples/01_virtuoso/layout/03_add_via.py
@@ -44,9 +44,9 @@ def main() -> int:
 
     elapsed, design = timed_call(client.get_current_design)
     print(f"[get_current_design] [{format_elapsed(elapsed)}]")
-    lib, cell, _ = design
-    if not lib or not cell:
-        print("Open a layout in Virtuoso first.")
+    lib, cell, view = design
+    if not lib or not cell or view != "layout":
+        print("Open a layout cellview in Virtuoso first.")
         return 1
 
     print(f"Target Library  : {lib}")

--- a/examples/01_virtuoso/layout/04_multilayer_routing.py
+++ b/examples/01_virtuoso/layout/04_multilayer_routing.py
@@ -40,9 +40,9 @@ def main() -> int:
 
     elapsed, design = timed_call(client.get_current_design)
     print(f"[get_current_design] [{format_elapsed(elapsed)}]")
-    lib, cell, _ = design
-    if not lib or not cell:
-        print("Open a layout in Virtuoso first.")
+    lib, cell, view = design
+    if not lib or not cell or view != "layout":
+        print("Open a layout cellview in Virtuoso first.")
         return 1
 
     print(f"Target Library  : {lib}")

--- a/examples/01_virtuoso/layout/05_bus_routing.py
+++ b/examples/01_virtuoso/layout/05_bus_routing.py
@@ -56,9 +56,9 @@ def main() -> int:
 
     elapsed, design = timed_call(client.get_current_design)
     print(f"[get_current_design] [{format_elapsed(elapsed)}]")
-    lib, cell, _ = design
-    if not lib or not cell:
-        print("No layout window open in Virtuoso.")
+    lib, cell, view = design
+    if not lib or not cell or view != "layout":
+        print("Open a layout cellview in Virtuoso first.")
         return 1
 
     print(f"Target Library  : {lib}")

--- a/examples/01_virtuoso/layout/06_read_layout.py
+++ b/examples/01_virtuoso/layout/06_read_layout.py
@@ -33,9 +33,9 @@ def main() -> int:
 
     elapsed, design = timed_call(client.get_current_design)
     print(f"[get_current_design] [{format_elapsed(elapsed)}]")
-    lib, cell, _ = design
-    if not lib or not cell:
-        print("Open a layout in Virtuoso first.")
+    lib, cell, view = design
+    if not lib or not cell or view != "layout":
+        print("Open a layout cellview in Virtuoso first.")
         return 1
 
     read_elapsed, result = timed_call(

--- a/examples/01_virtuoso/layout/08_clear_routing.py
+++ b/examples/01_virtuoso/layout/08_clear_routing.py
@@ -16,6 +16,13 @@ from virtuoso_bridge.virtuoso.layout.ops import layout_clear_routing
 def main() -> int:
     client = VirtuosoClient.from_env()
 
+    elapsed, design = timed_call(client.get_current_design)
+    print(f"[get_current_design] [{format_elapsed(elapsed)}]")
+    lib, cell, view = design
+    if not lib or not cell or view != "layout":
+        print("Open a layout cellview in Virtuoso first.")
+        return 1
+
     elapsed, result = timed_call(
         lambda: client.execute_skill(layout_clear_routing(), timeout=30)
     )

--- a/examples/01_virtuoso/layout/09_clear_current_layout.py
+++ b/examples/01_virtuoso/layout/09_clear_current_layout.py
@@ -16,6 +16,13 @@ from virtuoso_bridge.virtuoso.layout import clear_current_layout
 def main() -> int:
     client = VirtuosoClient.from_env()
 
+    elapsed, design = timed_call(client.get_current_design)
+    print(f"[get_current_design] [{format_elapsed(elapsed)}]")
+    lib, cell, view = design
+    if not lib or not cell or view != "layout":
+        print("Open a layout cellview in Virtuoso first.")
+        return 1
+
     elapsed, result = timed_call(
         lambda: client.execute_skill(clear_current_layout(), timeout=30)
     )

--- a/examples/01_virtuoso/layout/11_read_summary.py
+++ b/examples/01_virtuoso/layout/11_read_summary.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Read a lightweight summary of shapes and instances from the current layout cell.
+
+Prerequisites:
+  - virtuoso-bridge service running (virtuoso-bridge start)
+  - A layout cellview must be open in Virtuoso
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from _timing import decode_skill, format_elapsed, timed_call
+from virtuoso_bridge import VirtuosoClient
+from virtuoso_bridge.virtuoso.layout.ops import layout_read_summary
+
+
+def main() -> int:
+    client = VirtuosoClient.from_env()
+
+    elapsed, design = timed_call(client.get_current_design)
+    print(f"[get_current_design] [{format_elapsed(elapsed)}]")
+    lib, cell, view = design
+    if not lib or not cell or view != "layout":
+        print("Open a layout cellview in Virtuoso first.")
+        return 1
+
+    read_elapsed, result = timed_call(
+        lambda: client.execute_skill(layout_read_summary(lib, cell), timeout=30)
+    )
+    print(f"[layout_read_summary] [{format_elapsed(read_elapsed)}]")
+
+    output = decode_skill(result.output or "")
+    if output.startswith("ERROR"):
+        print(output)
+        return 1
+
+    print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/01_virtuoso/layout/12_layer_visibility.py
+++ b/examples/01_virtuoso/layout/12_layer_visibility.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Control layer visibility in the current layout window.
+
+Demonstrates three layer-visibility APIs in sequence:
+  1. hide_layers   — hide specific layer-purpose pairs
+  2. show_layers   — restore visibility of hidden layers
+  3. show_only_layers — hide everything, then show only requested layers
+
+Each step pauses briefly so you can observe the change in Virtuoso.
+
+Prerequisites:
+  - virtuoso-bridge service running (virtuoso-bridge start)
+  - A layout cellview must be open in Virtuoso
+
+Customize LAYERS below to match your PDK techfile.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from _timing import decode_skill, format_elapsed, timed_call
+from virtuoso_bridge import VirtuosoClient
+from virtuoso_bridge.virtuoso.layout.ops import (
+    layout_fit_view,
+    layout_hide_layers,
+    layout_show_layers,
+    layout_show_only_layers,
+)
+
+# ----------------------------------------------------------------------
+# Customize to match your PDK metal stack
+# ----------------------------------------------------------------------
+# Layer-purpose pairs to toggle. All must be defined in your PDK techfile.
+LAYERS = [
+    ("M3", "drawing"),
+    ("M4", "drawing"),
+]
+# ----------------------------------------------------------------------
+
+
+def main() -> int:
+    client = VirtuosoClient.from_env()
+
+    elapsed, design = timed_call(client.get_current_design)
+    print(f"[get_current_design] [{format_elapsed(elapsed)}]")
+    lib, cell, view = design
+    if not lib or not cell or view != "layout":
+        print("Open a layout cellview in Virtuoso first.")
+        return 1
+
+    layer_names = ", ".join(f"{l}/{p}" for l, p in LAYERS)
+    print(f"Target Library  : {lib}")
+    print(f"Target Cell     : {cell}")
+    print(f"Layers          : {layer_names}")
+    print()
+
+    # Step 1: hide
+    hide_elapsed, hide_result = timed_call(
+        lambda: client.execute_skill(layout_hide_layers(LAYERS), timeout=15)
+    )
+    print(f"[layout_hide_layers] [{format_elapsed(hide_elapsed)}]")
+    print(decode_skill(hide_result.output or ""))
+    print(f"  → Check Virtuoso: {layer_names} should now be invisible.\n")
+
+    # Step 2: restore
+    show_elapsed, show_result = timed_call(
+        lambda: client.execute_skill(layout_show_layers(LAYERS), timeout=15)
+    )
+    print(f"[layout_show_layers] [{format_elapsed(show_elapsed)}]")
+    print(decode_skill(show_result.output or ""))
+    print(f"  → Check Virtuoso: {layer_names} should be visible again.\n")
+
+    # Step 3: show only
+    only_elapsed, only_result = timed_call(
+        lambda: client.execute_skill(layout_show_only_layers(LAYERS), timeout=15)
+    )
+    print(f"[layout_show_only_layers] [{format_elapsed(only_elapsed)}]")
+    print(decode_skill(only_result.output or ""))
+    print(f"  → Check Virtuoso: only {layer_names} should be visible.\n")
+
+    # Fit to see the result clearly
+    fit_elapsed, _ = timed_call(
+        lambda: client.execute_skill(layout_fit_view(), timeout=10)
+    )
+    print(f"[layout_fit_view] [{format_elapsed(fit_elapsed)}]")
+    print("[Done] Layer visibility demo complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/01_virtuoso/layout/13_select_and_delete.py
+++ b/examples/01_virtuoso/layout/13_select_and_delete.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Select shapes in a bounding box and delete them from the current layout.
+
+Demonstrates:
+  1. layout_select_box  — select all figures within a rectangle region
+  2. layout_delete_selected — delete the current selection
+
+Prerequisites:
+  - virtuoso-bridge service running (virtuoso-bridge start)
+  - A layout cellview must be open in Virtuoso
+
+Customize BOX below to match the region you want to target.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from _timing import decode_skill, format_elapsed, timed_call
+from virtuoso_bridge import VirtuosoClient
+from virtuoso_bridge.virtuoso.layout.ops import (
+    layout_delete_selected,
+    layout_fit_view,
+    layout_select_box,
+)
+
+# ----------------------------------------------------------------------
+# Customize: bounding box of the region to select and delete
+# ----------------------------------------------------------------------
+# (x0, y0, x1, y1) — lower-left and upper-right corners in microns
+BOX = (0.5, 0.0, 2.5, 2.0)
+# ----------------------------------------------------------------------
+
+
+def main() -> int:
+    client = VirtuosoClient.from_env()
+
+    elapsed, design = timed_call(client.get_current_design)
+    print(f"[get_current_design] [{format_elapsed(elapsed)}]")
+    lib, cell, view = design
+    if not lib or not cell or view != "layout":
+        print("Open a layout cellview in Virtuoso first.")
+        return 1
+
+    print(f"Target Library  : {lib}")
+    print(f"Target Cell     : {cell}")
+    print(f"Select box      : {BOX}")
+    print()
+
+    # Step 1: select
+    sel_elapsed, sel_result = timed_call(
+        lambda: client.execute_skill(layout_select_box(BOX), timeout=15)
+    )
+    print(f"[layout_select_box] [{format_elapsed(sel_elapsed)}]")
+    sel_out = decode_skill(sel_result.output or "")
+    print(sel_out or "  (no output)")
+    if sel_out.startswith("ERROR"):
+        print("[Abort] Selection failed.")
+        return 1
+
+    # Step 2: delete
+    del_elapsed, del_result = timed_call(
+        lambda: client.execute_skill(layout_delete_selected(), timeout=15)
+    )
+    print(f"[layout_delete_selected] [{format_elapsed(del_elapsed)}]")
+    print(decode_skill(del_result.output or ""))
+
+    # Fit to confirm
+    fit_elapsed, _ = timed_call(
+        lambda: client.execute_skill(layout_fit_view(), timeout=10)
+    )
+    print(f"[layout_fit_view] [{format_elapsed(fit_elapsed)}]")
+    print("[Done] Shapes in the selected region have been deleted.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/01_virtuoso/layout/14_mosaic_and_nets.py
+++ b/examples/01_virtuoso/layout/14_mosaic_and_nets.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Create a mosaic array and highlight a net in the current layout.
+
+Demonstrates:
+  1. layout_create_simple_mosaic — array a cell as a mosaic instance
+  2. layout_highlight_net         — highlight shapes belonging to a named net
+  3. layout_set_active_lpp        — set the active layer-purpose pair
+
+Prerequisites:
+  - virtuoso-bridge service running (virtuoso-bridge start)
+  - A layout cellview must be open in Virtuoso
+
+Customize MOSAIC_* and NET_NAME below to match your design.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from _timing import decode_skill, format_elapsed, timed_call
+from virtuoso_bridge import VirtuosoClient
+from virtuoso_bridge.virtuoso.layout.ops import (
+    layout_create_simple_mosaic,
+    layout_fit_view,
+    layout_highlight_net,
+    layout_set_active_lpp,
+)
+
+# ----------------------------------------------------------------------
+# Customize to match your design
+# ----------------------------------------------------------------------
+# The cell to array — must exist in Virtuoso as a layout cellview.
+# A good candidate is the cell created by 01_create_layout.py.
+MOSAIC_LIB  = "tsmcN28"
+MOSAIC_CELL = "nch_ulvt_mac"
+
+# Mosaic parameters
+ROWS       = 2
+COLS       = 3
+ROW_PITCH  = 2.0  # um, vertical spacing between rows
+COL_PITCH  = 2.0  # um, horizontal spacing between columns
+ORIGIN     = (0.0, 0.0)
+ORIENT     = "R0"
+
+# Net name to highlight — must correspond to a named net in the layout.
+# For cells created by 01_create_layout.py, "IN" is the pin label.
+NET_NAME = "IN"
+
+# Layer to set as active after mosaic creation
+ACTIVE_LAYER   = "M1"
+ACTIVE_PURPOSE = "drawing"
+# ----------------------------------------------------------------------
+
+
+def main() -> int:
+    client = VirtuosoClient.from_env()
+
+    elapsed, design = timed_call(client.get_current_design)
+    print(f"[get_current_design] [{format_elapsed(elapsed)}]")
+    lib, cell, view = design
+    if not lib or not cell or view != "layout":
+        print("Open a layout cellview in Virtuoso first.")
+        return 1
+
+    print(f"Target Library  : {lib}")
+    print(f"Target Cell     : {cell}")
+    print(f"Mosaic Master   : {MOSAIC_LIB}/{MOSAIC_CELL}")
+    print(f"Array           : {ROWS}x{COLS}, pitch ({ROW_PITCH}, {COL_PITCH}) um")
+    print(f"Net to highlight: {NET_NAME}")
+    print()
+
+    # Step 1: create mosaic
+    mosaic_elapsed, mosaic_result = timed_call(
+        lambda: client.execute_skill(
+            layout_create_simple_mosaic(
+                MOSAIC_LIB,
+                MOSAIC_CELL,
+                origin=ORIGIN,
+                orientation=ORIENT,
+                rows=ROWS,
+                cols=COLS,
+                row_pitch=ROW_PITCH,
+                col_pitch=COL_PITCH,
+            ),
+            timeout=30,
+        )
+    )
+    print(f"[layout_create_simple_mosaic] [{format_elapsed(mosaic_elapsed)}]")
+    print(decode_skill(mosaic_result.output or ""))
+    print()
+
+    # Step 2: highlight net
+    net_elapsed, net_result = timed_call(
+        lambda: client.execute_skill(layout_highlight_net(NET_NAME), timeout=15)
+    )
+    print(f"[layout_highlight_net] [{format_elapsed(net_elapsed)}]")
+    net_out = decode_skill(net_result.output or "")
+    print(net_out or "  (no output)")
+    if net_out.startswith("ERROR"):
+        print(f"  → Net '{NET_NAME}' not found — this is normal if the cell has no such net.")
+    print()
+
+    # Step 3: set active layer
+    lpp_elapsed, lpp_result = timed_call(
+        lambda: client.execute_skill(
+            layout_set_active_lpp(ACTIVE_LAYER, ACTIVE_PURPOSE), timeout=10
+        )
+    )
+    print(f"[layout_set_active_lpp] [{format_elapsed(lpp_elapsed)}]")
+    print(decode_skill(lpp_result.output or ""))
+
+    # Fit to see everything
+    fit_elapsed, _ = timed_call(
+        lambda: client.execute_skill(layout_fit_view(), timeout=10)
+    )
+    print(f"[layout_fit_view] [{format_elapsed(fit_elapsed)}]")
+    print("[Done] Mosaic created, net highlighted, active layer set.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/01_virtuoso/layout/flower.py
+++ b/examples/01_virtuoso/layout/flower.py
@@ -25,7 +25,7 @@ import math
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from virtuoso_bridge import VirtuosoClient
 from virtuoso_bridge.virtuoso.layout.ops import (

--- a/examples/01_virtuoso/maestro/03_bg_open_read_close_maestro.py
+++ b/examples/01_virtuoso/maestro/03_bg_open_read_close_maestro.py
@@ -13,7 +13,10 @@ Usage::
     Running this script from VSCode without passing <LIB> will NOT work.
 """
 
+from __future__ import annotations
+
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -22,18 +25,21 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
 from virtuoso_bridge import VirtuosoClient
 from virtuoso_bridge.virtuoso.maestro import close_session, open_session
 
+# ----------------------------------------------------------------------
+# Customize to match your Maestro cell
+# ----------------------------------------------------------------------
+# Must exist as a Maestro view in <LIB>
 CELL = "TB_AMP_5T_D2S_DC_AC"
+# ----------------------------------------------------------------------
 
 
-def _decode_atom(raw: str | None) -> str:
-    text = (raw or "").strip().strip('"')
-    return "" if not text or text.lower() == "nil" else text
+def _first_element(raw: str | None) -> str:
+    """Extract the first quoted string from a SKILL list like (\"name\")."""
+    m = re.search(r'"([^"]+)"', raw or "")
+    return m.group(1) if m else ""
 
 
 def main() -> int:
-    # ------------------------------------------------------------------
-    # Argument check
-    # ------------------------------------------------------------------
     if len(sys.argv) < 2:
         print("=" * 60, file=sys.stderr)
         print(" ERROR: missing required argument <LIB>", file=sys.stderr)
@@ -52,34 +58,49 @@ def main() -> int:
         return 1
 
     lib = sys.argv[1]
-
     client = VirtuosoClient.from_env()
 
-    session = open_session(client, lib, CELL)
+    # Open background session — raises RuntimeError if the cell or view is missing
+    try:
+        session = open_session(client, lib, CELL)
+    except RuntimeError as exc:
+        print(f"[ERROR] Failed to open maestro: {exc}", file=sys.stderr)
+        print(
+            "  Verify that:\n"
+            f"    1. Library '{lib}' exists in Virtuoso\n"
+            f"    2. Cell '{CELL}' exists in '{lib}'\n"
+            f"    3. Cell '{CELL}' has a 'maestro' view\n",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Clean up regardless of whether reading succeeds
+    error: BaseException | None = None
     try:
         cfg: dict[str, str] = {"session": session}
-        test = _decode_atom(
+        test = _first_element(
             client.execute_skill(
                 f'maeGetSetup(?session "{session}")', timeout=15
             ).output
         )
-        if test:
-            cfg["test"] = test
-            cfg["lib"] = _decode_atom(
-                client.execute_skill(
-                    f'maeGetEnvOption("{test}" ?option "lib" ?session "{session}")',
-                    timeout=15,
-                ).output
-            )
-            cfg["cell"] = _decode_atom(
-                client.execute_skill(
-                    f'maeGetEnvOption("{test}" ?option "cell" ?session "{session}")',
-                    timeout=15,
-                ).output
-            )
+        cfg["test"] = test or "(none)"
+        cfg["lib"] = lib
+        cfg["cell"] = CELL
         print(json.dumps(cfg, indent=2, default=str))
+    except Exception as exc:
+        error = exc
+        print(f"[ERROR] Reading session config failed: {exc}", file=sys.stderr)
     finally:
-        close_session(client, session)
+        # close_session failure should not mask the original error
+        try:
+            close_session(client, session)
+        except Exception as close_exc:
+            print(f"[WARN] Failed to close session cleanly: {close_exc}", file=sys.stderr)
+            if error is None:
+                error = close_exc
+
+    if error is not None:
+        raise SystemExit(1)
     return 0
 
 

--- a/src/virtuoso_bridge/transport/ssh.py
+++ b/src/virtuoso_bridge/transport/ssh.py
@@ -194,7 +194,12 @@ class SSHRunner:
         # to opt out if a specific platform trips mux errors.
         _disable_cm = os.environ.get("VB_DISABLE_CONTROL_MASTER", "").strip().lower() in ("1", "true", "yes")
         _force_cm = os.environ.get("VB_FORCE_CONTROL_MASTER", "").strip().lower() in ("1", "true", "yes")
-        self._use_control_master = _force_cm or (not _disable_cm)
+        # Windows OpenSSH does not support ControlMaster — auto-disable unless
+        # the user explicitly forces it (e.g. MSYS2/Git-for-Windows SSH).
+        if os.name == "nt" and not _force_cm:
+            self._use_control_master = False
+        else:
+            self._use_control_master = _force_cm or (not _disable_cm)
 
         _user_part = user or "default"
         _tmp = tempfile.gettempdir()
@@ -531,11 +536,13 @@ class SSHRunner:
 
     def _run_command_once(self, command: str, timeout: int | None = None) -> CommandResult:
         effective_timeout = timeout or self._timeout
-        # Pipe the command to `ssh host sh` via stdin so it always runs in sh
-        # regardless of the remote user's login shell (which may be csh).
+        # Pipe the command to `ssh host sh -l` via stdin so it always runs in
+        # a POSIX login shell regardless of the remote user's login shell
+        # (which may be csh).  Using -l (login) sources /etc/profile and
+        # ~/.profile, making tools like python3 visible via PATH.
         # Passing the command as an SSH argument would have the login shell
         # interpret it, breaking sh syntax (&&, ${VAR:-}, etc.) if login=csh.
-        cmd = self._build_ssh_base() + ["sh"]
+        cmd = self._build_ssh_base() + ["sh", "-l"]
         self._print_cmd(cmd)
         logger.info("[server] %s", command)
         # Use bytes (text=False) to bypass Windows universal-newlines translation
@@ -869,7 +876,7 @@ class SSHRunner:
                 return
 
             self._close_persistent_shell_locked()
-            cmd = self._build_ssh_base() + ["sh", "-s"]
+            cmd = self._build_ssh_base() + ["sh", "-l", "-s"]
             logger.info("Starting persistent SSH shell: %s", " ".join(cmd))
             self._print_cmd(cmd)
             proc = subprocess.Popen(


### PR DESCRIPTION
## Summary
- 02~06: 增加 `view == "layout"` 检查，防止在 schematic/symbol 窗口误执行
- 08~09: 增加 `get_current_design` 预检查，无 cellview 时给出明确错误
- 01: `raise SystemExit(1)` → `return 1`，与其他样例风格统一
- flower: `sys.path.insert` 从 4 层 parent 统一为 3 层，与 01~10 一致

## Test plan
- [ ] 在无 layout 窗口时运行 02~06，确认报错退出
- [ ] 在 schematic 窗口时运行 02~06，确认报错退出
- [ ] 在 layout 窗口时运行 02~06，确认正常执行
- [ ] 无 cellview 时运行 08、09，确认报错退出
- [ ] 不传参数运行 01，确认 `return 1` 正常退出
- [ ] 运行 flower.py，确认 import 路径正常