### PR TITLE
test(spectre): regression tests for PR #76/#77 + tests/ scaffolding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
 # Microsoft Visio via COM, Windows-only.  The pure model layer in
 # `virtuoso/visio.py` has no extra deps and stays importable everywhere.
 visio = ["pywin32; sys_platform == 'win32'"]
+# Test runner.  Install with `pip install -e .[dev]` then `pytest`.
+dev = ["pytest>=7.0"]
 
 [project.scripts]
 virtuoso-bridge = "virtuoso_bridge.cli:main"
@@ -29,3 +31,8 @@ where = ["src"]
 "virtuoso_bridge.resources" = [".env_template"]
 "virtuoso_bridge.virtuoso.basic.resources" = ["*.il", "*.py"]
 "virtuoso_bridge.virtuoso.maestro" = ["*.yaml"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]
+addopts = "-q"

--- a/tests/test_spectre_parsers.py
+++ b/tests/test_spectre_parsers.py
@@ -1,0 +1,229 @@
+"""Regression tests for ``virtuoso_bridge.spectre.parsers`` and the
+sweep-data wiring in ``_build_simulation_result``.
+
+Covers behavior introduced in:
+  * #76 (chenzc24): X/LX flat sweep layout, GROUP→signal mapping in
+    ``_parse_psf_swept_data``, delta-compressed PSF handling, and the
+    "Circuit read-in complete" false-positive fix in the runner.
+  * #77 (follow-up): wiring ``parse_sweep_psf_directory`` into
+    ``_build_simulation_result`` so sweep results surface via
+    ``metadata["sweep_points"]``, and replacing the silent ``0.0``
+    fallback with ``math.nan`` for late-appearing signals.
+
+These tests synthesize PSF ASCII text and directory layouts on the
+fly — no real Spectre install needed.  When real PSF samples become
+available, drop them into ``tests/fixtures/`` and add corresponding
+parametrized tests.
+"""
+from __future__ import annotations
+
+import math
+from types import SimpleNamespace
+
+import pytest
+
+from virtuoso_bridge.spectre.parsers import (
+    _parse_psf_swept_data,
+    parse_sweep_psf_directory,
+)
+from virtuoso_bridge.spectre.runner import _build_simulation_result
+
+
+# ---------------------------------------------------------------------------
+# _parse_psf_swept_data — delta-compressed + late-appearing signals
+# ---------------------------------------------------------------------------
+
+PSF_TEXT_LATE_SIGNAL = """\
+HEADER
+PROPERTIES
+SWEEP
+"time" 1
+TRACE
+"sig_a" "V"
+"sig_b" "V"
+VALUE
+"time" 0.0
+"sig_a" 1.0
+"time" 1e-9
+"sig_a" 1.5
+"sig_b" 0.5
+"time" 2e-9
+"sig_a" 2.0
+"sig_b" 0.7
+END
+"""
+PSF_SECTIONS_LATE_SIGNAL = {
+    "HEADER": 0,
+    "PROPERTIES": 1,
+    "SWEEP": 2,
+    "TRACE": 4,
+    "VALUE": 7,
+    "END": 16,
+}
+
+
+@pytest.fixture
+def parsed_late_signal():
+    lines = PSF_TEXT_LATE_SIGNAL.splitlines()
+    return _parse_psf_swept_data(lines, len(lines), PSF_SECTIONS_LATE_SIGNAL)
+
+
+def test_swept_time_vector(parsed_late_signal):
+    assert parsed_late_signal["time"] == [0.0, 1e-9, 2e-9]
+
+
+def test_swept_signal_always_present_unchanged(parsed_late_signal):
+    assert parsed_late_signal["sig_a"] == [1.0, 1.5, 2.0]
+
+
+def test_swept_signal_late_first_step_is_nan(parsed_late_signal):
+    """Signal absent at the first time step must read NaN, not 0.0.
+
+    Regression of PR #77: the old `signal_state.get(name, 0.0)`
+    fallback was indistinguishable from a real 0V reading.
+    """
+    sig_b = parsed_late_signal["sig_b"]
+    assert len(sig_b) == 3
+    assert math.isnan(sig_b[0])
+    assert sig_b[1] == 0.5
+    assert sig_b[2] == 0.7
+
+
+# ---------------------------------------------------------------------------
+# parse_sweep_psf_directory — both layouts
+# ---------------------------------------------------------------------------
+
+_PSF_TEMPLATE = """\
+HEADER
+PROPERTIES
+SWEEP
+"time" 1
+TRACE
+"v_out" "V"
+VALUE
+"time" 0.0
+"v_out" {a}
+"time" 1e-9
+"v_out" {b}
+END
+"""
+
+
+@pytest.fixture
+def sweep_dir_subdir(tmp_path):
+    """Classic Spectre layout: ``sw1.sweep1/<idx>/<file>.tran.tran.tran``."""
+    for pt in (1, 2, 3):
+        d = tmp_path / "sw1.sweep1" / str(pt)
+        d.mkdir(parents=True)
+        (d / "tran.tran.tran").write_text(
+            _PSF_TEMPLATE.format(a=pt * 0.5, b=pt * 1.0)
+        )
+    return tmp_path
+
+
+@pytest.fixture
+def sweep_dir_flat(tmp_path):
+    """Spectre X/LX flat layout: ``sw1-NNN_<file>.tran.tran.tran``."""
+    for raw_idx in (0, 1, 2):
+        f = tmp_path / f"sw1-{raw_idx:03d}_tran.tran.tran"
+        # Single-step PSF for compact fixture
+        f.write_text(
+            f"""HEADER
+PROPERTIES
+SWEEP
+"time" 1
+TRACE
+"v_out" "V"
+VALUE
+"time" 0.0
+"v_out" {(raw_idx + 1) * 0.3}
+END
+"""
+        )
+    return tmp_path
+
+
+def test_sweep_subdir_layout_indexes(sweep_dir_subdir):
+    sweep = parse_sweep_psf_directory(sweep_dir_subdir)
+    assert sorted(sweep.keys()) == [1, 2, 3]
+
+
+def test_sweep_subdir_layout_values(sweep_dir_subdir):
+    sweep = parse_sweep_psf_directory(sweep_dir_subdir)
+    # pt=2 → v_out values [2*0.5, 2*1.0] = [1.0, 2.0]
+    assert sweep[2]["v_out"] == [1.0, 2.0]
+
+
+def test_sweep_flat_layout_bumps_to_1_indexed(sweep_dir_flat):
+    """Spectre X/LX uses 0-indexed raw filenames; the parser must
+    convert to 1-indexed point numbers to match the classic
+    ``sw1.sweep1/N/`` convention so sweep-aware consumers don't
+    have to special-case the layout source."""
+    sweep = parse_sweep_psf_directory(sweep_dir_flat)
+    assert sorted(sweep.keys()) == [1, 2, 3]
+    # raw_idx 0 → point 1, value (0+1)*0.3 = 0.3
+    assert sweep[1]["v_out"] == [0.3]
+
+
+def test_sweep_dir_no_layout_returns_empty(tmp_path):
+    """Single-point output (no ``sw*`` prefix anywhere) returns an
+    empty dict — caller falls back to ``parse_psf_ascii_directory``."""
+    (tmp_path / "tran.tran.tran").write_text("HEADER\nEND\n")
+    assert parse_sweep_psf_directory(tmp_path) == {}
+
+
+# ---------------------------------------------------------------------------
+# _build_simulation_result — runner.py wiring
+# ---------------------------------------------------------------------------
+
+def _fake_run_result(output_dir, *, returncode=0, stdout="", stderr=""):
+    return SimpleNamespace(
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+        output_dir=output_dir,
+        execution_time=0.1,
+    )
+
+
+def test_build_result_populates_sweep_points(sweep_dir_subdir):
+    """PR #77: sweep results must surface via ``metadata['sweep_points']``."""
+    run = _fake_run_result(
+        sweep_dir_subdir,
+        stdout="Circuit read-in complete\nsimulation completed.\n",
+    )
+    result = _build_simulation_result(
+        run, output_format="psfascii", extra_metadata=None,
+    )
+    sweep_meta = result.metadata.get("sweep_points")
+    assert sweep_meta is not None
+    assert sorted(sweep_meta.keys()) == [1, 2, 3]
+
+
+def test_build_result_no_readin_false_positive(sweep_dir_subdir):
+    """PR #76: 'Circuit read-in complete' is normal Spectre output and
+    must NOT produce a 'netlist read error' entry."""
+    run = _fake_run_result(
+        sweep_dir_subdir,
+        stdout="Circuit read-in complete\nsimulation completed.\n",
+    )
+    result = _build_simulation_result(
+        run, output_format="psfascii", extra_metadata=None,
+    )
+    err_text = " ".join(result.errors).lower()
+    assert "netlist read error" not in err_text
+
+
+def test_build_result_actual_readin_error_still_flagged(tmp_path):
+    """Regression guard: an actual 'error reading' message must still
+    be classified as a netlist read error."""
+    run = _fake_run_result(
+        tmp_path,
+        stdout="error reading netlist: cannot resolve include\n",
+        returncode=1,
+    )
+    result = _build_simulation_result(
+        run, output_format="psfascii", extra_metadata=None,
+    )
+    err_text = " ".join(result.errors).lower()
+    assert "netlist read error" in err_text


