### PR TITLE
fix: progn-wrap multi-statement SKILL + open_gui_session timeout kwarg

### DIFF
--- a/src/virtuoso_bridge/virtuoso/basic/resources/ramic_bridge.il
+++ b/src/virtuoso_bridge/virtuoso/basic/resources/ramic_bridge.il
@@ -53,9 +53,16 @@ procedure(RBIpcDataHandler(ipcId data)
   ; "\n" is flushed immediately.  Without "\n", output stays in the buffer
   ; until the next newline or explicit flush.  This differs from typing
   ; directly in CIW, where the interactive loop flushes after every command.
+  ;
+  ; We wrap data in (progn ...) so multi-statement payloads run all the
+  ; way through.  Bare evalstring() parses ONE form and silently drops
+  ; the rest -- callers who paste multi-statement SKILL would see only
+  ; the first form take effect.  The progn wrap is a no-op for
+  ; single-form input and returns the last form's value for multi-form
+  ; input, matching what every Python caller already expects.
   let((result)
     when(RBEcho printf("[RAMIC Bridge (%L)] receive:%L\n" ipcId data))
-    if(errset(result=evalstring(data)) then
+    if(errset(result=evalstring(strcat("(progn " data ")"))) then
 	    ; Success: Send response with STX (0x02) start marker and RS (0x1E) end marker
 	    ipcWriteProcess(ipcId sprintf(nil "%c%L%c" intToChar(2) result intToChar(30)))
 		when(RBEcho printf("[RAMIC Bridge (%L)] return:%L\n" ipcId result))

--- a/src/virtuoso_bridge/virtuoso/maestro/lifecycle.py
+++ b/src/virtuoso_bridge/virtuoso/maestro/lifecycle.py
@@ -222,7 +222,8 @@ let((result)
 # GUI session (required for simulation)
 # ---------------------------------------------------------------------------
 
-def open_gui_session(client: VirtuosoClient, lib: str, cell: str) -> str:
+def open_gui_session(client: VirtuosoClient, lib: str, cell: str,
+                     *, timeout: int = 60) -> str:
     """Open maestro in GUI mode, ready for simulation. Returns session string.
 
     Handles all edge cases safely:
@@ -230,6 +231,11 @@ def open_gui_session(client: VirtuosoClient, lib: str, cell: str) -> str:
     2. If an Editing GUI session exists for this cell, reuses it
     3. If a Reading GUI session exists, closes it (discards changes)
     4. Opens fresh GUI + maeMakeEditable if needed
+
+    `timeout` (default 60s) bounds the deOpenCellView SKILL call.
+    The previous hard-coded 10s was below the P50 of cold maestro opens
+    we observed (15-30s for fresh views, longer when results are being
+    indexed) and surfaced as a "Socket timeout after 10s" RuntimeError.
 
     Returns the session string (e.g. "fnxSession3").
     """
@@ -264,7 +270,7 @@ def open_gui_session(client: VirtuosoClient, lib: str, cell: str) -> str:
     logger.info("Opening GUI (editable): %s/%s/maestro", lib, cell)
     r = client.execute_skill(
         f'deOpenCellView("{lib}" "{cell}" "maestro" "maestro" nil "a")',
-        timeout=10)
+        timeout=timeout)
     if r.errors or not r.output or r.output.strip() in ("nil", ""):
         raise RuntimeError(f"deOpenCellView failed for {lib}/{cell}/maestro: {r.errors}")
 


### PR DESCRIPTION
## Summary

Two one-line fixes for surprises hit during a mixed-signal-verification session:

1. **`RBIpcDataHandler` silently drops all but the first SKILL form**

   `evalstring()` parses one top-level expression. Any client that sends a multi-statement SKILL string had subsequent statements silently dropped. The natural fix is to wrap the payload in \`(progn ...)\` — a no-op for single-form input, sequenced eval for multi-form. Matches what Python helpers building compound SKILL strings already expect.

   **Repro before fix:**
   \`\`\`python
   client.execute_skill('''
     openResults(\"/path\")
     selectResults('tran)
     ocnPrint(v(\"/x\") ?output \"/tmp/foo.txt\")
   ''')
   # /tmp/foo.txt never created — only openResults runs.
   \`\`\`

2. **\`open_gui_session\` 10s timeout too short for fresh maestro views**

   Hard-coded \`timeout=10\` on the \`deOpenCellView\` call. P50 of cold maestro view opens we observed is 15-30s (longer when results are being indexed), so on perfectly healthy systems we get \"Socket timeout after 10s\" \`RuntimeError\`. Add a \`timeout\` kwarg with default 60s.

## Test plan

- [x] Single-form callers unchanged: \`(progn foo)\` returns \`foo\`'s value, identical to bare \`foo\`.
- [x] Multi-form callers now run all forms: confirmed \`openResults; selectResults; ocnPrint\` produces the expected file.
- [x] \`open_gui_session()\` still uses 10x (now 60s) tighter when caller passes \`timeout=N\` explicitly.
- [ ] (For reviewer): regression-check on a Linux Cadence install where deOpenCellView is fast — should be no observable change.

## Out of scope (filed as separate items)

This PR is intentionally narrow. Other findings from the same session
go into a tracking issue (link to follow):
- API gaps: \`create_veriloga_cell\`, \`ensure_maestro_view\`, \`set_simulator_mode\` helpers
- \`export_waveform\` failing on parametric sweep sub-points (needs API design)
- \`label_term\` cosmetic defaults
- filesystem \`.cdslck\` lock sniffer as a diagnostics utility

🤖 Generated with [Claude Code](https://claude.com/claude-code)