### PR TITLE
fix(maestro): unify timeout kwarg across lifecycle helpers

### DIFF
--- a/skills/virtuoso/references/maestro-python-api.md
+++ b/skills/virtuoso/references/maestro-python-api.md
@@ -45,15 +45,22 @@ See **[simulation-flow.md](simulation-flow.md)** for the complete 8-step guide (
 | `open_session(client, lib, cell) -> str` | `maeOpenSetup` | Background open, returns session string |
 | `close_session(client, session)` | `maeCloseSession` | Background close |
 | `find_open_session(client) -> str \| None` | `maeGetSessions` + `maeGetSetup` | Find first active session with valid test |
-| `open_gui_session(client, lib, cell) -> str` | `deOpenCellView` + `maeMakeEditable` | GUI open (required for simulation) |
-| `close_gui_session(client)` | `hiCloseWindow` | GUI close |
-| `purge_maestro_cellviews(client)` | `dbPurgeCellView` | Clean stale internal locks before opening |
+| `open_gui_session(client, lib, cell, *, timeout=60) -> str` | `deOpenCellView` + `maeMakeEditable` | GUI open (required for simulation) |
+| `close_gui_session(client, session, save=True, *, timeout=60)` | `hiCloseWindow` (+ `maeMakeEditable`/`dbPurge` as needed) | GUI close |
+| `purge_maestro_cellviews(client, *, timeout=60)` | `dbPurgeCellView` | Clean stale internal locks before opening |
 
 ```python
 session = open_session(client, "PLAYGROUND_AMP", "TB_AMP_5T_D2S_DC_AC")
 # ... do work ...
 close_session(client, session)
 ```
+
+**`timeout` kwarg** (`open_gui_session` / `close_gui_session` /
+`purge_maestro_cellviews`): bounds each blocking SKILL call in the
+helper. Default 60s — generous enough for cold maestro view opens
+(P50 15-30s on busy servers) and the close-path's `dbPurge`. Pass a
+larger value (e.g. `timeout=120`) on heavily loaded systems; pass a
+smaller one only if you have your own retry/cancel logic.
 
 ## Read — `snapshot()` (single entry)
 

--- a/src/virtuoso_bridge/virtuoso/maestro/lifecycle.py
+++ b/src/virtuoso_bridge/virtuoso/maestro/lifecycle.py
@@ -78,7 +78,7 @@ def _send_x11_alt_n(runner) -> None:
 # Cellview memory management
 # ---------------------------------------------------------------------------
 
-def _purge_maestro_cellviews(client: VirtuosoClient) -> None:
+def _purge_maestro_cellviews(client: VirtuosoClient, *, timeout: int = 60) -> None:
     """Purge all maestro cellviews from Virtuoso's virtual memory.
 
     After hiCloseWindow + maeCloseSession, the cellview may still be
@@ -89,7 +89,7 @@ def _purge_maestro_cellviews(client: VirtuosoClient) -> None:
 foreach(cv dbGetOpenCellViews()
   when(cv~>viewName == "maestro"
     errset(dbPurge(cv))))
-''', timeout=10)
+''', timeout=timeout)
 
 
 # ---------------------------------------------------------------------------
@@ -283,7 +283,7 @@ def open_gui_session(client: VirtuosoClient, lib: str, cell: str,
 
 
 def close_gui_session(client: VirtuosoClient, session: str,
-                      save: bool = True) -> None:
+                      save: bool = True, *, timeout: int = 60) -> None:
     """Close a GUI maestro session safely.
 
     Checks window state before closing:
@@ -298,6 +298,10 @@ def close_gui_session(client: VirtuosoClient, session: str,
     Args:
         save: if True and session has unsaved changes, attempt to
               save before closing. If False, always discard changes.
+        timeout: budget (seconds) for each blocking SKILL call in the
+              close path (maeMakeEditable, hiCloseWindow, dbPurge).
+              Default 60s; previously hard-coded 10-15s, which was
+              below P50 of slow operations on a busy session.
     """
     windows = _get_session_windows(client)
     target_window = None
@@ -326,7 +330,7 @@ def close_gui_session(client: VirtuosoClient, session: str,
             if not other_editing:
                 # No conflict — promote to editable, save, close
                 logger.info("Promoting Reading* session %s to editable for save", session)
-                r = client.execute_skill('maeMakeEditable()', timeout=10)
+                r = client.execute_skill('maeMakeEditable()', timeout=timeout)
                 if not r.errors:
                     client.execute_skill(f'maeSaveSetup(?session "{session}")')
                 else:
@@ -335,17 +339,18 @@ def close_gui_session(client: VirtuosoClient, session: str,
                 # Another session holds edit lock — must discard
                 logger.info("Reading* session %s has conflicts, discarding changes", session)
 
-    _close_gui_window(client, target_window, windows)
+    _close_gui_window(client, target_window, windows, timeout=timeout)
 
     # Purge cellview from memory to release internal edit lock.
     # Without this, deOpenCellView("a") on another cell may fail with
     # ASSEMBLER-8127 even after hiCloseWindow + maeCloseSession.
-    _purge_maestro_cellviews(client)
+    _purge_maestro_cellviews(client, timeout=timeout)
     logger.info("Closed GUI session: %s", session)
 
 
 def _close_gui_window(client: VirtuosoClient, window_info: dict,
-                      all_windows: list[dict] | None = None) -> None:
+                      all_windows: list[dict] | None = None,
+                      *, timeout: int = 60) -> None:
     """Close a GUI window, handling save dialogs safely.
 
     If the window has unsaved changes (*), hiCloseWindow pops a save
@@ -380,7 +385,7 @@ let((w)
   foreach(win hiGetWindowList()
     when(win~>windowNum == {wnum} w = win))
   when(w hiCloseWindow(w)))
-''', timeout=15)
+''', timeout=timeout)
 
     if dismiss_thread is not None:
         dismiss_thread.join(timeout=10)


### PR DESCRIPTION
## Summary

Follow-up to #64. PR #64 added a \`timeout\` kwarg to \`open_gui_session\`'s \`deOpenCellView\` call but left three other hard-coded short timeouts in the close path untouched. They had the same failure mode (P50 of the underlying SKILL call exceeds the hard-coded budget on busy servers, surfacing as \`Socket timeout after Ns\` \`RuntimeError\`):

| Helper | SKILL call | Old | New |
|---|---|---:|---|
| \`close_gui_session\` | \`maeMakeEditable\` | 10s | kwarg, default 60s |
| \`_close_gui_window\` | \`hiCloseWindow\` | 15s | kwarg, default 60s |
| \`_purge_maestro_cellviews\` | \`dbPurge\` foreach | 10s | kwarg, default 60s |

\`close_gui_session\` now threads its \`timeout\` kwarg through both private helpers, so a single override on the public entrypoint propagates everywhere. Default 60s matches what #64 picked for \`open_gui_session\`.

The remaining \`timeout=10\` in this file (line 391, \`dismiss_thread.join\`) is intentionally untouched — it bounds the Python X11-dialog-dismisser thread, not a SKILL call.

Also updates \`skills/virtuoso/references/maestro-python-api.md\` so the lifecycle table reflects the new kwargs.

## Test plan

- [x] Backwards-compatible: existing callers that don't pass \`timeout=\` get the new 60s default (was 10/15s — strictly more headroom).
- [x] Override threads correctly: \`close_gui_session(client, sess, timeout=120)\` reaches \`maeMakeEditable\`, \`hiCloseWindow\`, and \`dbPurge\` calls.
- [ ] (For reviewer): regression-check on a fast Linux Cadence install — should be no observable change.

## Closes

Closes the second half of #65 A2 (the \`deOpenCellView\` half landed in #64). After this merges, A1 ✅ and A2 ✅; the umbrella issue can be updated to track only the B/C/D items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)