### PR TITLE
Feat/schematic examples 09-11

### DIFF
--- a/examples/01_virtuoso/schematic/09_create_pins.py
+++ b/examples/01_virtuoso/schematic/09_create_pins.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Create a schematic with explicit pins using pin creation APIs.
+
+Demonstrates two ways to add pins:
+  - schematic_create_pin() — place a pin at an explicit (x, y)
+  - schematic_create_pin_at_instance_term() — place a pin at an instance terminal
+
+Circuit: voltage divider with VDD, GND (input pins) and OUT (output pin).
+
+Usage::
+
+    python 09_create_pins.py <LIB>
+    python 09_create_pins.py <LIB> <CELL>
+
+Prerequisites:
+  - virtuoso-bridge service running (virtuoso-bridge start)
+  - analogLib cell masters (res) available
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime
+
+from virtuoso_bridge import VirtuosoClient
+from virtuoso_bridge.virtuoso.schematic.ops import (
+    schematic_create_inst_by_master_name as inst,
+    schematic_create_pin,
+    schematic_create_pin_at_instance_term,
+)
+
+
+def _create(client: VirtuosoClient, lib: str, cell: str) -> None:
+    with client.schematic.edit(lib, cell) as sch:
+        # Two resistors in series forming a voltage divider
+        sch.add(inst("analogLib", "res", "symbol", "R0", 0.0, 0.5, "R0"))
+        sch.add(inst("analogLib", "res", "symbol", "R1", 0.0, -0.5, "R0"))
+
+        # --- Method 1: explicit position pins ---
+        # VDD input pin placed above the top resistor
+        sch.add(schematic_create_pin("VDD", 0.0, 1.5, "R0", direction="input"))
+        # GND input pin placed below the bottom resistor
+        sch.add(schematic_create_pin("GND", 0.0, -1.5, "R0", direction="input"))
+
+        # --- Method 2: pin at instance terminal center ---
+        # OUT output pin auto-positioned at R0's MINUS terminal
+        sch.add(schematic_create_pin_at_instance_term(
+            "R0", "MINUS", "OUT", direction="output",
+        ))
+
+    client.open_window(lib, cell, view="schematic")
+    print(f"Created {lib}/{cell}/schematic")
+    print("Pins: VDD (input), GND (input), OUT (output)")
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print(f"Usage: python {__file__} <LIB> [CELL]", file=sys.stderr)
+        return 1
+
+    lib = sys.argv[1]
+    cell = (
+        sys.argv[2]
+        if len(sys.argv) >= 3
+        else f"pins_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+    )
+
+    client = VirtuosoClient.from_env()
+    _create(client, lib, cell)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/01_virtuoso/schematic/10_create_wire.py
+++ b/examples/01_virtuoso/schematic/10_create_wire.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Create a schematic with direct wires using wire creation APIs.
+
+Demonstrates two ways to draw wires:
+  - schematic_create_wire() — arbitrary polyline through explicit points
+  - schematic_create_wire_between_instance_terms() — auto-wire two terminals
+
+NOTE: Wire shapes alone have no electrical meaning — terminals must be
+connected to the same named net to carry current.  This example pairs
+wire drawing with net labels so the circuit is both visually wired and
+electrically connected.
+
+Circuit: RC filter — VDC → R0 → C0 → GND, with IN/OUT pins.
+
+Usage::
+
+    python 10_create_wire.py <LIB>
+    python 10_create_wire.py <LIB> <CELL>
+
+Prerequisites:
+  - virtuoso-bridge service running (virtuoso-bridge start)
+  - analogLib cell masters (vdc, res, cap) available
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime
+
+from virtuoso_bridge import VirtuosoClient
+from virtuoso_bridge.virtuoso.schematic.ops import (
+    schematic_create_inst_by_master_name as inst,
+    schematic_create_pin,
+    schematic_create_wire,
+    schematic_create_wire_between_instance_terms,
+    schematic_label_instance_term as label_term,
+)
+
+
+def _create(client: VirtuosoClient, lib: str, cell: str) -> None:
+    with client.schematic.edit(lib, cell) as sch:
+        # Place instances in a row
+        sch.add(inst("analogLib", "vdc", "symbol", "V0", 0.0, 0.0, "R0"))
+        sch.add(inst("analogLib", "res", "symbol", "R0", 3.0, 0.0, "R0"))
+        sch.add(inst("analogLib", "cap", "symbol", "C0", 6.0, 0.0, "R0"))
+
+        # --- Physical wires ---
+        # Draw wires between terminals; coordinates auto-calculated from
+        # the terminal geometry of each component.
+        sch.add(schematic_create_wire_between_instance_terms("V0", "PLUS", "R0", "PLUS"))
+        sch.add(schematic_create_wire_between_instance_terms("R0", "MINUS", "C0", "PLUS"))
+
+        # --- GND path: explicit polyline ---
+        # V0 MINUS and C0 MINUS are both at x=0 and x=6 respectively.
+        # Route a horizontal wire at y=-1.5 to bridge them.
+        sch.add(schematic_create_wire([
+            (0.0, -1.5),
+            (6.0, -1.5),
+        ]))
+
+        # --- Electrical binding via net labels ---
+        # Wire shapes are purely graphical.  To give terminals a net name
+        # (so the netlister knows they are connected), place net labels.
+        sch.add(label_term("V0", "PLUS",  "VDD"))
+        sch.add(label_term("V0", "MINUS", "GND"))
+        sch.add(label_term("R0", "PLUS",  "VDD"))
+        sch.add(label_term("R0", "MINUS", "OUT"))
+        sch.add(label_term("C0", "PLUS",  "OUT"))
+        sch.add(label_term("C0", "MINUS", "GND"))
+
+        # --- Pins at key nets ---
+        sch.add(schematic_create_pin("IN",  1.5, 0.75, "R0", direction="input"))
+        sch.add(schematic_create_pin("OUT", 4.5, 0.75, "R0", direction="output"))
+
+    # Set VDC = 1.0 V
+    client.execute_skill(
+        'schHiReplace(?replaceAll t ?propName "cellName" ?condOp "==" '
+        '?propValue "vdc" ?newPropName "vdc" ?newPropValue "1.0")')
+
+    client.open_window(lib, cell, view="schematic")
+    print(f"Created {lib}/{cell}/schematic")
+    print("Wire shapes drawn by schCreateWire; nets bound by net labels")
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print(f"Usage: python {__file__} <LIB> [CELL]", file=sys.stderr)
+        return 1
+
+    lib = sys.argv[1]
+    cell = (
+        sys.argv[2]
+        if len(sys.argv) >= 3
+        else f"wire_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+    )
+
+    client = VirtuosoClient.from_env()
+    _create(client, lib, cell)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/01_virtuoso/schematic/11_read_schematic_unified.py
+++ b/examples/01_virtuoso/schematic/11_read_schematic_unified.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Demonstrate the unified read_schematic() API.
+
+read_schematic() returns topology, positions, CDF params, and notes in a
+single SKILL call — superseding the legacy read_connectivity /
+read_instance_params / read_placement functions.
+
+Usage::
+
+    python 11_read_schematic_unified.py LIB CELL            # full read
+    python 11_read_schematic_unified.py LIB CELL --no-pos   # topology only
+    python 11_read_schematic_unified.py                     # active schematic
+    python 11_read_schematic_unified.py LIB CELL --all-params
+
+Options:
+    --no-pos       Omit xy/orient/bBox (faster for large schematics)
+    --all-params   Return all CDF params without filtering
+"""
+
+from __future__ import annotations
+
+import sys
+
+from virtuoso_bridge import VirtuosoClient
+from virtuoso_bridge.virtuoso.schematic.reader import read_schematic
+
+
+def _print_result(data: dict, *, include_positions: bool) -> None:
+    instances = data.get("instances", [])
+    nets = data.get("nets", {})
+    pins = data.get("pins", {})
+    notes = data.get("notes", [])
+
+    print(f"Instances : {len(instances)}   Nets : {len(nets)}   "
+          f"Pins : {len(pins)}   Notes : {len(notes)}")
+
+    if instances:
+        name_w = max(len(i["name"]) for i in instances)
+        print(f"\n{'INSTANCE':<{name_w}}  LIB/CELL           TERMS")
+        print("-" * (name_w + 50))
+        for i in instances:
+            terms = "  ".join(f"{t}={n}" for t, n in i.get("terms", {}).items())
+            line = f"{i['name']:<{name_w}}  {i['lib']}/{i['cell']}"
+            if include_positions:
+                xy = i.get("xy", [0, 0])
+                line += f"  @({xy[0]:.1f},{xy[1]:.1f}) {i.get('orient', '?')}"
+            if terms:
+                line += f"  {terms}"
+            print(line)
+
+            params = i.get("params", {})
+            if params:
+                param_str = "  ".join(f"{k}={v}" for k, v in params.items())
+                print(f"{'':<{name_w}}  params: {param_str}")
+
+            nl = i.get("nlAction")
+            if nl:
+                print(f"{'':<{name_w}}  nlAction={nl}")
+
+    if nets:
+        net_w = max(len(n) for n in nets)
+        print(f"\n{'NET':<{net_w}}  BITS  TYPE     CONNECTIONS")
+        print("-" * (net_w + 50))
+        for name, n in nets.items():
+            conns = "  ".join(n.get("connections", []))
+            print(f"{name:<{net_w}}  {n.get('numBits', 1):<5} {n.get('sigType', '?'):<9} {conns}")
+
+    if pins:
+        pin_w = max(len(p) for p in pins)
+        print(f"\n{'PIN':<{pin_w}}  DIR           BITS")
+        print("-" * (pin_w + 20))
+        for name, p in pins.items():
+            print(f"{name:<{pin_w}}  {p['direction']:<14}{p.get('numBits', 1)}")
+
+    if notes:
+        print(f"\nNOTES ({len(notes)}):")
+        for n in notes:
+            print(f"  \"{n['text']}\"")
+
+
+def main() -> int:
+    argv = sys.argv[1:]
+    include_positions = "--no-pos" not in argv
+    all_params = "--all-params" in argv
+    argv = [a for a in argv if a not in ("--no-pos", "--all-params")]
+
+    lib = argv[0] if len(argv) >= 1 else None
+    cell = argv[1] if len(argv) >= 2 else None
+
+    client = VirtuosoClient.from_env()
+
+    if not lib or not cell:
+        lib, cell, _ = client.get_current_design()
+        if not lib:
+            print("Usage: python 11_read_schematic_unified.py LIB CELL [--no-pos] [--all-params]")
+            print("       or open a schematic in Virtuoso first.")
+            return 1
+
+    print(f"Reading {lib}/{cell}/schematic (positions={'on' if include_positions else 'off'}, "
+          f"params={'all' if all_params else 'filtered'}) ...")
+
+    kw = {"include_positions": include_positions}
+    if all_params:
+        kw["param_filters"] = None
+
+    data = read_schematic(client, lib, cell, **kw)
+
+    _print_result(data, include_positions=include_positions)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

新增 3 个 schematic 示例，补齐 API 覆盖盲区：

- **09_create_pins** — 演示 `schematic_create_pin()` 和 `schematic_create_pin_at_instance_term()` 两种 pin 创建方式，以分压电路为例
- **10_create_wire** — 演示 `schematic_create_wire()`（手动折线）和 `schematic_create_wire_between_instance_terms()`（自动走线），强调 wire 形状 + net label 配合才有电气意义
- **11_read_schematic_unified** — 演示统一 `read_schematic()` API，支持 `--no-pos`（纯拓扑）和 `--all-params`（不过滤参数）选项

## Test plan

- [ ] `python 09_create_pins.py <LIB>` — 确认 VDD/GND/OUT pin 出现在正确位置
- [ ] `python 10_create_wire.py <LIB>` — 确认 wire 连接到器件 terminal，net label 绑定 VDD/OUT/GND
- [ ] `python 11_read_schematic_unified.py <LIB> <CELL>` — 确认返回 instances/nets/pins
- [ ] `python 11_read_schematic_unified.py <LIB> <CELL> --no-pos` — 确认不含坐标
- [ ] `python 11_read_schematic_unified.py <LIB> <CELL> --all-params` — 确认返回全部 CDF 参数
