### PR TITLE
fix(env): walk cwd upward to find VB-aware .env

### DIFF
--- a/src/virtuoso_bridge/env.py
+++ b/src/virtuoso_bridge/env.py
@@ -42,9 +42,18 @@ def resolve_env_path(explicit: str | Path | None = None, *, cwd: Path | None = N
             raise FileNotFoundError(f".env file not found: {env_path}")
         return env_path
 
-    cwd_env = base_cwd / ".env"
-    if cwd_env.is_file():
-        return cwd_env
+    # Walk cwd upward, accept the first .env that looks like a VB config
+    # (contains VB_REMOTE_HOST or VB_LOCAL_PORT). Skips unrelated .env files.
+    for parent in [base_cwd, *base_cwd.parents]:
+        candidate = parent / ".env"
+        if not candidate.is_file():
+            continue
+        try:
+            text = candidate.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if "VB_REMOTE_HOST" in text or "VB_LOCAL_PORT" in text:
+            return candidate
 
     user_env = default_user_env_path()
     if user_env.is_file():


### PR DESCRIPTION
resolve_env_path() now walks cwd upward and accepts the first .env containing VB_REMOTE_HOST or VB_LOCAL_PORT, skipping unrelated .env files (e.g. .env files belonging to other tools in a parent project).

Previously only base_cwd / ".env" was checked, which forced users to either cd into the directory holding .env or always pass --env when running virtuoso-bridge from a nested subdirectory.