### PR TITLE
feat(cli): add  command for executing SKILL .il files

### DIFF
--- a/src/virtuoso_bridge/cli.py
+++ b/src/virtuoso_bridge/cli.py
@@ -631,6 +631,47 @@ def _make_ssh_runner() -> tuple["SSHRunner", str]:
                      jump_host=jump_host, jump_user=jump_user), remote_user
 
 
+def cli_load(*, file: str, timeout: int = 60, quiet: bool = False) -> int:
+    """Execute a SKILL .il file in the running Virtuoso session.
+
+    The daemon already wraps multi-line SKILL into a temp file + load()
+    + capture-last-expression dance internally (see
+    ``ramic_bridge_daemon_3.py``), so we just hand it the file content
+    as a single ``execute_skill`` call.  No upload step needed even in
+    SSH mode.
+
+    Returns: 0 on success, 1 on SKILL-side error, 2 on missing file.
+    """
+    import sys
+    from pathlib import Path
+    from virtuoso_bridge import VirtuosoClient
+
+    # Check file before loading env -- missing/empty file is a frequent
+    # user-side typo; failing fast avoids the "using .env: ..." print
+    # before the actual error.
+    p = Path(file)
+    if not p.is_file():
+        print(f"ERROR: file not found: {p}", file=sys.stderr)
+        return 2
+    skill_code = p.read_text(encoding="utf-8")
+    if not skill_code.strip():
+        print(f"ERROR: file is empty: {p}", file=sys.stderr)
+        return 2
+
+    _load_cli_env()
+    client = VirtuosoClient.from_env(profile=_get_cli_profile())
+    result = client.execute_skill(skill_code, timeout=timeout)
+
+    if result.errors:
+        for err in result.errors:
+            print(f"SKILL error: {err}", file=sys.stderr)
+        return 1
+
+    if not quiet and result.output:
+        print(result.output)
+    return 0
+
+
 def cli_dismiss_dialog() -> int:
     """Find and dismiss blocking Virtuoso GUI dialogs via X11."""
     _load_cli_env()
@@ -939,6 +980,29 @@ def build_parser() -> argparse.ArgumentParser:
                         help="Connection profile (reads VB_*_<profile> env vars)")
         sp.add_argument("--env", default=None,
                         help="Explicit .env file path (highest priority)")
