### PR TITLE
feat(maestro): X11 dialog dismissal + history mtime sort in local mode

### DIFF
--- a/src/virtuoso_bridge/virtuoso/basic/bridge.py
+++ b/src/virtuoso_bridge/virtuoso/basic/bridge.py
@@ -654,8 +654,13 @@ let((result winName ciwNum)
         from virtuoso_bridge.virtuoso import x11
         runner = self.ssh_runner
         if runner is None:
-            raise RuntimeError("No SSH connection (tunnel not started?)")
-        user = runner.user or os.getenv("VB_REMOTE_USER", "")
+            # Local mode: x11.dismiss_dialogs accepts runner=None and runs
+            # the helper as a local subprocess.  user is only used to
+            # namespace the remote /tmp helper copy; in local mode it is
+            # unused but kept for API symmetry.
+            user = os.getenv("USER", "") or os.getenv("USERNAME", "") or "local"
+        else:
+            user = runner.user or os.getenv("VB_REMOTE_USER", "")
         return x11.dismiss_dialogs(runner, user, display)
 
     # -- file transfer (delegates to tunnel) --------------------------------

--- a/src/virtuoso_bridge/virtuoso/maestro/lifecycle.py
+++ b/src/virtuoso_bridge/virtuoso/maestro/lifecycle.py
@@ -19,28 +19,68 @@ logger = logging.getLogger(__name__)
 # X11 key sending (for dismissing dialogs that block SKILL)
 # ---------------------------------------------------------------------------
 
+def _x11_run(runner, cmd: str, timeout: int = 5):
+    """Run a shell command via SSH if *runner* is given, else locally.
+
+    Returned object exposes ``.returncode`` / ``.stdout`` / ``.stderr``
+    in both branches so callers can be agnostic.
+    """
+    if runner is not None:
+        return runner.run_command(cmd, timeout=timeout)
+    import subprocess
+    from types import SimpleNamespace
+    try:
+        r = subprocess.run(
+            ["sh", "-c", cmd],
+            capture_output=True, text=True, timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return SimpleNamespace(returncode=124, stdout="", stderr="timeout")
+    except FileNotFoundError:
+        # No /bin/sh — Windows local mode for example.  X11 isn't usable
+        # anyway in that environment; surface a no-op rather than crash.
+        return SimpleNamespace(returncode=127, stdout="", stderr="no shell")
+    return SimpleNamespace(
+        returncode=r.returncode,
+        stdout=r.stdout or "",
+        stderr=r.stderr or "",
+    )
+
+
 def _detect_virtuoso_display(runner) -> str:
-    """Detect the DISPLAY used by the Virtuoso process."""
+    """Detect the DISPLAY used by the Virtuoso process.
+
+    Order: ``$VB_DISPLAY`` → ``/proc/<virtuoso_pid>/environ`` → in local
+    mode, the caller's own ``$DISPLAY`` (last resort: same X server as
+    the script's terminal).
+    """
     import os
     display = os.getenv("VB_DISPLAY", "")
     if display:
         return display
-    r = runner.run_command(
+    r = _x11_run(
+        runner,
         'strings /proc/$(pgrep -u $(whoami) -f "64bit/virtuoso" | head -1)/environ 2>/dev/null '
         '| grep ^DISPLAY= | head -1',
-        timeout=5)
+        timeout=5,
+    )
     display = (r.stdout or "").strip().replace("DISPLAY=", "")
+    if not display and runner is None:
+        # Local mode last-resort: assume Virtuoso shares this terminal's
+        # X server.  Same-host, same-user runs typically do.
+        display = os.getenv("DISPLAY", "")
     if not display:
         logger.warning("Cannot detect DISPLAY for X11 key sending")
     return display
 
 
 def _send_x11_key(runner, keysym: int) -> None:
-    """Send a single keypress to the Virtuoso X11 display via SSH."""
+    """Send a single keypress to the Virtuoso X11 display."""
     display = _detect_virtuoso_display(runner)
     if not display:
         return
-    runner.run_command(
+    _x11_run(
+        runner,
         f'DISPLAY={display} python2.7 -c "'
         f'import ctypes,ctypes.util;'
         f'xlib=ctypes.cdll.LoadLibrary(ctypes.util.find_library(chr(88)+chr(49)+chr(49)));'
@@ -50,7 +90,8 @@ def _send_x11_key(runner, keysym: int) -> None:
         f'xtst.XTestFakeKeyEvent(dpy,kc,True,0);'
         f'xtst.XTestFakeKeyEvent(dpy,kc,False,0);'
         f'xlib.XFlush(dpy);xlib.XCloseDisplay(dpy)"',
-        timeout=5)
+        timeout=5,
+    )
 
 
 def _send_x11_alt_n(runner) -> None:
@@ -58,7 +99,8 @@ def _send_x11_alt_n(runner) -> None:
     display = _detect_virtuoso_display(runner)
     if not display:
         return
-    runner.run_command(
+    _x11_run(
+        runner,
         f'DISPLAY={display} python2.7 -c "'
         f'import ctypes,ctypes.util;'
         f'xlib=ctypes.cdll.LoadLibrary(ctypes.util.find_library(chr(88)+chr(49)+chr(49)));'
@@ -71,7 +113,8 @@ def _send_x11_alt_n(runner) -> None:
         f'xtst.XTestFakeKeyEvent(dpy,kn,False,0);'
         f'xtst.XTestFakeKeyEvent(dpy,ka,False,0);'
         f'xlib.XFlush(dpy);xlib.XCloseDisplay(dpy)"',
-        timeout=5)
+        timeout=5,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -367,18 +410,20 @@ def _close_gui_window(client: VirtuosoClient, window_info: dict,
 
     dismiss_thread = None
     if will_pop_dialog:
+        # runner is None in local mode; _send_x11_alt_n handles both
+        # SSH and local subprocess paths internally.
         runner = client.ssh_runner
-        if runner is not None:
-            def _dismiss_save_dialog():
-                """Send Alt+N after a short delay to dismiss save dialog."""
-                _time.sleep(0.5)
-                # Alt+N selects "No" (Don't Save) on save confirmation dialogs.
-                # Escape only cancels the dialog without closing the window.
-                _send_x11_alt_n(runner)
 
-            dismiss_thread = threading.Thread(target=_dismiss_save_dialog, daemon=True)
-            dismiss_thread.start()
-            logger.info("Started dismiss thread for modified window %d", wnum)
+        def _dismiss_save_dialog():
+            """Send Alt+N after a short delay to dismiss save dialog."""
+            _time.sleep(0.5)
+            # Alt+N selects "No" (Don't Save) on save confirmation dialogs.
+            # Escape only cancels the dialog without closing the window.
+            _send_x11_alt_n(runner)
+
+        dismiss_thread = threading.Thread(target=_dismiss_save_dialog, daemon=True)
+        dismiss_thread.start()
+        logger.info("Started dismiss thread for modified window %d", wnum)
 
     client.execute_skill(f'''
 let((w)

--- a/src/virtuoso_bridge/virtuoso/maestro/reader/bundle.py
+++ b/src/virtuoso_bridge/virtuoso/maestro/reader/bundle.py
@@ -263,13 +263,22 @@ def _first_nonnil_string(val: str) -> str:
 
 def _fetch_mtimes_via_shell(client: VirtuosoClient, remote_dir: str,
                              ) -> list[tuple[str, int]]:
-    """``find -printf`` → ``[(basename, unix_mtime), ...]`` via one
-    ssh round-trip.  Returns ``[]`` on any failure (caller falls back
-    to natural-sort-by-name)."""
+    """``find -printf`` (remote) or ``Path.stat`` (local) →
+    ``[(basename, unix_mtime), ...]``.  Returns ``[]`` on any failure
+    (caller falls back to natural-sort-by-name)."""
     import re as _re
     runner = getattr(getattr(client, "_tunnel", None), "_ssh_runner", None)
     if runner is None:
-        return []
+        # Local mode: Virtuoso shares the filesystem; iterate directly.
+        from pathlib import Path as _Path
+        try:
+            d = _Path(remote_dir)
+            if not d.is_dir():
+                return []
+            return [(p.name, int(p.stat().st_mtime))
+                    for p in d.iterdir() if p.is_file()]
+        except OSError:
+            return []
     # %T@ prints unix mtime as a float; %f is basename. '\n' between
     # rows, ' ' between fields.
     cmd = (f"find {remote_dir} -maxdepth 1 -type f "

--- a/src/virtuoso_bridge/virtuoso/x11.py
+++ b/src/virtuoso_bridge/virtuoso/x11.py
@@ -30,9 +30,36 @@ def _get_display(display: str | None) -> str | None:
     return os.getenv("VB_DISPLAY") or None
 
 
-def _detect_remote_python(runner: SSHRunner) -> str:
-    """Find a Python 3 interpreter on the remote host."""
-    r = runner.run_command(
+def _run(runner: SSHRunner | None, cmd: str, timeout: int):
+    """Dispatch a shell command via SSH or local subprocess.
+
+    Returns an object exposing ``.returncode`` / ``.stdout`` / ``.stderr``
+    so the call sites can be agnostic to mode.
+    """
+    if runner is not None:
+        return runner.run_command(cmd, timeout=timeout)
+    import subprocess
+    from types import SimpleNamespace
+    try:
+        r = subprocess.run(
+            ["sh", "-c", cmd],
+            capture_output=True, text=True, timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return SimpleNamespace(returncode=124, stdout="", stderr="timeout")
+    except FileNotFoundError:
+        return SimpleNamespace(returncode=127, stdout="", stderr="no shell")
+    return SimpleNamespace(
+        returncode=r.returncode,
+        stdout=r.stdout or "",
+        stderr=r.stderr or "",
+    )
+
+
+def _detect_remote_python(runner: SSHRunner | None) -> str:
+    """Find a Python 3 interpreter (remote host or local)."""
+    r = _run(
+        runner,
         'python3 --version 2>/dev/null && echo "CMD:python3" || '
         '(python --version 2>&1 | grep -q "Python 3" && echo "CMD:python") || '
         'echo "CMD:NONE"',
@@ -44,8 +71,15 @@ def _detect_remote_python(runner: SSHRunner) -> str:
     return "python3"  # fallback, will fail with clear error
 
 
-def _ensure_helper(runner: SSHRunner, user: str) -> str:
-    """Upload the helper script if not already present."""
+def _ensure_helper(runner: SSHRunner | None, user: str) -> str:
+    """Resolve the path to the helper script.
+
+    Remote: upload to ``/tmp/virtuoso_bridge_<user>/`` if not already there.
+    Local: the helper file is part of the installed package — return its
+    on-disk path directly, no copy needed.
+    """
+    if runner is None:
+        return str(_HELPER_SCRIPT)
     remote_path = f"/tmp/virtuoso_bridge_{user}/x11_dismiss_dialog.py"
     remote_dir = str(Path(remote_path).parent)
     runner.run_command(f"mkdir -p {remote_dir}")
@@ -54,11 +88,11 @@ def _ensure_helper(runner: SSHRunner, user: str) -> str:
 
 
 def find_dialogs(
-    runner: SSHRunner,
+    runner: SSHRunner | None,
     user: str,
     display: str | None = None,
 ) -> list[dict[str, Any]]:
-    """Find blocking dialog windows on the remote X11 display.
+    """Find blocking dialog windows on the X11 display.
 
     Returns list of dicts: [{"window_id", "title", "x", "y", "w", "h"}, ...]
     """
@@ -69,12 +103,12 @@ def find_dialogs(
     cmd = f"{py} {script}"
     if resolved:
         cmd += f" {resolved}"
-    result = runner.run_command(cmd, timeout=15)
+    result = _run(runner, cmd, timeout=15)
     return _parse_output(result.stdout)
 
 
 def dismiss_dialogs(
-    runner: SSHRunner,
+    runner: SSHRunner | None,
     user: str,
     display: str | None = None,
 ) -> list[dict[str, Any]]:
@@ -95,7 +129,7 @@ def dismiss_dialogs(
     cmd = f"{env_prefix}{py} {script} --dismiss"
     if resolved:
         cmd += f" {resolved}"
-    result = runner.run_command(cmd, timeout=15)
+    result = _run(runner, cmd, timeout=15)
     return _parse_output(result.stdout)
 
 


### PR DESCRIPTION
## Summary

Companion to #73 (run_and_wait) and #74 (snapshot). Closes the **two remaining "silent functional gap" cases** the maestro local-mode audit surfaced:

### Gap 1 — modal-dialog auto-dismissal (`lifecycle.py:370`)

`open_session` / `open_gui_session` start a side thread that sends X11 Alt+N when a "Save changes? Y/N" dialog is expected. The whole thread was gated on `ssh_runner is not None` — meaning in local mode any unexpected modal would block the SKILL channel forever, with no auto-recovery.

### Gap 2 — history mtime sort (`bundle.py:_fetch_mtimes_via_shell`)

Returned `[]` immediately when `ssh_runner is None`, forcing the caller to fall back to natural-sort-by-name. That mis-orders `Interactive.10` < `Interactive.2`.

## Approach

Both `virtuoso/x11.py` and `maestro/lifecycle.py` got a uniform `_run`-style helper that dispatches:

- `runner is not None` → `runner.run_command(...)` (existing SSH behaviour, unchanged)
- `runner is None` → `subprocess.run(["sh", "-c", cmd], ...)` (new local branch)

`x11._ensure_helper` in local mode skips the upload and returns the package's local helper-script path directly. `_detect_virtuoso_display` adds a final fallback to the script's own `$DISPLAY` (typical for same-host, same-user runs). `bridge.dismiss_dialog` no longer raises when `ssh_runner is None` — `user` is sourced from `$USER` / `$USERNAME` for API symmetry.

`bundle._fetch_mtimes_via_shell` now uses `Path.iterdir() + p.stat().st_mtime` in local mode — same shape of return value, no caller changes.

## Files

| File | Change |
|---|---|
| `virtuoso/maestro/reader/bundle.py` | `_fetch_mtimes_via_shell` local fs fallback |
| `virtuoso/maestro/lifecycle.py` | `_x11_run` dispatch helper; `_detect_virtuoso_display` / `_send_x11_*` route through it; auto-dismiss thread no longer gated on runner |
| `virtuoso/x11.py` | `_run` dispatch helper; `_detect_remote_python` / `_ensure_helper` / `find_dialogs` / `dismiss_dialogs` all mode-aware |
| `virtuoso/basic/bridge.py` | `dismiss_dialog` no-raise when `ssh_runner is None` |

## Test plan

- [x] Dispatch dry-run: 13/13 (`logs/verify_x11_local_dispatch.py`, gitignored)
  - bundle.local: mtime, file-only filter, nonexistent-dir → `[]`
  - lifecycle._x11_run: both dispatch branches
  - lifecycle.display: VB_DISPLAY > /proc > $DISPLAY > empty fallback chain
  - x11._ensure_helper local resolution
  - x11._run: both dispatch branches
  - bridge.dismiss_dialog: no-raise in local mode
- [ ] **User-side smoke**: on a local-mode host, intentionally open a "Save changes?" dialog (e.g. close a modified Maestro session) and confirm Alt+N gets sent — modal closes without blocking SKILL.
- [ ] **User-side smoke**: list histories of a session with `Interactive.{1,2,...,10}` and confirm sort order is mtime-based, not lexicographic.

## Out of scope

`spectre/runner.py` and `cli.py` spectre subcommand still require SSH by current design (Spectre as a remote simulation service). If local-spectre is wanted, that's a separate audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
