### PR TITLE
feat(profile): resolve bridge profile from virtualenv binding

### DIFF
--- a/src/virtuoso_bridge/__init__.py
+++ b/src/virtuoso_bridge/__init__.py
@@ -19,6 +19,7 @@ from virtuoso_bridge.models import (
 )
 from virtuoso_bridge.spectre.runner import SpectreSimulator
 from virtuoso_bridge.wrappers import SanitizingClient
+from virtuoso_bridge.profile import resolve_profile, resolve_profile_info
 
 def decode_skill_output(raw: str | None) -> str:
     """Decode raw SKILL output: strip outer quotes, unescape \\\\n and \\\\"."""
@@ -35,5 +36,7 @@ __all__ = [
     "ExecutionStatus",
     "SkillResult",
     "SimulationResult",
+    "resolve_profile",
+    "resolve_profile_info",
     "decode_skill_output",
 ]

--- a/src/virtuoso_bridge/cli.py
+++ b/src/virtuoso_bridge/cli.py
@@ -80,6 +80,49 @@ def _load_cli_env() -> Path | None:
     return env_path
 
 
+def cli_profile(*, action: str, profile: str | None = None) -> int:
+    """Inspect or edit profile bindings."""
+    from virtuoso_bridge.profile import (
+        bind_venv_profile,
+        clear_venv_profile,
+        read_venv_profile,
+        resolve_profile_info,
+    )
+
+    if action == "bind":
+        if profile is None:
+            print("profile bind requires a profile name")
+            return 2
+        try:
+            path = bind_venv_profile(profile)
+        except Exception as exc:
+            print(f"profile bind failed: {exc}")
+            return 1
+        print(f"Bound current virtualenv to profile {profile!r}")
+        print(f"  {path}")
+        return 0
+
+    if action == "clear":
+        try:
+            path = clear_venv_profile()
+        except Exception as exc:
+            print(f"profile clear failed: {exc}")
+            return 1
+        print("Cleared current virtualenv profile binding")
+        print(f"  {path}")
+        return 0
+
+    info = resolve_profile_info()
+    venv_path, venv_profile = read_venv_profile()
+    print(f"resolved profile : {info.profile or '(default)'}")
+    print(f"source           : {info.source}")
+    if info.path:
+        print(f"source path      : {info.path}")
+    print(f"venv binding     : {venv_profile or '(none)'}")
+    print(f"venv path        : {venv_path or '(no active virtualenv)'}")
+    return 0
+
+
 def _fmt(seconds: float) -> str:
     return f"{seconds:.3f}s"
 
@@ -1046,6 +1089,27 @@ def build_parser() -> argparse.ArgumentParser:
                         help="Connection profile (reads VB_*_<profile> env vars)")
         sp.add_argument("--env", default=None,
                         help="Explicit .env file path (highest priority)")
