### PR TITLE
Feat/layout examples 11 to 14

### DIFF
--- a/examples/01_virtuoso/layout/11_read_summary.py
+++ b/examples/01_virtuoso/layout/11_read_summary.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Read a lightweight summary of shapes and instances from the current layout cell.
+
+Prerequisites:
+  - virtuoso-bridge service running (virtuoso-bridge start)
+  - A layout cellview must be open in Virtuoso
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from _timing import decode_skill, format_elapsed, timed_call
+from virtuoso_bridge import VirtuosoClient
+from virtuoso_bridge.virtuoso.layout.ops import layout_read_summary
+
+
+def main() -> int:
+    client = VirtuosoClient.from_env()
+
+    elapsed, design = timed_call(client.get_current_design)
+    print(f"[get_current_design] [{format_elapsed(elapsed)}]")
+    lib, cell, view = design
+    if not lib or not cell or view != "layout":
+        print("Open a layout cellview in Virtuoso first.")
+        return 1
+
+    read_elapsed, result = timed_call(
+        lambda: client.execute_skill(layout_read_summary(lib, cell), timeout=30)
+    )
+    print(f"[layout_read_summary] [{format_elapsed(read_elapsed)}]")
+
+    output = decode_skill(result.output or "")
+    if output.startswith("ERROR"):
+        print(output)
+        return 1
+
+    print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/01_virtuoso/layout/12_layer_visibility.py
+++ b/examples/01_virtuoso/layout/12_layer_visibility.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Control layer visibility in the current layout window.
+
+Demonstrates three layer-visibility APIs in sequence:
+  1. hide_layers   — hide specific layer-purpose pairs
+  2. show_layers   — restore visibility of hidden layers
+  3. show_only_layers — hide everything, then show only requested layers
+
+Each step pauses briefly so you can observe the change in Virtuoso.
+
+Prerequisites:
+  - virtuoso-bridge service running (virtuoso-bridge start)
+  - A layout cellview must be open in Virtuoso
+
+Customize LAYERS below to match your PDK techfile.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from _timing import decode_skill, format_elapsed, timed_call
+from virtuoso_bridge import VirtuosoClient
+from virtuoso_bridge.virtuoso.layout.ops import (
+    layout_fit_view,
+    layout_hide_layers,
+    layout_show_layers,
+    layout_show_only_layers,
+)
+
+# ----------------------------------------------------------------------
+# Customize to match your PDK metal stack
+# ----------------------------------------------------------------------
+# Layer-purpose pairs to toggle. All must be defined in your PDK techfile.
+LAYERS = [
+    ("M3", "drawing"),
+    ("M4", "drawing"),
+]
+# ----------------------------------------------------------------------
+
+
+def main() -> int:
+    client = VirtuosoClient.from_env()
+
+    elapsed, design = timed_call(client.get_current_design)
+    print(f"[get_current_design] [{format_elapsed(elapsed)}]")
+    lib, cell, view = design
+    if not lib or not cell or view != "layout":
+        print("Open a layout cellview in Virtuoso first.")
+        return 1
+
+    layer_names = ", ".join(f"{l}/{p}" for l, p in LAYERS)
+    print(f"Target Library  : {lib}")
+    print(f"Target Cell     : {cell}")
+    print(f"Layers          : {layer_names}")
+    print()
+
+    # Step 1: hide
+    hide_elapsed, hide_result = timed_call(
+        lambda: client.execute_skill(layout_hide_layers(LAYERS), timeout=15)
+    )
+    print(f"[layout_hide_layers] [{format_elapsed(hide_elapsed)}]")
+    print(decode_skill(hide_result.output or ""))
+    print(f"  → Check Virtuoso: {layer_names} should now be invisible.\n")
+
+    # Step 2: restore
+    show_elapsed, show_result = timed_call(
+        lambda: client.execute_skill(layout_show_layers(LAYERS), timeout=15)
+    )
+    print(f"[layout_show_layers] [{format_elapsed(show_elapsed)}]")
+    print(decode_skill(show_result.output or ""))
+    print(f"  → Check Virtuoso: {layer_names} should be visible again.\n")
+
+    # Step 3: show only
+    only_elapsed, only_result = timed_call(
+        lambda: client.execute_skill(layout_show_only_layers(LAYERS), timeout=15)
+    )
+    print(f"[layout_show_only_layers] [{format_elapsed(only_elapsed)}]")
+    print(decode_skill(only_result.output or ""))
+    print(f"  → Check Virtuoso: only {layer_names} should be visible.\n")
+
+    # Fit to see the result clearly
+    fit_elapsed, _ = timed_call(
+        lambda: client.execute_skill(layout_fit_view(), timeout=10)
+    )
+    print(f"[layout_fit_view] [{format_elapsed(fit_elapsed)}]")
+    print("[Done] Layer visibility demo complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/01_virtuoso/layout/13_select_and_delete.py
+++ b/examples/01_virtuoso/layout/13_select_and_delete.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Select shapes in a bounding box and delete them from the current layout.
+
+Demonstrates:
+  1. layout_select_box  — select all figures within a rectangle region
+  2. layout_delete_selected — delete the current selection
+
+Prerequisites:
+  - virtuoso-bridge service running (virtuoso-bridge start)
+  - A layout cellview must be open in Virtuoso
+
+Customize BOX below to match the region you want to target.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from _timing import decode_skill, format_elapsed, timed_call
+from virtuoso_bridge import VirtuosoClient
+from virtuoso_bridge.virtuoso.layout.ops import (
+    layout_delete_selected,
+    layout_fit_view,
+    layout_select_box,
+)
+
+# ----------------------------------------------------------------------
+# Customize: bounding box of the region to select and delete
+# ----------------------------------------------------------------------
+# (x0, y0, x1, y1) — lower-left and upper-right corners in microns
+BOX = (0.5, 0.0, 2.5, 2.0)
+# ----------------------------------------------------------------------
+
+
+def main() -> int:
+    client = VirtuosoClient.from_env()
+
+    elapsed, design = timed_call(client.get_current_design)
+    print(f"[get_current_design] [{format_elapsed(elapsed)}]")
+    lib, cell, view = design
+    if not lib or not cell or view != "layout":
+        print("Open a layout cellview in Virtuoso first.")
+        return 1
+
+    print(f"Target Library  : {lib}")
+    print(f"Target Cell     : {cell}")
+    print(f"Select box      : {BOX}")
+    print()
+
+    # Step 1: select
+    sel_elapsed, sel_result = timed_call(
+        lambda: client.execute_skill(layout_select_box(BOX), timeout=15)
+    )
+    print(f"[layout_select_box] [{format_elapsed(sel_elapsed)}]")
+    sel_out = decode_skill(sel_result.output or "")
+    print(sel_out or "  (no output)")
+    if sel_out.startswith("ERROR"):
+        print("[Abort] Selection failed.")
+        return 1
+
+    # Step 2: delete
+    del_elapsed, del_result = timed_call(
+        lambda: client.execute_skill(layout_delete_selected(), timeout=15)
+    )
+    print(f"[layout_delete_selected] [{format_elapsed(del_elapsed)}]")
+    print(decode_skill(del_result.output or ""))
+
+    # Fit to confirm
+    fit_elapsed, _ = timed_call(
+        lambda: client.execute_skill(layout_fit_view(), timeout=10)
+    )
+    print(f"[layout_fit_view] [{format_elapsed(fit_elapsed)}]")
+    print("[Done] Shapes in the selected region have been deleted.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/01_virtuoso/layout/14_mosaic_and_nets.py
+++ b/examples/01_virtuoso/layout/14_mosaic_and_nets.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Create a mosaic array and highlight a net in the current layout.
+
+Demonstrates:
+  1. layout_create_simple_mosaic — array a cell as a mosaic instance
+  2. layout_highlight_net         — highlight shapes belonging to a named net
+  3. layout_set_active_lpp        — set the active layer-purpose pair
+
+Prerequisites:
+  - virtuoso-bridge service running (virtuoso-bridge start)
+  - A layout cellview must be open in Virtuoso
+
+Customize MOSAIC_* and NET_NAME below to match your design.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from _timing import decode_skill, format_elapsed, timed_call
+from virtuoso_bridge import VirtuosoClient
+from virtuoso_bridge.virtuoso.layout.ops import (
+    layout_create_simple_mosaic,
+    layout_fit_view,
+    layout_highlight_net,
+    layout_set_active_lpp,
+)
+
+# ----------------------------------------------------------------------
+# Customize to match your design
+# ----------------------------------------------------------------------
+# The cell to array — must exist in Virtuoso as a layout cellview.
+# A good candidate is the cell created by 01_create_layout.py.
+MOSAIC_LIB  = "tsmcN28"
+MOSAIC_CELL = "nch_ulvt_mac"
+
+# Mosaic parameters
+ROWS       = 2
+COLS       = 3
+ROW_PITCH  = 2.0  # um, vertical spacing between rows
+COL_PITCH  = 2.0  # um, horizontal spacing between columns
+ORIGIN     = (0.0, 0.0)
+ORIENT     = "R0"
+
+# Net name to highlight — must correspond to a named net in the layout.
+# For cells created by 01_create_layout.py, "IN" is the pin label.
+NET_NAME = "IN"
+
+# Layer to set as active after mosaic creation
+ACTIVE_LAYER   = "M1"
+ACTIVE_PURPOSE = "drawing"
+# ----------------------------------------------------------------------
+
+
+def main() -> int:
+    client = VirtuosoClient.from_env()
+
+    elapsed, design = timed_call(client.get_current_design)
+    print(f"[get_current_design] [{format_elapsed(elapsed)}]")
+    lib, cell, view = design
+    if not lib or not cell or view != "layout":
+        print("Open a layout cellview in Virtuoso first.")
+        return 1
+
+    print(f"Target Library  : {lib}")
+    print(f"Target Cell     : {cell}")
+    print(f"Mosaic Master   : {MOSAIC_LIB}/{MOSAIC_CELL}")
+    print(f"Array           : {ROWS}x{COLS}, pitch ({ROW_PITCH}, {COL_PITCH}) um")
+    print(f"Net to highlight: {NET_NAME}")
+    print()
+
+    # Step 1: create mosaic
+    mosaic_elapsed, mosaic_result = timed_call(
+        lambda: client.execute_skill(
+            layout_create_simple_mosaic(
+                MOSAIC_LIB,
+                MOSAIC_CELL,
+                origin=ORIGIN,
+                orientation=ORIENT,
+                rows=ROWS,
+                cols=COLS,
+                row_pitch=ROW_PITCH,
+                col_pitch=COL_PITCH,
+            ),
+            timeout=30,
+        )
+    )
+    print(f"[layout_create_simple_mosaic] [{format_elapsed(mosaic_elapsed)}]")
+    print(decode_skill(mosaic_result.output or ""))
+    print()
+
+    # Step 2: highlight net
+    net_elapsed, net_result = timed_call(
+        lambda: client.execute_skill(layout_highlight_net(NET_NAME), timeout=15)
+    )
+    print(f"[layout_highlight_net] [{format_elapsed(net_elapsed)}]")
+    net_out = decode_skill(net_result.output or "")
+    print(net_out or "  (no output)")
+    if net_out.startswith("ERROR"):
+        print(f"  → Net '{NET_NAME}' not found — this is normal if the cell has no such net.")
+    print()
+
+    # Step 3: set active layer
+    lpp_elapsed, lpp_result = timed_call(
+        lambda: client.execute_skill(
+            layout_set_active_lpp(ACTIVE_LAYER, ACTIVE_PURPOSE), timeout=10
+        )
+    )
+    print(f"[layout_set_active_lpp] [{format_elapsed(lpp_elapsed)}]")
+    print(decode_skill(lpp_result.output or ""))
+
+    # Fit to see everything
+    fit_elapsed, _ = timed_call(
+        lambda: client.execute_skill(layout_fit_view(), timeout=10)
+    )
+    print(f"[layout_fit_view] [{format_elapsed(fit_elapsed)}]")
+    print("[Done] Mosaic created, net highlighted, active layer set.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Add four example scripts that exercise previously uncovered layout APIs:

| # | File | APIs demonstrated |
|---|------|-------------------|
| 11 | `11_read_summary.py` | `layout_read_summary` |
| 12 | `12_layer_visibility.py` | `layout_hide_layers`, `layout_show_layers`, `layout_show_only_layers` |
| 13 | `13_select_and_delete.py` | `layout_select_box`, `layout_delete_selected` |
| 14 | `14_mosaic_and_nets.py` | `layout_create_simple_mosaic`, `layout_highlight_net`, `layout_set_active_lpp` |

All follow the same structure as 01–10: `VirtuosoClient.from_env()` → pre-flight check → timed calls → output.

## Test plan
- [ ] Run each script with a layout cellview open in Virtuoso
- [ ] 12: visually confirm layers hide / show / show-only in LSW
- [ ] 13: confirm shapes inside the box are deleted
- [ ] 14: confirm mosaic appears, net is highlighted, active layer changes
