### PR TITLE
refactor: promote SKILL string-literal helper `q` to ops module

### DIFF
--- a/examples/01_virtuoso/digital_import/add_power_labels.py
+++ b/examples/01_virtuoso/digital_import/add_power_labels.py
@@ -31,11 +31,7 @@ import argparse
 import sys
 
 from virtuoso_bridge import VirtuosoClient
-from virtuoso_bridge.virtuoso.ops import escape_skill_string
-
-
-def _q(s: str) -> str:
-    return f'"{escape_skill_string(s)}"'
+from virtuoso_bridge.virtuoso.ops import q as _q
 
 
 # Single-shot SKILL: find ref instance, read master pin y, transform to

--- a/examples/01_virtuoso/digital_import/import_gds.py
+++ b/examples/01_virtuoso/digital_import/import_gds.py
@@ -36,12 +36,7 @@ import time
 from pathlib import Path
 
 from virtuoso_bridge import VirtuosoClient
-from virtuoso_bridge.virtuoso.ops import escape_skill_string
-
-
-def _q(s: str) -> str:
-    """Wrap a Python string as a SKILL string literal."""
-    return f'"{escape_skill_string(s)}"'
+from virtuoso_bridge.virtuoso.ops import q as _q
 
 
 def main() -> int:

--- a/examples/01_virtuoso/digital_import/import_verilog.py
+++ b/examples/01_virtuoso/digital_import/import_verilog.py
@@ -28,12 +28,7 @@ import sys
 import uuid
 
 from virtuoso_bridge import VirtuosoClient
-from virtuoso_bridge.virtuoso.ops import escape_skill_string
-
-
-def _q(s: str) -> str:
-    """Wrap a Python string as a SKILL string literal."""
-    return f'"{escape_skill_string(s)}"'
+from virtuoso_bridge.virtuoso.ops import q as _q
 
 
 # Cadence batch parameter file (key := value).  Field semantics taken from

--- a/examples/01_virtuoso/digital_import/restyle_labels.py
+++ b/examples/01_virtuoso/digital_import/restyle_labels.py
@@ -39,7 +39,7 @@ import sys
 from pathlib import Path
 
 from virtuoso_bridge import VirtuosoClient
-from virtuoso_bridge.virtuoso.ops import escape_skill_string
+from virtuoso_bridge.virtuoso.ops import q as _q
 
 
 SIDE_TO_ORIENT = {
@@ -48,10 +48,6 @@ SIDE_TO_ORIENT = {
     "Left":   "R180",
     "Right":  "R0",
 }
-
-
-def _q(s: str) -> str:
-    return f'"{escape_skill_string(s)}"'
 
 
 def parse_floorplan_pin_sides(fp_tcl_path: str) -> dict[str, str]:

--- a/src/virtuoso_bridge/virtuoso/ops.py
+++ b/src/virtuoso_bridge/virtuoso/ops.py
@@ -8,6 +8,15 @@ def escape_skill_string(value: str) -> str:
     """Escape a Python string for use inside a SKILL string literal."""
     return value.replace("\\", "\\\\").replace('"', '\\"')
 
+def q(value: str) -> str:
+    """Wrap a Python string as a SKILL string literal (escaped + quoted).
+
+    Shorthand for ``f'"{escape_skill_string(value)}"'`` — useful when
+    composing SKILL expressions from Python f-strings, where the
+    quote-then-escape pattern would otherwise be duplicated everywhere.
+    """
+    return f'"{escape_skill_string(value)}"'
+
 def default_view_type_for(view: str) -> str:
     """Map a logical Virtuoso view name to the expected viewType."""
     normalized = (view or "").strip().lower()


### PR DESCRIPTION
The four digital_import scripts each defined an identical local `_q(s)` wrapping `escape_skill_string` into `f'"{...}"'`.  Promote that one-liner into `virtuoso_bridge.virtuoso.ops.q` next to the existing `escape_skill_string`, and rewrite the four examples as `from virtuoso_bridge.virtuoso.ops import q as _q` so call sites are unchanged.

Removes 4x duplication, makes the canonical short form available to any new script that builds SKILL expressions from Python.