### PR TITLE
fix(tunnel): isolate setup files per profile

### DIFF
--- a/src/virtuoso_bridge/cli.py
+++ b/src/virtuoso_bridge/cli.py
@@ -290,7 +290,7 @@ def _print_load_hint(setup_path: str) -> None:
 def _print_status() -> int:
     _load_cli_env()
     profile = _get_cli_profile()
-    from virtuoso_bridge.transport.tunnel import SSHClient, _is_localhost
+    from virtuoso_bridge.transport.tunnel import SSHClient, _is_localhost, _profiled_bridge_leaf
     from virtuoso_bridge.virtuoso.basic.bridge import VirtuosoClient
 
     state = SSHClient.read_state(profile)
@@ -316,7 +316,7 @@ def _print_status() -> int:
                 user = getpass.getuser()
             except Exception:
                 return None
-        return f"/tmp/virtuoso_bridge_{user}/virtuoso_bridge/virtuoso_setup.il"
+        return f"/tmp/virtuoso_bridge_{user}/{_profiled_bridge_leaf(profile)}/virtuoso_setup.il"
 
     if is_local:
         print(f"\n[mode] local (no SSH tunnel)")

--- a/src/virtuoso_bridge/transport/tunnel.py
+++ b/src/virtuoso_bridge/transport/tunnel.py
@@ -111,6 +111,18 @@ def _update_env_file(key: str, value: str) -> bool:
     return False
 
 
+def _profiled_bridge_leaf(profile: str | None) -> str:
+    """Remote bridge directory leaf for a connection profile."""
+    if not profile:
+        return "virtuoso_bridge"
+    safe = re.sub(r"[^a-zA-Z0-9._-]", "_", profile.strip())[:64]
+    return f"virtuoso_bridge_{safe or 'profile'}"
+
+
+def _profiled_env_key(base: str, profile: str | None) -> str:
+    return f"{base}_{profile}" if profile else base
+
+
 # ---------------------------------------------------------------------------
 # SSHClient
 # ---------------------------------------------------------------------------
@@ -312,7 +324,10 @@ class SSHClient:
             configured_user=self._remote_user,
             runner=runner,
         )
-        self._remote_work_dir = default_virtuoso_bridge_dir(remote_username, "virtuoso_bridge")
+        self._remote_work_dir = default_virtuoso_bridge_dir(
+            remote_username,
+            _profiled_bridge_leaf(self._profile),
+        )
 
         remote_daemon = f"{self._remote_work_dir}/{daemon_filename}"
         remote_il = f"{self._remote_work_dir}/ramic_bridge.il"
@@ -421,7 +436,7 @@ class SSHClient:
                     logger.info("Local port %d was busy, using port %d", self._local_port, local_port)
                     print(f"[port] {self._local_port} busy, auto-switched to {local_port}", flush=True)
                     self._local_port = local_port
