### PR TITLE
fix(ssh): default-disable ControlMaster on Windows + sanitize Control…

### DIFF
--- a/src/virtuoso_bridge/transport/ssh.py
+++ b/src/virtuoso_bridge/transport/ssh.py
@@ -190,15 +190,22 @@ class SSHRunner:
 
         # ControlMaster socket path for SSH connection multiplexing.
         # All ssh/scp calls to the same host reuse one TCP connection.
-        # Enabled by default on every OS; set VB_DISABLE_CONTROL_MASTER=1
-        # to opt out if a specific platform trips mux errors.
+        # Enabled by default on POSIX.  Disabled by default on Windows because
+        # the OpenSSH mux protocol is unreliable on Windows pipe semantics —
+        # both native System32 ssh.exe and Git-for-Windows ssh fail with
+        # ``mux_client_request_session: read from master failed: Connection
+        # reset by peer`` when run from a Python subprocess.  Users with a
+        # known-good Windows ssh.exe can opt in via VB_FORCE_CONTROL_MASTER=1.
         _disable_cm = os.environ.get("VB_DISABLE_CONTROL_MASTER", "").strip().lower() in ("1", "true", "yes")
         _force_cm = os.environ.get("VB_FORCE_CONTROL_MASTER", "").strip().lower() in ("1", "true", "yes")
-        self._use_control_master = _force_cm or (not _disable_cm)
+        self._use_control_master = _force_cm or (not _disable_cm and os.name != "nt")
 
         _user_part = user or "default"
         _tmp = tempfile.gettempdir()
-        self._control_path = f"{_tmp}/vb_ssh_{_user_part}@{host}:{jump_host or 'direct'}"
+        # Colons are illegal in Windows filenames; use '_' as the separator
+        # so the control socket path is valid on both POSIX and Windows.
+        _jump_tag = (jump_host or "direct").replace(":", "_")
+        self._control_path = f"{_tmp}/vb_ssh_{_user_part}@{host}_{_jump_tag}"
 
         # Persistent SSH shell = one long-lived ``ssh host sh -s`` subprocess
         # shared by every run_command call.  Turns N cold handshakes into 1.


### PR DESCRIPTION
…Path

OpenSSH connection multiplexing is unreliable on Windows pipe semantics: both native System32 ssh.exe and Git-for-Windows ssh fail with::

  mux_client_request_session: read from master failed: Connection
  reset by peer

when run from a Python ``subprocess`` (verified empirically on Windows 11 + jump-less direct connection, both ssh distros).  This breaks ``virtuoso-bridge start`` with the misleading ``Detection output: ''`` symptom: SSH itself returns rc=0, but the mux layer eats stdin so the remote sh receives nothing.

Two interlocking fixes, kept minimal so the diff vs main is two substantive lines:

1. ``_use_control_master`` adds ``os.name != "nt"`` to its default-on clause.  ``VB_FORCE_CONTROL_MASTER=1`` remains as escape hatch for users whose Windows ssh.exe + jump-host combination does work.

2. ``_control_path`` no longer embeds ``:`` between host and jump tag (colon is illegal in Windows filenames; the resulting socket file could not be created even before the mux protocol issue).  Uses ``_`` as the separator on both POSIX and Windows.

Persistent-shell behavior on Windows is unchanged from main: with ControlMaster now off by default on Windows, the existing gate ``persistent_shell and not _use_control_master and not jump_host`` naturally re-enables persistent shell in the common direct-connection case, which is what makes daemon deploy reuse a single SSH.

Tested on chenzc24's Windows + Git-for-Windows ssh + thu-wei direct: ``tunnel.warm = 5.1s``, persistent shell handles all warm() calls.