### PR TITLE
Fix/maestro 03 skill parsing

### DIFF
--- a/examples/01_virtuoso/maestro/03_bg_open_read_close_maestro.py
+++ b/examples/01_virtuoso/maestro/03_bg_open_read_close_maestro.py
@@ -13,7 +13,10 @@ Usage::
     Running this script from VSCode without passing <LIB> will NOT work.
 """
 
+from __future__ import annotations
+
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -22,18 +25,21 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
 from virtuoso_bridge import VirtuosoClient
 from virtuoso_bridge.virtuoso.maestro import close_session, open_session
 
+# ----------------------------------------------------------------------
+# Customize to match your Maestro cell
+# ----------------------------------------------------------------------
+# Must exist as a Maestro view in <LIB>
 CELL = "TB_AMP_5T_D2S_DC_AC"
+# ----------------------------------------------------------------------
 
 
-def _decode_atom(raw: str | None) -> str:
-    text = (raw or "").strip().strip('"')
-    return "" if not text or text.lower() == "nil" else text
+def _first_element(raw: str | None) -> str:
+    """Extract the first quoted string from a SKILL list like (\"name\")."""
+    m = re.search(r'"([^"]+)"', raw or "")
+    return m.group(1) if m else ""
 
 
 def main() -> int:
-    # ------------------------------------------------------------------
-    # Argument check
-    # ------------------------------------------------------------------
     if len(sys.argv) < 2:
         print("=" * 60, file=sys.stderr)
         print(" ERROR: missing required argument <LIB>", file=sys.stderr)
@@ -52,34 +58,49 @@ def main() -> int:
         return 1
 
     lib = sys.argv[1]
-
     client = VirtuosoClient.from_env()
 
-    session = open_session(client, lib, CELL)
+    # Open background session — raises RuntimeError if the cell or view is missing
+    try:
+        session = open_session(client, lib, CELL)
+    except RuntimeError as exc:
+        print(f"[ERROR] Failed to open maestro: {exc}", file=sys.stderr)
+        print(
+            "  Verify that:\n"
+            f"    1. Library '{lib}' exists in Virtuoso\n"
+            f"    2. Cell '{CELL}' exists in '{lib}'\n"
+            f"    3. Cell '{CELL}' has a 'maestro' view\n",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Clean up regardless of whether reading succeeds
+    error: BaseException | None = None
     try:
         cfg: dict[str, str] = {"session": session}
-        test = _decode_atom(
+        test = _first_element(
             client.execute_skill(
                 f'maeGetSetup(?session "{session}")', timeout=15
             ).output
         )
-        if test:
-            cfg["test"] = test
-            cfg["lib"] = _decode_atom(
-                client.execute_skill(
-                    f'maeGetEnvOption("{test}" ?option "lib" ?session "{session}")',
-                    timeout=15,
-                ).output
-            )
-            cfg["cell"] = _decode_atom(
-                client.execute_skill(
-                    f'maeGetEnvOption("{test}" ?option "cell" ?session "{session}")',
-                    timeout=15,
-                ).output
-            )
+        cfg["test"] = test or "(none)"
+        cfg["lib"] = lib
+        cfg["cell"] = CELL
         print(json.dumps(cfg, indent=2, default=str))
+    except Exception as exc:
+        error = exc
+        print(f"[ERROR] Reading session config failed: {exc}", file=sys.stderr)
     finally:
-        close_session(client, session)
+        # close_session failure should not mask the original error
+        try:
+            close_session(client, session)
+        except Exception as close_exc:
+            print(f"[WARN] Failed to close session cleanly: {close_exc}", file=sys.stderr)
+            if error is None:
+                error = close_exc
+
+    if error is not None:
+        raise SystemExit(1)
     return 0
 
 


### PR DESCRIPTION
## Summary
- `_decode_atom` treated SKILL list output like `("name")` as a plain atom — replaced with `_first_element` regex that correctly extracts the first quoted string
- `maeGetEnvOption("lib"/"cell")` always returned empty because those keys do not exist in the maestro environment alist — now uses the `lib` argument and `CELL` constant directly
- `open_session` wrapped in try/except with actionable error messages (missing lib/cell/view)
- `close_session` placed in `finally` block; its failure does not mask the original error

## Test plan
- [ ] `python 03_bg_open_read_close_maestro.py <LIB>` with a valid maestro cell — should print JSON with session, test name, lib, cell
- [ ] Run with an invalid library — should print clear error about missing lib/cell/view
- [ ] Session should close cleanly in Virtuoso after script exits
