### PR TITLE
fix(digital_import): Windows tmp portability + robust import_verilog …

### DIFF
--- a/examples/01_virtuoso/digital_import/digital_import.py
+++ b/examples/01_virtuoso/digital_import/digital_import.py
@@ -22,10 +22,12 @@ Lab paths are fixed for thu-wei.  For a different setup, edit the constants.
 import argparse
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
+TMP_DIR = Path(tempfile.gettempdir())
 
 # Lab-fixed defaults — edit here, not via CLI flags.
 TECH_LIB     = "tsmcN28"
@@ -81,8 +83,7 @@ def main() -> int:
     if args.sram_cell:
         ref_libs.append(SRAM_LIB)
     ihdl_ref_libs = ",".join(ref_libs)
-    strmin_ref_file = Path("/tmp/_digital_import_reflibs.txt")
-    strmin_ref_file.parent.mkdir(exist_ok=True)
+    strmin_ref_file = TMP_DIR / "_digital_import_reflibs.txt"
     strmin_ref_file.write_text("\n".join(ref_libs) + "\n")
 
     # Pre-import SRAM if needed.
@@ -94,7 +95,7 @@ def main() -> int:
         else:
             stem = args.sram_cell.lower()
             sram_gds = f"{SRAM_ROOT}/{stem}_180a/GDSII/{stem}_180a.gds"
-            empty_ref = Path("/tmp/_digital_import_empty_ref.txt")
+            empty_ref = TMP_DIR / "_digital_import_empty_ref.txt"
             empty_ref.write_text("")
             run("strmin SRAM macro", [
                 "import_gds.py", sram_gds,

--- a/examples/01_virtuoso/digital_import/import_verilog.py
+++ b/examples/01_virtuoso/digital_import/import_verilog.py
@@ -115,10 +115,12 @@ def main() -> int:
         help="Ground-net name in the schematic (default: VSSS)",
     )
     parser.add_argument(
-        "--structural-views", default="schematic",
+        "--structural-views", default="schematic_and_functional",
         choices=sorted(STRUCTURAL_VIEWS.keys()),
-        help="What views to create for structural modules "
-             "(default: schematic; pass schematic_and_functional for both)",
+        help="What views to create for structural modules.  Default: "
+             "schematic_and_functional (some Cadence versions, asked for "
+             "'schematic only' via value=1, emit functional instead of "
+             "schematic; asking for both is robust across versions).",
     )
     parser.add_argument(
         "--import-lib-cells", action="store_true",
@@ -128,7 +130,9 @@ def main() -> int:
     parser.add_argument(
         "--cell", default=None,
         help="Override the top cell to verify after import "
-             "(default: Verilog filename stem with any '_import' suffix removed)",
+             "(default: Verilog filename split on first '.', with any "
+             "'_import' suffix then removed — handles foo.v, foo_import.v, "
+             "and PnR-style foo.ipg_import_elc.v / foo.route_tapeout.v)",
     )
     args = parser.parse_args()
 
@@ -223,7 +227,7 @@ def main() -> int:
     client.execute_skill("ddUpdateLibList()")
 
     # 7. Verify imported views + schematic content.
-    cell = args.cell or os.path.basename(args.verilog).rsplit(".", 1)[0]
+    cell = args.cell or os.path.basename(args.verilog).split(".", 1)[0]
     if cell.endswith("_import"):
         cell = cell[: -len("_import")]
 
@@ -233,16 +237,24 @@ def main() -> int:
     )
     print(f"[OK] {args.target_lib}/{cell}/views: {r.output}")
 
+    # ihdl emits either `schematic` or `functional` depending on the
+    # Cadence version's interpretation of structural_views.  Try the
+    # requested schematic view first, fall back to functional so the
+    # final OK line reports whichever view actually got populated.
     sk_sch = (
-        f"let((cv) "
-        f"  cv=dbOpenCellViewByType({_q(args.target_lib)} {_q(cell)} {_q(args.schematic_view)} nil \"r\") "
+        f"let((cv view) "
+        f"  view = {_q(args.schematic_view)} "
+        f"  cv = dbOpenCellViewByType({_q(args.target_lib)} {_q(cell)} view nil \"r\") "
+        f"  when(null(cv) "
+        f"    view = \"functional\" "
+        f"    cv = dbOpenCellViewByType({_q(args.target_lib)} {_q(cell)} view nil \"r\")) "
         f"  if(cv "
-        f"     sprintf(nil \"instances=%d nets=%d terms=%d\" "
-        f"             length(cv~>instances) length(cv~>nets) length(cv~>terminals)) "
-        f"     \"OPEN_FAILED\")) "
+        f"     sprintf(nil \"%s instances=%d nets=%d terms=%d\" "
+        f"             view length(cv~>instances) length(cv~>nets) length(cv~>terminals)) "
+        f"     \"OPEN_FAILED (neither schematic nor functional)\")) "
     )
     r = client.execute_skill(sk_sch)
-    print(f"[OK] {args.target_lib}/{cell}/{args.schematic_view}: {r.output}")
+    print(f"[OK] {args.target_lib}/{cell}: {r.output}")
     return 0
 
 


### PR DESCRIPTION
…verify

digital_import.py: switch /tmp paths to tempfile.gettempdir().  On Windows the literal `/tmp/...` resolved to `D:\tmp\` while Git Bash's tar treated `/tmp` as `C:\Users\<user>\AppData\Local\Temp` — upload "succeeded" but strmin then reported `Failed to open refLibList` because the file landed in the wrong dir.

import_verilog.py:
- Cell-name derivation uses split(".", 1)[0] instead of rsplit, so PnR-style filenames like FIFO_128x16b.ipg_import_elc.v map to `FIFO_128x16b` instead of the multi-dotted stem.  The old logic made the post-import verify always print OPEN_FAILED.
- Verify step falls back from schematic to functional view.  Observed on this Cadence version: structural_views := 1 (documented as "schematic only") emits a functional view instead, so the OK line now reports whichever view actually got populated.
- --structural-views defaults to schematic_and_functional (value 5) for robustness across Cadence versions that disagree on the value=1 encoding.