### PR TITLE
fix(spectre): wire sweep parser + NaN fallback + docstring (PR #76 follow-up)

### DIFF
--- a/src/virtuoso_bridge/spectre/parsers.py
+++ b/src/virtuoso_bridge/spectre/parsers.py
@@ -210,8 +210,24 @@ def parse_sweep_psf_directory(output_dir: Path) -> dict[int, dict[str, Any]]:
        ``<raw>/sw1-001_tran.tran.tran``
        ...
 
-    Returns ``{point_index: {signal: values}}`` where point_index starts at 1.
-    Returns empty dict if no sweep subdirectories found.
+    Returns ``{point_index: {signal: values}}`` where point_index starts
+    at 1.  Returns empty dict if no sweep layout is recognised — caller
+    should then fall back to :func:`parse_psf_ascii_directory` for
+    single-point output.
+
+    Note: this function is wired into :class:`SpectreSimulator` already —
+    sweep results surface via ``result.metadata["sweep_points"]``.
+    Direct callers only need this entry point when reading raw output
+    dirs outside the simulator class.
+
+    Example::
+
+        >>> from virtuoso_bridge.spectre.parsers import parse_sweep_psf_directory
+        >>> sweep = parse_sweep_psf_directory(Path("/tmp/sim/raw"))
+        >>> if sweep:
+        ...     for pt_idx, signals in sorted(sweep.items()):
+        ...         vout_final = signals["v_out"][-1]
+        ...         print(f"point {pt_idx}: v_out(t_end) = {vout_final}")
     """
     scan_root = _spectre_psf_scan_root(output_dir)
     sweep_data: dict[int, dict[str, Any]] = {}
@@ -410,6 +426,12 @@ def _parse_psf_swept_data(
 
     # Pass 2: Step-interpolate — build time vector and per-signal vectors.
     # Each time-step boundary resets which signals to record at that step.
+    # Signals not yet seen at a snapshot point use NaN, not 0.0 — a real
+    # 0V reading and a "this signal hasn't appeared yet in the stream"
+    # state are otherwise indistinguishable to consumers.
+    import math as _math
+    _MISSING = _math.nan
+
     time_values: list[float | complex] = []
     # Current value of each signal (carry-forward / step-interpolation)
     signal_state: dict[str, float | complex] = {}
@@ -423,7 +445,7 @@ def _parse_psf_swept_data(
             # Time-step boundary: snapshot all signals at the previous step
             if time_values:
                 for name in trace_names:
-                    signal_series[name].append(signal_state.get(name, 0.0))
+                    signal_series[name].append(signal_state.get(name, _MISSING))
             time_values.append(value)  # type: ignore[arg-type]
         else:
             signal_state[key] = value  # type: ignore[assignment]
@@ -431,7 +453,7 @@ def _parse_psf_swept_data(
     # Snapshot at the last time step
     if time_values:
         for name in trace_names:
-            signal_series[name].append(signal_state.get(name, 0.0))
+            signal_series[name].append(signal_state.get(name, _MISSING))
 
     data: dict[str, list[float | complex]] = {sweep_var: time_values}
     data.update(signal_series)

--- a/src/virtuoso_bridge/spectre/runner.py
+++ b/src/virtuoso_bridge/spectre/runner.py
@@ -16,7 +16,10 @@ from typing import Any, NamedTuple
 
 from virtuoso_bridge.env import load_vb_env
 from virtuoso_bridge.models import ExecutionStatus, SimulationResult
-from virtuoso_bridge.spectre.parsers import parse_psf_ascii_directory
+from virtuoso_bridge.spectre.parsers import (
+    parse_psf_ascii_directory,
+    parse_sweep_psf_directory,
+)
 from virtuoso_bridge.transport.tunnel import _is_localhost
 from virtuoso_bridge.transport.remote_paths import (
     default_remote_spectre_work_dir,
@@ -410,14 +413,22 @@ def _build_simulation_result(
         status = ExecutionStatus.SUCCESS
 
     data: dict[str, Any] = {}
+    sweep_data: dict[int, dict[str, Any]] = {}
     if output_dir and output_dir.exists() and output_format == "psfascii":
         data = parse_psf_ascii_directory(output_dir)
+        sweep_data = parse_sweep_psf_directory(output_dir)
 
     metadata: dict[str, Any] = {
         "returncode": run_result.returncode,
         "output_dir": str(output_dir) if output_dir and output_dir.exists() else None,
         "output_files": output_files,
     }
+    if sweep_data:
+        # Per-point sweep results live in metadata to keep `data` flat
+        # for the common single-point caller.  Sweep-aware consumers
+        # check `result.metadata.get("sweep_points")` -- shape is
+        # `{point_index: {signal_name: [values]}, ...}`.
+        metadata["sweep_points"] = sweep_data
     if extra_metadata:
         metadata.update(extra_metadata)
 


### PR DESCRIPTION
## Summary

Follow-up to #76 (merged in e6e9c77). Closes three of the five items called out in the post-merge review comment:

**1. Wire `parse_sweep_psf_directory` into `runner.py`** — it was added as a public function in #76 but had no caller, so X/LX sweep results never surfaced end-to-end through `SimulationResult`. Now `_build_simulation_result` calls it and stashes the result under `metadata["sweep_points"]` (shape: `{point_index: {signal_name: [values]}}`). `result.data` continues to hold single-point output exactly as before — existing consumers don't need source changes.

**2. Replace `signal_state.get(name, 0.0)` with `math.nan`** — the 0.0 default is indistinguishable from a real 0V reading. NaN makes "signal absent at this time step" explicit; consumers can `isnan()`-check, and `sum()`/numpy ops will propagate the NaN rather than silently dilute averages with phantom zeros.

**3. Add usage example to `parse_sweep_psf_directory` docstring** — points readers at the `metadata["sweep_points"]` path for the `SpectreSimulator` flow, so they don't reimplement what's already wired.

Out of scope (deferred to separate PR): fixture-based parser test infrastructure (the structural gap noted in the review comment) — that's larger and worth its own dedicated commit message.

## Test plan

- [x] Dry run, 11/11 cases (`logs/verify_spectre_followup.py`, gitignored)
  - NaN: time vector intact; signal always present unchanged; signal absent at first step → `[nan, 0.5, 0.7]`
  - Subdirectory layout (`sw1.sweep1/<idx>/`) → 3 points 1-indexed, values correct
  - Flat layout (`sw1-000_*` X/LX) → 3 points 1-indexed (0-indexed raw bumped)
  - Non-sweep directory → empty dict (caller falls back to single-point parser)
  - `_build_simulation_result` populates `metadata["sweep_points"]` for sweep dir
  - PR #76's read-in false-positive fix still holds (`"Circuit read-in complete"` → no spurious error)
- [ ] **User-side smoke**: real Spectre X/LX run on a Cadence box, verify `result.metadata["sweep_points"]` matches the expected per-point values

## Notes for future readers

- `metadata["sweep_points"]` is the **only** place sweep-aware consumers should read. `data` stays single-point flat for the common path.
- NaN propagation: any consumer doing `numpy.array(result.data["sig"])` will get `dtype=float64` with NaNs preserved, no dtype object fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