-                    _update_env_file("VB_LOCAL_PORT", str(local_port))
+                    _update_env_file(_profiled_env_key("VB_LOCAL_PORT", self._profile), str(local_port))
                 logger.info(
                     "SSH tunnel established (PID %d): localhost:%d -> %s:localhost:%d",
                     proc.pid, local_port, self._remote_host, self._port,

--- a/src/virtuoso_bridge/virtuoso/basic/bridge.py
+++ b/src/virtuoso_bridge/virtuoso/basic/bridge.py
@@ -817,13 +817,17 @@ let((result winName ciwNum)
         p = Path(path)
         if self._tunnel is not None and p.is_file():
             from virtuoso_bridge.transport.remote_paths import default_virtuoso_bridge_dir, resolve_remote_username
+            from virtuoso_bridge.transport.tunnel import _profiled_bridge_leaf
             work_dir = self._tunnel.remote_work_dir
             if not work_dir:
                 remote_username = resolve_remote_username(
                     configured_user=getattr(self._tunnel, '_remote_user', None),
                     runner=self._tunnel.ssh_runner,
                 )
-                work_dir = default_virtuoso_bridge_dir(remote_username, "virtuoso_bridge")
+                work_dir = default_virtuoso_bridge_dir(
+                    remote_username,
+                    _profiled_bridge_leaf(getattr(self._tunnel, '_profile', None)),
+                )
             remote_dir = work_dir.rstrip("/")
             remote_path = f"{remote_dir}/{p.name}"
             content = p.read_bytes()

--- a/tests/test_tunnel_profiles.py
+++ b/tests/test_tunnel_profiles.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from virtuoso_bridge.transport.ssh import CommandResult
+from virtuoso_bridge.transport.tunnel import (
+    SSHClient,
+    _profiled_bridge_leaf,
+    _profiled_env_key,
+)
+from virtuoso_bridge import cli
+
+
+class _FakeRunner:
+    def __init__(self) -> None:
+        self.commands: list[str] = []
+        self.uploads: dict[str, str] = {}
+
+    def run_command(self, command: str, timeout=None) -> CommandResult:
+        self.commands.append(command)
+        return CommandResult(returncode=0, stdout="", stderr="")
+
+    def upload_text(self, text: str, remote_path: str, timeout=None) -> CommandResult:
+        self.uploads[remote_path] = text
+        return CommandResult(returncode=0, stdout="", stderr="")
+
+
+def test_profiled_bridge_leaf_preserves_default_path() -> None:
+    assert _profiled_bridge_leaf(None) == "virtuoso_bridge"
+
+
+def test_profiled_bridge_leaf_adds_profile_suffix() -> None:
+    assert _profiled_bridge_leaf("t28_digital") == "virtuoso_bridge_t28_digital"
+    assert _profiled_bridge_leaf("t28/io") == "virtuoso_bridge_t28_io"
+
+
+def test_profiled_env_key_preserves_default_and_suffixes_profiles() -> None:
+    assert _profiled_env_key("VB_LOCAL_PORT", None) == "VB_LOCAL_PORT"
+    assert _profiled_env_key("VB_LOCAL_PORT", "t180_io") == "VB_LOCAL_PORT_t180_io"
+
+
+def test_remote_setup_path_and_port_are_profile_scoped(monkeypatch) -> None:
+    fake = _FakeRunner()
+    client = SSHClient(
+        remote_host="thu-wei",
+        remote_user="designer",
+        port=65263,
+        profile="t28_digital",
+    )
+    client._ssh_runner = fake
+    monkeypatch.setattr(client, "_detect_remote_python", lambda: ("python3", 3, 11))
+
+    client.ensure_remote_setup()
+
+    assert client.remote_work_dir == "/tmp/virtuoso_bridge_designer/virtuoso_bridge_t28_digital"
+    setup_path = "/tmp/virtuoso_bridge_designer/virtuoso_bridge_t28_digital/virtuoso_setup.il"
+    setup = fake.uploads[setup_path]
+    assert 'setShellEnvVar("RB_PORT" "65263")' in setup
+    assert '/tmp/virtuoso_bridge_designer/virtuoso_bridge_t28_digital/ramic_bridge.il' in setup
+
+
+def test_status_infers_profile_scoped_setup_path(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(cli, "_load_cli_env", lambda: None)
+    monkeypatch.setattr(cli, "_CLI_PROFILE", ["t28_io"])
+    monkeypatch.setenv("VB_REMOTE_HOST_t28_io", "thu-wei")
+    monkeypatch.setenv("VB_REMOTE_USER_t28_io", "designer")
+
+    class _FakeSSHClient:
+        @staticmethod
+        def read_state(profile=None):
+            return None
+
+        @staticmethod
+        def is_running(profile=None):
+            return False
+
+    monkeypatch.setattr("virtuoso_bridge.transport.tunnel.SSHClient", _FakeSSHClient)
+
+    rc = cli._print_status()
+
+    assert rc == 1
+    assert (
+        'load("/tmp/virtuoso_bridge_designer/virtuoso_bridge_t28_io/virtuoso_setup.il")'
+        in capsys.readouterr().out
+    )


### PR DESCRIPTION
## Summary
- isolate remote bridge deployment directories by connection profile
- keep default profile on the existing `virtuoso_bridge` path for compatibility
- update profile-mode local-port auto-switch writes to `VB_LOCAL_PORT_<profile>`
- make `status -p` infer the profile-scoped setup path before the tunnel is running

## Tests
- `pytest -q`
- `python -m compileall -q src/virtuoso_bridge/transport/tunnel.py src/virtuoso_bridge/cli.py tests/test_tunnel_profiles.py`