### PR TITLE
fix(maestro): run_and_wait works in local mode (no SSH tunnel)

### DIFF
--- a/src/virtuoso_bridge/virtuoso/maestro/reader/snapshot.py
+++ b/src/virtuoso_bridge/virtuoso/maestro/reader/snapshot.py
@@ -189,7 +189,18 @@ def _dump_run_artifacts(client: VirtuosoClient, snap_dir: Path, *,
     """
     if not (history and lib_path and scratch_root):
         return
-    runner = client._tunnel._ssh_runner
+    runner = client.ssh_runner
+    if runner is None:
+        # Local mode: this function does a remote `find | tar` + `scp`
+        # round-trip to pull per-point artifacts.  A local-fs equivalent
+        # is feasible but not yet implemented; skip rather than crash.
+        import sys as _sys
+        print(
+            "[warn] _dump_run_artifacts: snapshot skipped — local mode "
+            "not yet supported (see issue tracker for status).",
+            file=_sys.stderr,
+        )
+        return
     maestro_dir = f"{lib_path}/{cell}/{view}/results/maestro"
     log_remote = f"{maestro_dir}/{history}.log"
     hist_remote = (f"{scratch_root}/{lib}/{cell}/{view}"

--- a/src/virtuoso_bridge/virtuoso/maestro/writer.py
+++ b/src/virtuoso_bridge/virtuoso/maestro/writer.py
@@ -346,35 +346,52 @@ def run_simulation(client: VirtuosoClient, *, session: str = "",
     return _q(client, parts)
 
 
+def _remove_marker(runner, marker: str) -> None:
+    """Delete the marker file in either local or remote mode."""
+    if runner is None:
+        from pathlib import Path as _Path
+        try:
+            _Path(marker).unlink()
+        except FileNotFoundError:
+            pass
+        except OSError:
+            pass
+    else:
+        runner.run_command(f"rm -f {marker}", timeout=10)
+
+
 def _wait_until_done(client: VirtuosoClient, marker: str,
                       timeout: int = 600) -> str:
     """Internal: poll the marker file written by run_and_wait's SKILL callback.
 
     Cadence-side ``maeRunSimulation(?callback ...)`` registers a SKILL
     callback that ``echo``s ``done`` to ``marker`` when the run finishes.
-    This function ``ssh cat``s that marker every 2 s on the SSH channel,
-    keeping the SKILL channel free for other work (dialog dismissal,
-    screenshots, ...).
+    Local mode reads the file directly via stdlib; remote mode ``ssh
+    cat``s it every 2 s on the SSH channel, keeping the SKILL channel
+    free for other work (dialog dismissal, screenshots, ...).
 
     Not public — call :func:`run_and_wait` instead, which sets up the
     callback + marker and calls this helper.
     """
     import time as _time
+    from pathlib import Path as _Path
 
     runner = client.ssh_runner
-    if runner is None:
-        raise RuntimeError("No SSH connection (tunnel not started?)")
-
-    runner = client.ssh_runner
-    if runner is None:
-        raise RuntimeError("No SSH connection (tunnel not started?)")
 
     deadline = _time.monotonic() + timeout
     while _time.monotonic() < deadline:
-        r = runner.run_command(f"cat {marker} 2>/dev/null", timeout=10)
-        if r.returncode == 0 and r.stdout.strip():
-            runner.run_command(f"rm -f {marker}", timeout=10)
-            return r.stdout.strip()
+        if runner is None:
+            mp = _Path(marker)
+            if mp.exists():
+                content = mp.read_text().strip()
+                if content:
+                    _remove_marker(runner, marker)
+                    return content
+        else:
+            r = runner.run_command(f"cat {marker} 2>/dev/null", timeout=10)
+            if r.returncode == 0 and r.stdout.strip():
+                _remove_marker(runner, marker)
+                return r.stdout.strip()
         _time.sleep(2)
 
     raise TimeoutError(f"Simulation did not finish within {timeout}s")
@@ -466,13 +483,13 @@ def run_and_wait(client: VirtuosoClient, *, session: str = "",
     """
     import uuid
 
+    # runner is None in local mode (Virtuoso on the same host); _remove_marker
+    # and _wait_until_done both handle that case via local fs operations.
     runner = client.ssh_runner
-    if runner is None:
-        raise RuntimeError("No SSH connection (tunnel not started?)")
 
     nonce = uuid.uuid4().hex[:8]
     marker = f"/tmp/vb_sim_done_{nonce}"
-    runner.run_command(f"rm -f {marker}", timeout=10)
+    _remove_marker(runner, marker)
 
     # Define callback that writes marker file when simulation finishes.
     # Use system("echo ... > file") instead of outfile/fprintf to avoid
@@ -500,7 +517,7 @@ procedure(_vb_sim_done_{nonce}(session runID)
             history_name = _strip_skill_atom(history)
 
         if not history_name or history_name == "nil":
-            runner.run_command(f"rm -f {marker}", timeout=10)
+            _remove_marker(runner, marker)
             test = info.get("test", "") or "<unknown>"
             analyses = info.get("enabled_analyses", "") or "<unknown>"
             explorer = info.get("is_explorer_window", "unknown")


### PR DESCRIPTION
## Summary

A user reported that running `examples/01_virtuoso/maestro/06b_rc_simulate_and_read.py` on a host where Virtuoso runs **on the same machine** (no SSH tunnel needed) crashes with:

```
RuntimeError: No SSH connection (tunnel not started?)
  at src/virtuoso_bridge/virtuoso/maestro/writer.py:471, in run_and_wait
```

The status output of the same setup confirms `[mode] local (no SSH tunnel)` — i.e. local mode is a **first-class state** of the framework (set by `transport/tunnel.py:147` when the host is localhost), but the maestro paths weren't honoring it. Three call sites needed a local-mode branch:

- **`writer.py:_wait_until_done`** — used `ssh cat`/`rm` to poll the marker file. In local mode the marker is on the local disk; switched to `pathlib.Path` operations.
- **`writer.py:run_and_wait`** — gatekept on `ssh_runner is None` and threw. Also had a *duplicated* None-check block (cargo-cult dead code, line 364-370). Removed both.
- **`reader/snapshot.py:_dump_run_artifacts`** — directly accessed `client._tunnel._ssh_runner` with no None check, would `AttributeError`. Switched to `client.ssh_runner` property + None-check + early-return-with-warning. A local-fs snapshot equivalent is feasible but out of scope here (separate enhancement).

The fix introduces one helper, `_remove_marker(runner, marker)`, that dispatches to either `pathlib.Path.unlink` or `runner.run_command("rm -f ...")`. Both `run_and_wait` and `_wait_until_done` route through it.

## Test plan

- [x] String/runtime dry run: 6/6 cases (`logs/verify_local_mode_fix.py`, gitignored — not in this PR)
  - local `_remove_marker` deletes existing
  - local `_remove_marker` is no-op on missing
  - remote `_remove_marker` dispatches `rm -f` via runner
  - local `_wait_until_done` returns when marker appears, removes file
  - local `_wait_until_done` raises `TimeoutError` on stale marker
  - remote `_wait_until_done` polls until `cat` returns content
- [ ] **User-side smoke** (we have no local-mode Virtuoso here): rerun the original repro on the affected host
  ```
  python3 examples/01_virtuoso/maestro/06b_rc_simulate_and_read.py UMC55LP_LAB TB_RC_FILTER_*
  ```
  Expect the simulation to complete and print `[sim] Done: ...` instead of the SSH error.

## Out of scope

- Local-fs equivalent of `_dump_run_artifacts` (snapshot collection). Currently early-returns with a stderr warning. Separate enhancement.
- Other `ssh_runner`-direct call sites in `cli.py`, `bridge.py:655` (X11 helper), `spectre/runner.py` — these are remote-only paths by current design and not blocking the user's reported flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