+        if name == "start":
+            sp.add_argument("--bind-venv", action="store_true",
+                            help="Bind the active virtualenv to this -p profile before starting")
+
+    sp_profile = subparsers.add_parser("profile", help="Show or edit profile bindings")
+    profile_sub = sp_profile.add_subparsers(dest="profile_action", required=True)
+    sp_profile_show = profile_sub.add_parser("show", help="Show resolved profile")
+    sp_profile_show.add_argument("--env", default=None,
+                                 help="Explicit .env file path (highest priority)")
+    sp_profile_bind = profile_sub.add_parser("bind", help="Bind current virtualenv to a profile")
+    sp_profile_bind.add_argument("profile", help="Profile name to bind")
+    sp_profile_bind.add_argument("--venv", action="store_true",
+                                 help="Bind the current virtualenv (the only supported scope)")
+    sp_profile_bind.add_argument("--env", default=None,
+                                 help="Explicit .env file path (highest priority)")
+    sp_profile_clear = profile_sub.add_parser("clear", help="Clear current virtualenv profile binding")
+    sp_profile_clear.add_argument("--venv", action="store_true",
+                                  help="Clear the current virtualenv binding (the only supported scope)")
+    sp_profile_clear.add_argument("--env", default=None,
+                                  help="Explicit .env file path (highest priority)")
+
     sp_load = subparsers.add_parser(
         "load",
         help="Execute a SKILL .il file in the running Virtuoso session",
@@ -1200,11 +1264,30 @@ def main(argv: list[str] | None = None) -> int:
     _make_stdio_safe()
     parser = build_parser()
     args = parser.parse_args(argv)
+    _CLI_PROFILE[0] = None
+    set_runtime_env_file(getattr(args, "env", None))
+    if getattr(args, "bind_venv", False):
+        profile_arg = getattr(args, "profile", None)
+        if not profile_arg:
+            parser.error("--bind-venv requires -p/--profile")
+        from virtuoso_bridge.profile import bind_venv_profile
+        try:
+            bind_venv_profile(profile_arg)
+        except Exception as exc:
+            parser.error(str(exc))
+    from virtuoso_bridge.profile import resolve_profile
+    profile = resolve_profile(getattr(args, "profile", None))
+    if profile is not None:
+        _CLI_PROFILE[0] = profile
     dispatch = {
         "init": lambda: cli_init(
             remote=getattr(args, "remote", None),
             jump=getattr(args, "jump", None),
             force=getattr(args, "force", False),
+        ),
+        "profile": lambda: cli_profile(
+            action=getattr(args, "profile_action"),
+            profile=getattr(args, "profile", None),
         ),
         "start": cli_start,
         "stop": cli_stop,
@@ -1228,11 +1311,6 @@ def main(argv: list[str] | None = None) -> int:
         "snapshot": cli_snapshot,
         "export-visio": cli_export_visio,
     }
-    # Pass profile to commands that support it
-    profile = getattr(args, "profile", None)
-    if profile is not None:
-        _CLI_PROFILE[0] = profile
-    set_runtime_env_file(getattr(args, "env", None))
     screenshot_target = getattr(args, "target", None)
     if screenshot_target is not None:
         _SCREENSHOT_TARGET[0] = screenshot_target

--- a/src/virtuoso_bridge/profile.py
+++ b/src/virtuoso_bridge/profile.py
@@ -1,0 +1,132 @@
+"""Connection profile resolution and virtualenv binding helpers."""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from dotenv import dotenv_values
+
+from virtuoso_bridge.env import default_user_env_path, get_runtime_env_file
+
+PROFILE_BINDING_FILENAME = ".virtuoso-bridge-profile"
+
+
+@dataclass(frozen=True)
+class ProfileResolution:
+    profile: str | None
+    source: str
+    path: Path | None = None
+
+
+def _clean_profile(value: str | None) -> str | None:
+    profile = (value or "").strip()
+    return profile or None
+
+
+def venv_profile_path(venv: str | Path | None = None) -> Path | None:
+    """Return the profile binding path for a virtualenv, if one is active."""
+    raw = venv if venv is not None else os.environ.get("VIRTUAL_ENV", "")
+    if not str(raw).strip() and sys.prefix != getattr(sys, "base_prefix", sys.prefix):
+        raw = sys.prefix
+    if not str(raw).strip():
+        return None
+    root = Path(raw).expanduser()
+    return root.resolve() / PROFILE_BINDING_FILENAME
+
+
+def _read_profile_file(path: Path | None) -> str | None:
+    if path is None or not path.is_file():
+        return None
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            profile = _clean_profile(line)
+            if profile and not profile.startswith("#"):
+                return profile
+    except OSError:
+        return None
+    return None
+
+
+def _profile_from_env_file(path: Path | None) -> str | None:
+    if path is None or not path.is_file():
+        return None
+    try:
+        return _clean_profile(dotenv_values(path).get("VB_PROFILE"))
+    except OSError:
+        return None
+
+
+def resolve_profile_info(explicit: str | None = None) -> ProfileResolution:
+    """Resolve the active connection profile and explain where it came from.
+
+    Resolution order:
+    1. explicit ``profile=`` argument
+    2. process environment ``VB_PROFILE``
+    3. runtime ``--env`` file, when one was explicitly selected
+    4. active virtualenv binding file
+    5. user-level ``~/.virtuoso-bridge/.env`` ``VB_PROFILE``
+    6. ``None`` for the legacy default profile
+    """
+    profile = _clean_profile(explicit)
+    if profile:
+        return ProfileResolution(profile, "explicit")
+
+    profile = _clean_profile(os.environ.get("VB_PROFILE"))
+    if profile:
+        return ProfileResolution(profile, "environment")
+
+    runtime_env = get_runtime_env_file()
+    profile = _profile_from_env_file(runtime_env)
+    if profile:
+        return ProfileResolution(profile, "runtime_env", runtime_env)
+
+    venv_path = venv_profile_path()
+    profile = _read_profile_file(venv_path)
+    if profile:
+        return ProfileResolution(profile, "venv", venv_path)
+
+    user_env = default_user_env_path()
+    profile = _profile_from_env_file(user_env)
+    if profile:
+        return ProfileResolution(profile, "user_env", user_env)
+
+    return ProfileResolution(None, "default")
+
+
+def resolve_profile(explicit: str | None = None) -> str | None:
+    """Resolve the active connection profile, preserving legacy None fallback."""
+    return resolve_profile_info(explicit).profile
+
+
+def bind_venv_profile(profile: str, *, venv: str | Path | None = None) -> Path:
+    """Bind the active virtualenv to a connection profile."""
+    cleaned = _clean_profile(profile)
+    if not cleaned:
+        raise ValueError("profile must be a non-empty string")
+    path = venv_profile_path(venv)
+    if path is None:
+        raise RuntimeError("No active virtualenv. Set VIRTUAL_ENV or pass --venv from an activated venv.")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"{cleaned}\n", encoding="utf-8")
+    return path
+
+
+def clear_venv_profile(*, venv: str | Path | None = None) -> Path:
+    """Remove the active virtualenv profile binding if present."""
+    path = venv_profile_path(venv)
+    if path is None:
+        raise RuntimeError("No active virtualenv. Set VIRTUAL_ENV or pass --venv from an activated venv.")
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+    return path
+
+
+def read_venv_profile(*, venv: str | Path | None = None) -> tuple[Path | None, str | None]:
+    """Return ``(binding_path, profile)`` for the active virtualenv."""
+    path = venv_profile_path(venv)
+    return path, _read_profile_file(path)

