### PR TITLE
feat(digital_import): auto-detect SRAM cell from Verilog

### DIFF
--- a/examples/01_virtuoso/digital_import/digital_import.py
+++ b/examples/01_virtuoso/digital_import/digital_import.py
@@ -9,6 +9,9 @@ invocation is short:
          --sram-cell TS1N28HPCPSVTB4096X24M8S
 
 What it does automatically:
+  • Auto-detects the SRAM cell name from the Verilog netlist (grep for
+    TS1N28*); only one unique cell allowed.  Pass --sram-cell to override
+    or to handle multi-bank designs.
   • Pre-imports the SRAM into the `sram` lib (if cell isn't already there)
   • Derives GDS/Verilog paths from <top> (under /home/zhangz/.../DIG_SYN_AI/)
   • Derives SRAM GDS path from <sram_cell>
@@ -28,11 +31,17 @@ are stable across users — edit them in place if your PDK differs.
 
 import argparse
 import os
+import re
+import shlex
 import subprocess
 import sys
 import tempfile
 import time
 from pathlib import Path
+
+from virtuoso_bridge.virtuoso.ops import q as _q
+
+SRAM_CELL_REGEX = re.compile(r"\bTS1N28[A-Z0-9]+\b")
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 TMP_DIR = Path(tempfile.gettempdir())
@@ -66,6 +75,47 @@ def sram_exists(client, lib: str, cell: str) -> bool:
     return "exists" in (r.output or "")
 
 
+def detect_sram_cells(client, verilog_path: str) -> list[str]:
+    """Return the unique sorted list of TS1N28* cell names referenced by
+    *verilog_path*.
+
+    Reads the file locally when the path exists on the caller's filesystem
+    (handles user-supplied --verilog pointing at a Windows path); otherwise
+    greps the file on the remote Virtuoso host via SKILL ``system()`` and
+    reads the grep output back through SKILL ``infile``.
+    """
+    p = Path(verilog_path)
+    if p.exists():
+        return sorted(set(SRAM_CELL_REGEX.findall(p.read_text(errors="replace"))))
+
+    remote_tmp = f"/tmp/vb_sram_detect_{os.getpid()}.out"
+    cmd = (
+        f"grep -hoE 'TS1N28[A-Z0-9]+' {shlex.quote(verilog_path)} "
+        f"| sort -u > {shlex.quote(remote_tmp)}"
+    )
+    client.execute_skill(f"system({_q(cmd)})")
+
+    read_skill = (
+        f"let((p line body) "
+        f"  p = infile({_q(remote_tmp)}) "
+        f"  body = \"\" "
+        f"  when(p "
+        f"    while(gets(line p) body = strcat(body line)) "
+        f"    close(p)) "
+        f"  body)"
+    )
+    r = client.execute_skill(read_skill)
+    body = (r.output or "").strip()
+    if body.startswith('"') and body.endswith('"'):
+        body = body[1:-1]
+    body = body.replace('\\"', '"').replace('\\n', '\n').replace('\\\\', '\\')
+    return sorted({
+        line.strip()
+        for line in body.splitlines()
+        if line.strip().startswith("TS1N28")
+    })
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -74,9 +124,11 @@ def main() -> int:
     ap.add_argument("--target-lib", required=True,
                     help="Target Virtuoso lib for the design (e.g. DIG_OUTPUT_TEST3)")
     ap.add_argument("--sram-cell", default=None,
-                    help="SRAM cell name (e.g. TS1N28HPCPSVTB4096X24M8S).  Omit for "
-                         "plain-digital (no SRAM macro).  When set, the SRAM is "
-                         "pre-imported into the `sram` lib if not already there.")
+                    help="SRAM cell name (e.g. TS1N28HPCPSVTB4096X24M8S).  When "
+                         "omitted, the Verilog is scanned for TS1N28* references; "
+                         "unique match is used automatically, multi-bank designs "
+                         "must pass this flag explicitly, and plain-digital "
+                         "designs (no TS1N28* in the Verilog) skip SRAM steps.")
     ap.add_argument("--gds", default=None,
                     help="Override design GDS path (default: PNR_SIGNOFF/RESULTS/<top>.route_tapeout.gds)")
     ap.add_argument("--verilog", default=None,
@@ -89,6 +141,24 @@ def main() -> int:
     if args.verilog is None:
         args.verilog = f"{pnr_dir}/{args.top}.ipg_import_elc.v"
 
+    # Auto-detect SRAM cell from the Verilog when not specified.  The same
+    # client is reused for the SRAM pre-import step below.
+    client = None
+    if args.sram_cell is None:
+        from virtuoso_bridge import VirtuosoClient
+        client = VirtuosoClient.from_env()
+        detected = detect_sram_cells(client, args.verilog)
+        if len(detected) == 1:
+            args.sram_cell = detected[0]
+            print(f"[digital-import] auto-detected SRAM cell: {args.sram_cell}")
+        elif len(detected) > 1:
+            sys.exit(
+                f"ERROR: Verilog references multiple SRAM cells {detected}; "
+                f"pass --sram-cell <name> to pick one."
+            )
+        else:
+            print("[digital-import] no TS1N28* in Verilog — plain-digital flow")
+
     # ref-libs: file format (one per line) for strmin, comma-separated for ihdl.
     ref_libs = [STDCELL_LIB]
     if args.sram_cell:
@@ -99,8 +169,9 @@ def main() -> int:
 
     # Pre-import SRAM if needed.
     if args.sram_cell:
-        from virtuoso_bridge import VirtuosoClient
-        client = VirtuosoClient.from_env()
+        if client is None:
+            from virtuoso_bridge import VirtuosoClient
+            client = VirtuosoClient.from_env()
         if sram_exists(client, SRAM_LIB, args.sram_cell):
             print(f"[digital-import] SRAM {args.sram_cell} already in {SRAM_LIB}, skipping pre-import")
         else:


### PR DESCRIPTION
Previously --sram-cell was a mandatory hand-typed flag like `TS1N28HPCPSVTB128X16M4S` — but that name is right there in the Verilog netlist that we're about to import.

Add `detect_sram_cells(client, verilog_path)` that scans the netlist for `TS1N28[A-Z0-9]+` references.  When --sram-cell is omitted:

  * exactly one match           → use it (printed for transparency)
  * multiple matches            → error out, ask user to pick
                                  (multi-bank designs)
  * no matches                  → plain-digital flow, no SRAM steps

The detector reads the file locally when the path exists on the caller's filesystem (e.g. user-supplied --verilog with a Windows path), and otherwise falls back to a remote `grep | sort -u` via SKILL system() with the output read back through SKILL infile/gets.

The shared bridge client is created once for autodetect and reused for the SRAM pre-import below, so there's no extra round-trip when the auto-detect path is taken.