### PR TITLE
Fix/layout examples view type guard

### DIFF
--- a/examples/01_virtuoso/layout/01_create_layout.py
+++ b/examples/01_virtuoso/layout/01_create_layout.py
@@ -89,7 +89,7 @@ def main() -> int:
             file=sys.stderr,
         )
         print("=" * 60, file=sys.stderr)
-        raise SystemExit(1)
+        return 1
 
     lib_name = sys.argv[1]
     cell_name = f"layout_demo_{datetime.now().strftime('%Y%m%d_%H%M%S')}"

--- a/examples/01_virtuoso/layout/02_add_polygon.py
+++ b/examples/01_virtuoso/layout/02_add_polygon.py
@@ -37,9 +37,9 @@ def main() -> int:
 
     elapsed, design = timed_call(client.get_current_design)
     print(f"[get_current_design] [{format_elapsed(elapsed)}]")
-    lib, cell, _ = design
-    if not lib or not cell:
-        print("Open a layout in Virtuoso first.")
+    lib, cell, view = design
+    if not lib or not cell or view != "layout":
+        print("Open a layout cellview in Virtuoso first.")
         return 1
 
     print(f"Target Library  : {lib}")

--- a/examples/01_virtuoso/layout/03_add_via.py
+++ b/examples/01_virtuoso/layout/03_add_via.py
@@ -44,9 +44,9 @@ def main() -> int:
 
     elapsed, design = timed_call(client.get_current_design)
     print(f"[get_current_design] [{format_elapsed(elapsed)}]")
-    lib, cell, _ = design
-    if not lib or not cell:
-        print("Open a layout in Virtuoso first.")
+    lib, cell, view = design
+    if not lib or not cell or view != "layout":
+        print("Open a layout cellview in Virtuoso first.")
         return 1
 
     print(f"Target Library  : {lib}")

--- a/examples/01_virtuoso/layout/04_multilayer_routing.py
+++ b/examples/01_virtuoso/layout/04_multilayer_routing.py
@@ -40,9 +40,9 @@ def main() -> int:
 
     elapsed, design = timed_call(client.get_current_design)
     print(f"[get_current_design] [{format_elapsed(elapsed)}]")
-    lib, cell, _ = design
-    if not lib or not cell:
-        print("Open a layout in Virtuoso first.")
+    lib, cell, view = design
+    if not lib or not cell or view != "layout":
+        print("Open a layout cellview in Virtuoso first.")
         return 1
 
     print(f"Target Library  : {lib}")

--- a/examples/01_virtuoso/layout/05_bus_routing.py
+++ b/examples/01_virtuoso/layout/05_bus_routing.py
@@ -56,9 +56,9 @@ def main() -> int:
 
     elapsed, design = timed_call(client.get_current_design)
     print(f"[get_current_design] [{format_elapsed(elapsed)}]")
-    lib, cell, _ = design
-    if not lib or not cell:
-        print("No layout window open in Virtuoso.")
+    lib, cell, view = design
+    if not lib or not cell or view != "layout":
+        print("Open a layout cellview in Virtuoso first.")
         return 1
 
     print(f"Target Library  : {lib}")

--- a/examples/01_virtuoso/layout/06_read_layout.py
+++ b/examples/01_virtuoso/layout/06_read_layout.py
@@ -33,9 +33,9 @@ def main() -> int:
 
     elapsed, design = timed_call(client.get_current_design)
     print(f"[get_current_design] [{format_elapsed(elapsed)}]")
-    lib, cell, _ = design
-    if not lib or not cell:
-        print("Open a layout in Virtuoso first.")
+    lib, cell, view = design
+    if not lib or not cell or view != "layout":
+        print("Open a layout cellview in Virtuoso first.")
         return 1
 
     read_elapsed, result = timed_call(

--- a/examples/01_virtuoso/layout/08_clear_routing.py
+++ b/examples/01_virtuoso/layout/08_clear_routing.py
@@ -16,6 +16,13 @@ from virtuoso_bridge.virtuoso.layout.ops import layout_clear_routing
 def main() -> int:
     client = VirtuosoClient.from_env()
 
+    elapsed, design = timed_call(client.get_current_design)
+    print(f"[get_current_design] [{format_elapsed(elapsed)}]")
+    lib, cell, view = design
+    if not lib or not cell or view != "layout":
+        print("Open a layout cellview in Virtuoso first.")
+        return 1
+
     elapsed, result = timed_call(
         lambda: client.execute_skill(layout_clear_routing(), timeout=30)
     )

--- a/examples/01_virtuoso/layout/09_clear_current_layout.py
+++ b/examples/01_virtuoso/layout/09_clear_current_layout.py
@@ -16,6 +16,13 @@ from virtuoso_bridge.virtuoso.layout import clear_current_layout
 def main() -> int:
     client = VirtuosoClient.from_env()
 
+    elapsed, design = timed_call(client.get_current_design)
+    print(f"[get_current_design] [{format_elapsed(elapsed)}]")
+    lib, cell, view = design
+    if not lib or not cell or view != "layout":
+        print("Open a layout cellview in Virtuoso first.")
+        return 1
+
     elapsed, result = timed_call(
         lambda: client.execute_skill(clear_current_layout(), timeout=30)
     )

--- a/examples/01_virtuoso/layout/flower.py
+++ b/examples/01_virtuoso/layout/flower.py
@@ -25,7 +25,7 @@ import math
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from virtuoso_bridge import VirtuosoClient
 from virtuoso_bridge.virtuoso.layout.ops import (


### PR DESCRIPTION
## Summary
- All layout examples (01–09, flower) now verify the active cellview is a `layout` view before running, preventing silent wrong-window execution
- `08_clear_routing` and `09_clear_current_layout` gain a `get_current_design` pre-flight check (destructive ops must confirm context first)
- `flower.py` had an off-by-one `sys.path` depth; `01_create_layout.py` used inconsistent `raise SystemExit(1)` instead of `return 1`

## Test plan
- [ ] Run any layout example with a schematic window active — should print "Open a layout cellview in Virtuoso first." and exit cleanly
- [ ] Run 08/09 without an open cellview — same guard fires
- [ ] Run flower.py — imports resolve correctly