--- a/src/virtuoso_bridge/spectre/runner.py
+++ b/src/virtuoso_bridge/spectre/runner.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any, NamedTuple
 
 from virtuoso_bridge.env import load_vb_env
+from virtuoso_bridge.profile import resolve_profile
 from virtuoso_bridge.models import ExecutionStatus, SimulationResult
 from virtuoso_bridge.spectre.parsers import (
     parse_psf_ascii_directory,
@@ -466,6 +467,7 @@ class SpectreSimulator:
         ssh_runner: SSHRunner | None = None,
         profile: str | None = None,
     ) -> None:
+        profile = resolve_profile(profile)
         load_vb_env()
         self._spectre_cmd = spectre_cmd
         self._spectre_args = list(spectre_args or [])
@@ -521,6 +523,7 @@ class SpectreSimulator:
         ControlMaster).  Raises RuntimeError if no remote connection is
         available.
         """
+        profile = resolve_profile(profile)
         load_vb_env()
         # Check if we should run locally
         suffix = f"_{profile}" if profile else ""

--- a/src/virtuoso_bridge/transport/ssh.py
+++ b/src/virtuoso_bridge/transport/ssh.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Any, NamedTuple
 
 from virtuoso_bridge.env import load_vb_env
+from virtuoso_bridge.profile import resolve_profile
 
 logger = logging.getLogger(__name__)
 
@@ -97,8 +98,10 @@ def remote_ssh_env_from_os(profile: str | None = None) -> RemoteSshEnv:
     """Read remote SSH target from environment variables.
 
     If *profile* is given (e.g. ``"gpu1"``), reads ``VB_REMOTE_HOST_GPU1``
