### PR TITLE
feat(import_gds): add --use-cds-lib shortcut for -refLibList XST_CDS_LIB

### DIFF
--- a/examples/01_virtuoso/digital_import/README.md
+++ b/examples/01_virtuoso/digital_import/README.md
@@ -55,6 +55,22 @@ python import_gds.py /path/to/foo.route_tapeout.gds \
        --ref-libs   /path/to/ref_libs_dir
 ```
 
+Alternative — if the project's ``cds.lib`` already DEFINEs every
+referenced lib (std cell, IO, SRAM macro, etc.), use the ``--use-cds-lib``
+shortcut to skip maintaining a separate ``ref`` file:
+
+```
+python import_gds.py /path/to/foo.route_tapeout.gds \
+       --target-lib  DIG_OUTPUT \
+       --tech-lib    tsmcN28 \
+       --use-cds-lib
+```
+
+This passes ``-refLibList XST_CDS_LIB`` to ``strmin``, a magic literal
+that tells the tool to consult the cds.lib of its current working
+directory instead of a flat ref file.  Mutually exclusive with
+``--ref-libs``.
+
 After completion the script prints ``instances=N shapes=M bbox=...`` for
 the new ``layout`` view as a sanity check.
 

--- a/examples/01_virtuoso/digital_import/import_gds.py
+++ b/examples/01_virtuoso/digital_import/import_gds.py
@@ -12,6 +12,15 @@ Prerequisites
   ``cds.lib``.  ``strmin`` creates the cellview directories but does
   not amend ``cds.lib``.
 
+Reference libraries (pick one)
+------------------------------
+* ``--ref-libs <file>`` — point at a plain text file listing referenced
+  lib names, one per line.  Lab convention is ``<workdir>/ref``.
+* ``--use-cds-lib`` — shortcut for strmin's magic ``-refLibList
+  XST_CDS_LIB``: use every lib defined in the cds.lib resolved from
+  Virtuoso's cwd.  Convenient when the project's cds.lib is already
+  curated; avoids maintaining a separate ``ref`` file.
+
 The script prints instance/shape counts of the new layout cellview as a
 sanity check after import.
 """
@@ -46,10 +55,19 @@ def main() -> int:
         "--tech-lib", default="tsmcN28",
         help="OA library that supplies the tech file (default: tsmcN28)",
     )
-    parser.add_argument(
+    refgrp = parser.add_mutually_exclusive_group()
+    refgrp.add_argument(
         "--ref-libs", default=None,
-        help="Reference-library path passed to -refLibList (e.g. a directory "
-             "containing pre-imported standard-cell libs)",
+        help="File path passed to strmin -refLibList — a plain text file "
+             "with one referenced lib name per line (e.g. tcbn28hpcplus..., "
+             "tphn28hpcpgv18...).  Mutually exclusive with --use-cds-lib.",
+    )
+    refgrp.add_argument(
+        "--use-cds-lib", action="store_true",
+        help="Shortcut for `-refLibList XST_CDS_LIB`: tell strmin to use "
+             "EVERY lib defined in the cds.lib of its current working "
+             "directory as a reference.  Convenient when the project's "
+             "cds.lib is already curated.  Mutually exclusive with --ref-libs.",
     )
     parser.add_argument(
         "--cell", default=None,
@@ -80,7 +98,12 @@ def main() -> int:
         "-attachTechFileOfLib", shlex.quote(args.tech_lib),
         "-logFile",            "strmIn.log",
     ]
-    if args.ref_libs:
+    if args.use_cds_lib:
+        # XST_CDS_LIB is a magic literal that strmin understands as
+        # "use every lib defined in the cds.lib resolved from cwd".
+        # Not a path — must NOT be shell-quoted as a filename.
+        parts += ["-refLibList", "XST_CDS_LIB"]
+    elif args.ref_libs:
         parts += ["-refLibList", shlex.quote(args.ref_libs)]
     parts.append("-replaceBusBitChar")
     cmd = " ".join(parts)


### PR DESCRIPTION
## Motivation

`strmin` accepts a magic literal value `XST_CDS_LIB` for `-refLibList` —
when used, the tool consults the `cds.lib` of its current working
directory and treats every `DEFINE`'d lib as a referenced library, no
need for a separate ref-list file.

The wrapper already forwards `--ref-libs` verbatim to `strmin`, so today
users *can* technically do `--ref-libs XST_CDS_LIB` and it works.  But:
- The `--ref-libs` help text says "file path", which actively discourages it
- The magic literal is undocumented in the wrapper
- Discoverability is zero

## Change

- New `--use-cds-lib` boolean flag, mutually exclusive with `--ref-libs`
- When set, the wrapper passes `-refLibList XST_CDS_LIB` literally
  (NOT shell-quoted as a filename)
- Updated docstring with a new "Reference libraries (pick one)" section
- Added an `--use-cds-lib` example to README

## Verified

```
$ python import_gds.py --help    # both flags appear, marked mutex
$ python import_gds.py foo.gds --target-lib X --ref-libs y --use-cds-lib
import_gds.py: error: argument --use-cds-lib: not allowed with argument --ref-libs
```

## Trade-off captured in docstring

`--use-cds-lib` is convenient when the project's `cds.lib` is curated;
the explicit `--ref-libs <file>` is preferable when the nearby
`cds.lib` is bloated (50+ collaborator libs) — strmin will scan all of
them under `XST_CDS_LIB`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)