### PR DESCRIPTION
## Summary

Closes the structural test gap that #76 + #77 surfaced — repo had **zero** automated tests despite spectre parser flowing in non-trivial behavior (delta-compressed PSF, GROUP→signal mapping, X/LX flat sweep layout, NaN fallback for missing signals).

This PR adds:

1. **`tests/` scaffolding**: `tests/__init__.py`, `pyproject.toml` `[tool.pytest.ini_options]` with `pythonpath=["src"]` + `testpaths=["tests"]` so `pytest` works from repo root without `pip install -e .`. Optional-dep `dev = ["pytest>=7.0"]`.
2. **`tests/test_spectre_parsers.py`**: 10 regression tests covering the #76 + #77 surface area.

## Coverage matrix

| Test | Guards against |
|---|---|
| `test_swept_time_vector` | sweep var collection regression |
| `test_swept_signal_always_present_unchanged` | classic always-present-signal path stays correct after PR #76's two-pass rewrite |
| `test_swept_signal_late_first_step_is_nan` | **PR #77 fix**: silent `0.0` fallback gone, late-appearing signal reads NaN |
| `test_sweep_subdir_layout_indexes` / `_values` | classic `sw1.sweep1/N/` layout still parses |
| `test_sweep_flat_layout_bumps_to_1_indexed` | **PR #76 X/LX support**: flat `sw1-NNN_*` files map 0→1 indexed |
| `test_sweep_dir_no_layout_returns_empty` | single-point fallback contract |
| `test_build_result_populates_sweep_points` | **PR #77 wiring**: sweep results land in `metadata["sweep_points"]` |
| `test_build_result_no_readin_false_positive` | **PR #76 fix**: "Circuit read-in complete" doesn't trigger spurious error |
| `test_build_result_actual_readin_error_still_flagged` | regression guard: a real "error reading" must still be caught |

## Approach

Synthesizes PSF ASCII text and directory layouts in-memory (`tmp_path` fixture). No real Spectre install needed. When real PSF samples surface from users, drop them in `tests/fixtures/` and parametrize over sample paths — that's the "phase 2" of this test foundation, single-PR follow-up.

## Test plan

- [x] `pytest` from repo root → 10/10 pass on Python 3.11.9 (Windows venv)
- [ ] Run on Linux (CI not yet configured — separate issue)
- [ ] Add real PSF fixture files when available (separate PR)

## Out of scope

- CI integration (GitHub Actions workflow). The test infrastructure is in place; wiring it to CI is a separate decision (compute, secrets, where to run).
- Coverage of other modules: `transport/`, `virtuoso/maestro/`, `virtuoso/x11.py`. Each has its own structural complexity worth tests; should be separate PRs to keep review surface focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