-    etc.  Otherwise reads the default unsuffixed variables.
+    etc.  Otherwise resolves a profile binding before falling back to the
+    default unsuffixed variables.
     """
+    profile = resolve_profile(profile)
     load_vb_env()
     suffix = f"_{profile}" if profile else ""
 

--- a/src/virtuoso_bridge/transport/tunnel.py
+++ b/src/virtuoso_bridge/transport/tunnel.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Any
 
 from virtuoso_bridge.env import load_vb_env, resolve_env_path
+from virtuoso_bridge.profile import resolve_profile
 from virtuoso_bridge.transport.remote_paths import default_virtuoso_bridge_dir, resolve_remote_username
 from virtuoso_bridge.transport.ssh import SSHRunner, CommandResult
 
@@ -179,8 +180,10 @@ class SSHClient:
         """Create from VB_* environment variables.
 
         If *profile* is given (e.g. ``"gpu1"``), reads ``VB_REMOTE_HOST_gpu1``
-        etc.  Otherwise reads the default unsuffixed variables.
+        etc.  Otherwise resolves a profile binding before falling back to the
+        default unsuffixed variables.
         """
+        profile = resolve_profile(profile)
         load_vb_env()
 
         suffix = f"_{profile}" if profile else ""

--- a/src/virtuoso_bridge/virtuoso/basic/bridge.py
+++ b/src/virtuoso_bridge/virtuoso/basic/bridge.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 from virtuoso_bridge.env import load_vb_env
+from virtuoso_bridge.profile import resolve_profile
 from virtuoso_bridge.virtuoso.basic.composition import compose_skill_script
 from virtuoso_bridge.models import ExecutionStatus, VirtuosoInterface, VirtuosoResult
 from virtuoso_bridge.virtuoso.ops import (
@@ -107,9 +108,12 @@ class VirtuosoClient(VirtuosoInterface):
         """Create a VirtuosoClient from environment variables.
 
         If *profile* is given (e.g. ``"gpu1"``), reads ``VB_REMOTE_HOST_gpu1``