+    sp_load = subparsers.add_parser(
+        "load",
+        help="Execute a SKILL .il file in the running Virtuoso session",
+        description=(
+            "Reads the file's contents and runs them as a single SKILL "
+            "block in the daemon's CIW; prints the value of the last "
+            "expression on stdout, errors on stderr.  Useful as a 'Run "
+            "File' target from VSCode (.vscode/tasks.json):\n"
+            '  { "label": "Load SKILL", "type": "shell",\n'
+            '    "command": "virtuoso-bridge load \\"${file}\\"" }'
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sp_load.add_argument("file", help="Path to the .il file to execute")
+    sp_load.add_argument("-p", "--profile", default=None,
+                         help="Connection profile (reads VB_*_<profile> env vars)")
+    sp_load.add_argument("--env", default=None,
+                         help="Explicit .env file path (highest priority)")
+    sp_load.add_argument("--timeout", type=int, default=60,
+                         help="SKILL execution timeout in seconds (default: 60)")
+    sp_load.add_argument("--quiet", action="store_true",
+                         help="Suppress printing the SKILL return value")
+
     sp_dismiss = subparsers.add_parser(
         "dismiss-dialog", help="Find and dismiss blocking Virtuoso GUI dialogs")
     sp_dismiss.add_argument("-p", "--profile", default=None,
@@ -1045,6 +1109,11 @@ def main(argv: list[str] | None = None) -> int:
         "restart": cli_restart,
         "status": cli_status,
         "license": cli_license,
+        "load": lambda: cli_load(
+            file=getattr(args, "file"),
+            timeout=getattr(args, "timeout", 60),
+            quiet=getattr(args, "quiet", False),
+        ),
         "dismiss-dialog": cli_dismiss_dialog,
         "screenshot": cli_screenshot,
         "windows": cli_windows,

--- a/tests/test_cli_load.py
+++ b/tests/test_cli_load.py
@@ -1,0 +1,42 @@
+"""Tests for ``virtuoso-bridge load`` CLI command.
+
+Covers the user-side input-validation paths that don't need a running
+daemon: missing file and empty file return non-zero exit codes with
+stderr messages, before any env / client instantiation happens.
+
+Daemon-dependent paths (successful execute_skill, SKILL error
+classification) require a real Virtuoso install and are out of scope
+for this unit-test layer.
+"""
+from __future__ import annotations
+
+from virtuoso_bridge.cli import main
+
+
+def test_load_missing_file_returns_2(tmp_path, capsys):
+    rc = main(["load", str(tmp_path / "nonexistent.il")])
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert "not found" in captured.err.lower()
+    # Should not print env info before failing -- error path is
+    # supposed to short-circuit before _load_cli_env().
+    assert "using .env" not in captured.out
+
+
+def test_load_empty_file_returns_2(tmp_path, capsys):
+    f = tmp_path / "empty.il"
+    f.write_text("")
+    rc = main(["load", str(f)])
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert "empty" in captured.err.lower()
+
+
+def test_load_whitespace_only_file_returns_2(tmp_path, capsys):
+    """A file with only whitespace/newlines should be treated as empty."""
+    f = tmp_path / "blank.il"
+    f.write_text("\n   \n\t\n")
+    rc = main(["load", str(f)])
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert "empty" in captured.err.lower()


### PR DESCRIPTION
## Summary

Adds a new CLI subcommand:

```
virtuoso-bridge load <file.il> [--profile NAME] [--timeout 60] [--quiet]
```

Reads the file content and hands it to the running daemon as a single `execute_skill` call. The daemon **already** wraps multi-line SKILL into a temp file + `load()` + last-expression capture (`ramic_bridge_daemon_3.py:192-200`), so this is a thin user-facing wrapper. No upload step needed even in SSH mode — the temp file lives on the Virtuoso host.

## Use case

VSCode users editing `.il` files want a "Run File" button. `.vscode/tasks.json`:

```json
{
  "version": "2.0.0",
  "tasks": [{
    "label": "Load SKILL in Virtuoso",
    "type": "shell",
    "command": "virtuoso-bridge load \"${file}\"",
    "group": { "kind": "build", "isDefault": true },
    "problemMatcher": []
  }]
}
```

`Ctrl+Shift+B` (or any keybinding bound to the default build task) on the active `.il` file → sent to Virtuoso for execution.

## Behavior

| Exit | When |
|---|---|
| 0 | Success — prints SKILL return value to stdout unless `--quiet` |
| 1 | SKILL-side error — diagnostics to stderr |
| 2 | File missing / empty — short-circuits before env loading (frequent user typo, no need to print "using .env: ..." before the real error) |

## Test plan

- [x] `pytest tests/` → 13/13 pass (10 prior + 3 new)
  - `test_load_missing_file_returns_2`
  - `test_load_empty_file_returns_2`
  - `test_load_whitespace_only_file_returns_2`
- [x] `virtuoso-bridge load --help` renders with usage example
- [ ] **User-side smoke**: live Virtuoso, run a small `.il` script via the new command, verify return value prints
- [ ] **VSCode smoke**: configure `.vscode/tasks.json` per the example, hit Ctrl+Shift+B on a `.il` buffer, verify task succeeds

## Out of scope

- **Capturing SKILL `printf` output** (the "D2" question in the design discussion). Daemon currently only returns the last-expression value; capturing CIW stdout would need daemon protocol changes. Separate enhancement if there's demand.
- **Watch mode / auto-reload on file change** — possible follow-up if users want it.
- **`.vscode/tasks.json` shipped in the repo** — left as a docstring example in `--help` so users opt in by copying into their own workspace, not forced on every clone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