-        etc.  If an SSH tunnel is already running (via ``virtuoso-bridge start``),
-        connects to its port.  Otherwise creates a new SSHClient.
+        etc.  Otherwise resolves a profile binding before falling back to the
+        default unsuffixed variables.  If an SSH tunnel is already running (via
+        ``virtuoso-bridge start``), connects to its port.  Otherwise creates a
+        new SSHClient.
         """
+        profile = resolve_profile(profile)
         load_vb_env()
         from virtuoso_bridge.transport.tunnel import SSHClient
 

--- a/tests/test_profile_resolver.py
+++ b/tests/test_profile_resolver.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+from virtuoso_bridge import cli
+from virtuoso_bridge.profile import (
+    bind_venv_profile,
+    clear_venv_profile,
+    resolve_profile,
+    resolve_profile_info,
+    venv_profile_path,
+)
+from virtuoso_bridge.spectre.runner import SpectreSimulator
+from virtuoso_bridge.virtuoso.basic.bridge import VirtuosoClient
+
+
+def _isolate_profile_env(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("VB_PROFILE", raising=False)
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    monkeypatch.setattr(
+        "virtuoso_bridge.profile.default_user_env_path",
+        lambda: tmp_path / "missing-user.env",
+    )
+    monkeypatch.setattr(
+        "virtuoso_bridge.profile.get_runtime_env_file",
+        lambda: None,
+    )
+
+
+def test_resolve_profile_prefers_explicit(monkeypatch, tmp_path) -> None:
+    _isolate_profile_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("VB_PROFILE", "from_env")
+
+    info = resolve_profile_info("explicit")
+
+    assert info.profile == "explicit"
+    assert info.source == "explicit"
+
+
+def test_resolve_profile_prefers_environment_over_venv(monkeypatch, tmp_path) -> None:
+    _isolate_profile_env(monkeypatch, tmp_path)
+    venv = tmp_path / ".venv"
+    monkeypatch.setenv("VIRTUAL_ENV", str(venv))
+    bind_venv_profile("from_venv")
+    monkeypatch.setenv("VB_PROFILE", "from_env")
+
+    info = resolve_profile_info()
+
+    assert info.profile == "from_env"
+    assert info.source == "environment"
+
+
+def test_resolve_profile_reads_runtime_env_before_venv(monkeypatch, tmp_path) -> None:
+    _isolate_profile_env(monkeypatch, tmp_path)
+    runtime_env = tmp_path / "custom.env"
+    runtime_env.write_text("VB_PROFILE=from_runtime\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "virtuoso_bridge.profile.get_runtime_env_file",
+        lambda: runtime_env,
+    )
+    venv = tmp_path / ".venv"
+    monkeypatch.setenv("VIRTUAL_ENV", str(venv))
+    bind_venv_profile("from_venv")
+
+    info = resolve_profile_info()
+
+    assert info.profile == "from_runtime"
+    assert info.source == "runtime_env"
+    assert info.path == runtime_env
+
+
+def test_resolve_profile_reads_venv_binding(monkeypatch, tmp_path) -> None:
+    _isolate_profile_env(monkeypatch, tmp_path)
+    venv = tmp_path / ".venv"
+    monkeypatch.setenv("VIRTUAL_ENV", str(venv))
+    binding = bind_venv_profile("t180_io")
+
+    info = resolve_profile_info()
+
+    assert binding == venv / ".virtuoso-bridge-profile"
+    assert info.profile == "t180_io"
+    assert info.source == "venv"
+    assert info.path == binding
+
+
+def test_resolve_profile_reads_user_env_after_venv(monkeypatch, tmp_path) -> None:
+    _isolate_profile_env(monkeypatch, tmp_path)
+    user_env = tmp_path / "user.env"
+    user_env.write_text("VB_PROFILE=user_default\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "virtuoso_bridge.profile.default_user_env_path",
+        lambda: user_env,
+    )
+
+    assert resolve_profile() == "user_default"
+
+
+def test_resolve_profile_returns_none_without_binding(monkeypatch, tmp_path) -> None:
+    _isolate_profile_env(monkeypatch, tmp_path)
+
+    info = resolve_profile_info()
+
+    assert info.profile is None
+    assert info.source == "default"
+
+
+def test_clear_venv_profile_removes_binding(monkeypatch, tmp_path) -> None:
+    _isolate_profile_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("VIRTUAL_ENV", str(tmp_path / ".venv"))
+    path = bind_venv_profile("t28_io")
+
+    cleared = clear_venv_profile()
+
+    assert cleared == path
+    assert not path.exists()
+    assert venv_profile_path() == path
+
+
+def test_venv_profile_path_falls_back_to_sys_prefix(monkeypatch, tmp_path) -> None:
+    _isolate_profile_env(monkeypatch, tmp_path)
+    venv = tmp_path / ".venv"
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    monkeypatch.setattr(sys, "prefix", str(venv))
+    monkeypatch.setattr(sys, "base_prefix", str(tmp_path / "base-python"))
+
+    assert venv_profile_path() == venv / ".virtuoso-bridge-profile"
+
+
+def test_virtuoso_client_from_env_uses_resolved_profile(monkeypatch, tmp_path) -> None:
+    _isolate_profile_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("VIRTUAL_ENV", str(tmp_path / ".venv"))
+    bind_venv_profile("t28_digital")
+    monkeypatch.setattr(
+        "virtuoso_bridge.virtuoso.basic.bridge.load_vb_env",
+        lambda: None,
+    )
+    seen: list[tuple[str, str | None]] = []
+
+    class _FakeSSHClient:
+        @staticmethod
+        def is_running(profile=None):
+            seen.append(("is_running", profile))
+            return True
+
+        @staticmethod
+        def read_state(profile=None):
+            seen.append(("read_state", profile))
+            return {"port": 65501}
+
+        @classmethod
+        def from_env(cls, keep_remote_files=True, profile=None):
+            seen.append(("from_env", profile))
+            return cls()
+
+    monkeypatch.setattr("virtuoso_bridge.transport.tunnel.SSHClient", _FakeSSHClient)
+
+    client = VirtuosoClient.from_env()
+
+    assert client.port == 65501
+    assert seen == [
+        ("is_running", "t28_digital"),
+        ("read_state", "t28_digital"),
+        ("from_env", "t28_digital"),
+    ]
+
+
+def test_spectre_simulator_direct_constructor_uses_resolved_profile(monkeypatch, tmp_path) -> None:
+    _isolate_profile_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("VIRTUAL_ENV", str(tmp_path / ".venv"))
+    bind_venv_profile("t28_io")
+    monkeypatch.setenv("VB_REMOTE_HOST_t28_io", "thu-wei")
+    monkeypatch.setenv("VB_REMOTE_USER_t28_io", "designer")
+    monkeypatch.setattr("virtuoso_bridge.spectre.runner.load_vb_env", lambda: None)
+    monkeypatch.setattr("virtuoso_bridge.transport.ssh.load_vb_env", lambda: None)
+
+    sim = SpectreSimulator(remote=True)
+
+    assert sim._profile == "t28_io"
+    assert sim._remote_host == "thu-wei"
+    assert sim._remote_user == "designer"
+
+
+def test_cli_profile_bind_show_clear(monkeypatch, tmp_path, capsys) -> None:
+    _isolate_profile_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("VIRTUAL_ENV", str(tmp_path / ".venv"))
+
+    assert cli.main(["profile", "bind", "t180_io", "--venv"]) == 0
+    assert (tmp_path / ".venv" / ".virtuoso-bridge-profile").read_text(encoding="utf-8") == "t180_io\n"
+
+    assert cli.main(["profile", "show"]) == 0
+    out = capsys.readouterr().out
+    assert "resolved profile : t180_io" in out
+    assert "source           : venv" in out
+
+    assert cli.main(["profile", "clear", "--venv"]) == 0
+    assert not (tmp_path / ".venv" / ".virtuoso-bridge-profile").exists()
+
+
+def test_cli_status_uses_venv_binding(monkeypatch, tmp_path, capsys) -> None:
+    _isolate_profile_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("VIRTUAL_ENV", str(tmp_path / ".venv"))
+    bind_venv_profile("t28_io")
+    monkeypatch.setattr(cli, "_load_cli_env", lambda: None)
+    monkeypatch.setenv("VB_REMOTE_HOST_t28_io", "thu-wei")
+    monkeypatch.setenv("VB_REMOTE_USER_t28_io", "designer")
+
+    class _FakeSSHClient:
+        @staticmethod
+        def read_state(profile=None):
+            assert profile == "t28_io"
+            return None
+
+        @staticmethod
+        def is_running(profile=None):
+            assert profile == "t28_io"
+            return False
+
+    monkeypatch.setattr("virtuoso_bridge.transport.tunnel.SSHClient", _FakeSSHClient)
+
+    rc = cli.main(["status"])
+
+    assert rc == 1
+    assert "[t28_io]" in capsys.readouterr().out


### PR DESCRIPTION
## Purpose

This PR makes connection profile selection a first-class, reusable bridge-layer capability instead of requiring each downstream project to hand-roll wrappers around `VirtuosoClient.from_env(profile=...)`.

It introduces an explicit virtualenv profile binding file so a shared user-level `~/.virtuoso-bridge/.env` can continue to hold all host/user/port settings, while a specific Python environment can declare its default profile with only a profile name.

Example:

```powershell
virtuoso-bridge profile bind t28_digital --venv
virtuoso-bridge start
python run_task.py
```

After binding, naked API calls such as `VirtuosoClient.from_env()` and `SpectreSimulator.from_env()` resolve to the bound profile, while explicit `profile=` and CLI `-p` still take precedence.

## Motivation

The previous multi-profile support isolated ports, state files, and setup directories, but callers still had to pass the profile everywhere. Any existing task code that called `VirtuosoClient.from_env()` without a profile would fall back to the default profile/state file. In a multi-CIW workflow this is risky: the task might fail to connect, or worse, execute SKILL in the wrong CIW if a default tunnel happens to be alive.

Downstream projects can solve this with wrappers, but that spreads profile-resolution policy across repos. The bridge can provide a common resolver while still avoiding any project-specific assumptions about what `t28_digital`, `t28_io`, or other profile names mean.

## What changed

- Adds `virtuoso_bridge.profile` with:
  - `resolve_profile()` / `resolve_profile_info()`
  - `bind_venv_profile()` / `clear_venv_profile()`
  - virtualenv binding path: `$VIRTUAL_ENV/.virtuoso-bridge-profile`
  - fallback to `sys.prefix` so direct `path/to/.venv/Scripts/virtuoso-bridge.exe` works even when the shell is not activated
- Wires the resolver into:
  - `VirtuosoClient.from_env()`
  - `SSHClient.from_env()`
  - `SpectreSimulator.from_env()` and direct `SpectreSimulator(remote=True)`
  - `remote_ssh_env_from_os()`
  - CLI profile selection
- Adds CLI commands:
  - `virtuoso-bridge profile show`
  - `virtuoso-bridge profile bind PROFILE --venv`
  - `virtuoso-bridge profile clear --venv`
- Adds convenience startup:
  - `virtuoso-bridge start -p PROFILE --bind-venv`
- Keeps ordinary `start -p PROFILE` non-persistent. It does not modify the virtualenv binding.

## Resolution order

The resolver currently uses:

1. explicit `profile=` argument or CLI `-p`
2. process environment `VB_PROFILE`
3. explicitly selected `--env` file's `VB_PROFILE`
4. active virtualenv binding file
5. user-level `~/.virtuoso-bridge/.env` `VB_PROFILE`
6. `None` for legacy default-profile behavior

## Compatibility

- Explicit `profile=` and CLI `-p` remain highest priority.
- Existing users without profile bindings keep the old default behavior.
- A plain `start -p foo` remains temporary and does not write persistent state.
- The virtualenv binding stores only a profile name, not host/user/ports/secrets.

## Risks and caveats

- **Hidden persistent state:** a virtualenv binding is local state. Users might forget a venv is bound to a profile. Mitigation: `virtuoso-bridge profile show` prints the resolved profile, source, and binding path.
- **Shared virtualenvs:** if one virtualenv is reused across unrelated task domains, binding it to one profile can make naked `from_env()` calls use the wrong profile. Mitigation: explicit `-p`, explicit `profile=`, and `VB_PROFILE` all override the binding; ordinary `start -p` does not persistently bind.
- **This is not a daemon identity guard:** the resolver selects the intended profile, but it does not prove the remote daemon/CIW actually corresponds to that profile. A future follow-up could write `RB_PROFILE` into the setup script and have the client reject mismatches.
- **Project semantics remain outside the bridge:** the bridge resolves profile names, but it still does not know which profile is appropriate for a specific PDK, IO flow, or project. Downstream projects can choose to bind a venv, set `VB_PROFILE`, or continue passing explicit `profile=`.

## Tests

- `pytest -q` -> 48 passed
- `python -m compileall -q src/virtuoso_bridge tests`
- manual smoke test for `profile bind/show/clear` using a temporary virtualenv directory