### PR TITLE
Scope remote scratch directories by local client

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,13 +65,15 @@ virtuoso-bridge start
 
 **4. Load SKILL in Virtuoso CIW**
 
-`virtuoso-bridge start` deploys the SKILL bridge files to a per-user
-temp dir on the remote host and prints the exact `load(...)` line you
-need to paste into the CIW (the path includes your username, so it is
-collision-free across users on a shared machine):
+`virtuoso-bridge start` deploys the SKILL bridge files to a per-remote-user,
+per-local-client temp dir on the remote host and prints the exact `load(...)`
+line you need to paste into the CIW. The client segment defaults to the local
+account running bridge (for example `90590` on Windows) and can be overridden
+with `VB_CLIENT_ID` or `VB_CLIENT_ID_<profile>`, so it is collision-free across
+users and across local machines sharing the same remote scratch root:
 
 ```
-load("/tmp/virtuoso_bridge_<user>/virtuoso_bridge/virtuoso_setup.il")
+load("/tmp/virtuoso_bridge_<remote_user>/<client_id>/virtuoso_bridge/virtuoso_setup.il")
 ```
 
 (Run `virtuoso-bridge status` again at any time to re-print this line.
@@ -168,9 +170,8 @@ Your machine  ──SSH──►  Jump host (bastion)  ──SSH──►  Compu
 
 Same flow as remote, but with `VB_REMOTE_HOST=localhost` (or `127.0.0.1`):
 `virtuoso-bridge start` notices it's local, skips the SSH tunnel, and
-deploys the SKILL bridge files to `/tmp/virtuoso_bridge_<user>/`.  Paste
-the `load(...)` line it prints into your CIW once, then connect from
-Python:
+deploys the SKILL bridge files under the local bridge cache.  Paste the
+`load(...)` line it prints into your CIW once, then connect from Python:
 
 ```python
 from virtuoso_bridge import VirtuosoClient

--- a/examples/01_virtuoso/basic/06_screenshot.py
+++ b/examples/01_virtuoso/basic/06_screenshot.py
@@ -22,6 +22,7 @@ from _timing import decode_skill, format_elapsed, timed_call
 from virtuoso_bridge import VirtuosoClient
 from virtuoso_bridge.transport.remote_paths import (
     default_virtuoso_bridge_dir,
+    resolve_client_id,
     resolve_remote_username,
 )
 from virtuoso_bridge.virtuoso.ops import escape_skill_string
@@ -50,7 +51,11 @@ def main() -> int:
         configured_user=client._tunnel._remote_user,
         runner=client._tunnel._ssh_runner,
     )
-    screenshot_dir = default_virtuoso_bridge_dir(username, "screenshots")
+    screenshot_dir = default_virtuoso_bridge_dir(
+        username,
+        "screenshots",
+        resolve_client_id(getattr(client._tunnel, "_profile", None)) if client._tunnel else None,
+    )
     remote_path = f"{screenshot_dir}/{cell}_{stamp}.png"
     # Create directory via SSH (not SKILL csh) so it exists on the SSH-accessible filesystem
     mkdir_result = client._tunnel._ssh_runner.run_command(f"mkdir -p {screenshot_dir}")

--- a/examples/01_virtuoso/schematic/08_import_cdl_cap_array.py
+++ b/examples/01_virtuoso/schematic/08_import_cdl_cap_array.py
@@ -35,6 +35,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 from virtuoso_bridge import VirtuosoClient
 from virtuoso_bridge.transport.remote_paths import (
     default_virtuoso_bridge_dir,
+    resolve_client_id,
     resolve_remote_username,
 )
 
@@ -137,7 +138,11 @@ def main() -> int:
         configured_user=client._tunnel._remote_user,
         runner=client._tunnel._ssh_runner,
     )
-    remote_tmp = default_virtuoso_bridge_dir(username, "cap_array")
+    remote_tmp = default_virtuoso_bridge_dir(
+        username,
+        "cap_array",
+        resolve_client_id(getattr(client._tunnel, "_profile", None)) if client._tunnel else None,
+    )
 
     # 1. Write CDL and devmap locally, upload via bridge
     cdl_path = f"{remote_tmp}/cap_array_4b.cdl"

--- a/src/virtuoso_bridge/cli.py
+++ b/src/virtuoso_bridge/cli.py
@@ -797,7 +797,7 @@ def cli_dismiss_dialog() -> int:
     from virtuoso_bridge.virtuoso import x11
     runner, user = _make_ssh_runner()
 
-    dialogs = x11.dismiss_dialogs(runner, user)
+    dialogs = x11.dismiss_dialogs(runner, user, profile=_get_cli_profile())
     if not dialogs:
         print("No dialog windows found.")
         return 0

--- a/src/virtuoso_bridge/cli.py
+++ b/src/virtuoso_bridge/cli.py
@@ -352,6 +352,11 @@ def _print_status() -> int:
 
     # Infer setup_path from user config when state is unavailable
     def _infer_setup_path() -> str | None:
+        from virtuoso_bridge.transport.remote_paths import (
+            default_virtuoso_bridge_dir,
+            resolve_client_id,
+        )
+
         user = configured_user
         if not user:
             import getpass
@@ -359,7 +364,12 @@ def _print_status() -> int:
                 user = getpass.getuser()
             except Exception:
                 return None
-        return f"/tmp/virtuoso_bridge_{user}/{_profiled_bridge_leaf(profile)}/virtuoso_setup.il"
+        work_dir = default_virtuoso_bridge_dir(
+            user,
+            _profiled_bridge_leaf(profile),
+            resolve_client_id(profile),
+        )
+        return f"{work_dir}/virtuoso_setup.il"
 
     if is_local:
         print(f"\n[mode] local (no SSH tunnel)")

--- a/src/virtuoso_bridge/resources/.env_template
+++ b/src/virtuoso_bridge/resources/.env_template
@@ -21,6 +21,11 @@
 VB_REMOTE_HOST=
 VB_REMOTE_USER=
 
+# Local client identity used as a remote scratch path segment.
+# Defaults to the local account running bridge (for example Windows USERNAME).
+# Set this when multiple local machines share one remote account/scratch root.
+# VB_CLIENT_ID=
+
 # Jump host (only if your SSH path uses a bastion)
 # VB_JUMP_HOST=
 # VB_JUMP_USER=

--- a/src/virtuoso_bridge/spectre/runner.py
+++ b/src/virtuoso_bridge/spectre/runner.py
@@ -24,6 +24,7 @@ from virtuoso_bridge.spectre.parsers import (
 from virtuoso_bridge.transport.tunnel import _is_localhost
 from virtuoso_bridge.transport.remote_paths import (
     default_remote_spectre_work_dir,
+    resolve_client_id,
     resolve_remote_username,
 )
 from virtuoso_bridge.transport.ssh import SSHRunner, RemoteTaskResult, run_remote_task, remote_ssh_env_from_os
@@ -821,7 +822,10 @@ class SpectreSimulator:
                 configured_user=self._remote_user or runner.user,
                 runner=runner,
             )
-            self._remote_work_dir = default_remote_spectre_work_dir(username)
+            self._remote_work_dir = default_remote_spectre_work_dir(
+                username,
+                resolve_client_id(self._profile),
+            )
             logger.info("Remote work dir: %s", self._remote_work_dir)
         if self._remote_work_dir is None:
             return SimulationResult(

--- a/src/virtuoso_bridge/transport/remote_paths.py
+++ b/src/virtuoso_bridge/transport/remote_paths.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import getpass
 import os
 import re
+import socket
 from typing import TYPE_CHECKING
 
 from virtuoso_bridge.env import load_vb_env
@@ -13,11 +14,14 @@ if TYPE_CHECKING:
     from virtuoso_bridge.transport.ssh import SSHRunner
 
 REMOTE_SCRATCH_ROOT_ENV = "VB_REMOTE_SCRATCH_ROOT"
+CLIENT_ID_ENV = "VB_CLIENT_ID"
+
 
 def remote_scratch_root() -> str:
     """Base directory for remote scratch (default ``/tmp``)."""
     load_vb_env()
     return os.environ.get(REMOTE_SCRATCH_ROOT_ENV, "/tmp").rstrip("/")
+
 
 def sanitize_username_for_path(username: str) -> str:
     """Make a username safe as a single path segment."""
@@ -27,6 +31,44 @@ def sanitize_username_for_path(username: str) -> str:
     if re.match(r"^[a-zA-Z0-9._-]+$", s):
         return s[:64]
     return re.sub(r"[^a-zA-Z0-9._-]", "_", s)[:64]
+
+
+def sanitize_client_id_for_path(client_id: str) -> str:
+    """Make a local client identity safe as a single path segment."""
+    s = client_id.strip()
+    if not s:
+        return "unknown_client"
+    if re.match(r"^[a-zA-Z0-9._-]+$", s):
+        return s[:64]
+    return re.sub(r"[^a-zA-Z0-9._-]", "_", s)[:64]
+
+
+def resolve_client_id(profile: str | None = None) -> str:
+    """Resolve local client identity for remote scratch isolation.
+
+    This is the machine/account running the bridge locally, not the remote
+    EDA host.  Override with ``VB_CLIENT_ID`` or ``VB_CLIENT_ID_<profile>``.
+    """
+    load_vb_env()
+    suffix = f"_{profile}" if profile else ""
+    for key in (f"{CLIENT_ID_ENV}{suffix}", CLIENT_ID_ENV, "USERNAME", "USER"):
+        v = os.environ.get(key, "").strip()
+        if v:
+            return sanitize_client_id_for_path(v)
+    try:
+        local = getpass.getuser()
+        if local:
+            return sanitize_client_id_for_path(local)
+    except Exception:
+        pass
+    try:
+        host = socket.gethostname()
+        if host:
+            return sanitize_client_id_for_path(host)
+    except Exception:
+        pass
+    return "unknown_client"
+
 
 def resolve_remote_username(
     *,
@@ -55,15 +97,32 @@ def resolve_remote_username(
             return sanitize_username_for_path(v)
     return fallback
 
-def default_virtuoso_bridge_dir(username: str, leaf: str) -> str:
-    """Return ``{scratch}/virtuoso_bridge_{user}/{leaf}``."""
+
+def default_virtuoso_bridge_dir(
+    username: str,
+    leaf: str,
+    client_id: str | None = None,
+) -> str:
+    """Return the default remote scratch directory for bridge artifacts.
+
+    When *client_id* is provided, include it as a path segment so the same
+    remote user/profile pair can safely use a shared scratch root from
+    multiple local machines.
+    """
     safe = sanitize_username_for_path(username)
     root = remote_scratch_root()
     leaf_norm = leaf.strip("/").replace("\\", "/")
+    if client_id:
+        safe_client = sanitize_client_id_for_path(client_id)
+        return f"{root}/virtuoso_bridge_{safe}/{safe_client}/{leaf_norm}"
     return f"{root}/virtuoso_bridge_{safe}/{leaf_norm}"
 
 REMOTE_SPECTRE_LEAF = "virtuoso_bridge_spectre"
 
-def default_remote_spectre_work_dir(username: str) -> str:
+
+def default_remote_spectre_work_dir(
+    username: str,
+    client_id: str | None = None,
+) -> str:
     """Default remote scratch for Spectre simulations."""
-    return default_virtuoso_bridge_dir(username, REMOTE_SPECTRE_LEAF)
+    return default_virtuoso_bridge_dir(username, REMOTE_SPECTRE_LEAF, client_id)

--- a/src/virtuoso_bridge/transport/tunnel.py
+++ b/src/virtuoso_bridge/transport/tunnel.py
@@ -21,7 +21,11 @@ from typing import Any
 
 from virtuoso_bridge.env import load_vb_env, resolve_env_path
 from virtuoso_bridge.profile import resolve_profile
-from virtuoso_bridge.transport.remote_paths import default_virtuoso_bridge_dir, resolve_remote_username
+from virtuoso_bridge.transport.remote_paths import (
+    default_virtuoso_bridge_dir,
+    resolve_client_id,
+    resolve_remote_username,
+)
 from virtuoso_bridge.transport.ssh import SSHRunner, CommandResult
 
 logger = logging.getLogger(__name__)
@@ -330,6 +334,7 @@ class SSHClient:
         self._remote_work_dir = default_virtuoso_bridge_dir(
             remote_username,
             _profiled_bridge_leaf(self._profile),
+            resolve_client_id(self._profile),
         )
 
         remote_daemon = f"{self._remote_work_dir}/{daemon_filename}"

--- a/src/virtuoso_bridge/virtuoso/basic/bridge.py
+++ b/src/virtuoso_bridge/virtuoso/basic/bridge.py
@@ -668,7 +668,8 @@ let((result winName ciwNum)
             user = os.getenv("USER", "") or os.getenv("USERNAME", "") or "local"
         else:
             user = runner.user or os.getenv("VB_REMOTE_USER", "")
-        return x11.dismiss_dialogs(runner, user, display)
+        profile = getattr(self._tunnel, "_profile", None) if self._tunnel else None
+        return x11.dismiss_dialogs(runner, user, display, profile=profile)
 
     # -- file transfer (delegates to tunnel) --------------------------------
 

--- a/src/virtuoso_bridge/virtuoso/basic/bridge.py
+++ b/src/virtuoso_bridge/virtuoso/basic/bridge.py
@@ -520,7 +520,10 @@ let((result winName ciwNum)
             configured_user=self._tunnel._remote_user if self._tunnel else None,
             runner=self._tunnel._ssh_runner if self._tunnel else None,
         )
-        screenshot_dir = default_virtuoso_bridge_dir(username, "screenshots")
+        from virtuoso_bridge.transport.remote_paths import resolve_client_id
+
+        client_id = resolve_client_id(getattr(self._tunnel, '_profile', None)) if self._tunnel else None
+        screenshot_dir = default_virtuoso_bridge_dir(username, "screenshots", client_id)
         if self._tunnel and self._tunnel._ssh_runner:
             self._tunnel._ssh_runner.run_command(f"mkdir -p {screenshot_dir}")
 
@@ -820,7 +823,11 @@ let((result winName ciwNum)
         """Return (remote_path, uploaded) where uploaded=False means cache hit."""
         p = Path(path)
         if self._tunnel is not None and p.is_file():
-            from virtuoso_bridge.transport.remote_paths import default_virtuoso_bridge_dir, resolve_remote_username
+            from virtuoso_bridge.transport.remote_paths import (
+                default_virtuoso_bridge_dir,
+                resolve_client_id,
+                resolve_remote_username,
+            )
             from virtuoso_bridge.transport.tunnel import _profiled_bridge_leaf
             work_dir = self._tunnel.remote_work_dir
             if not work_dir:
@@ -831,6 +838,7 @@ let((result winName ciwNum)
                 work_dir = default_virtuoso_bridge_dir(
                     remote_username,
                     _profiled_bridge_leaf(getattr(self._tunnel, '_profile', None)),
+                    resolve_client_id(getattr(self._tunnel, '_profile', None)),
                 )
             remote_dir = work_dir.rstrip("/")
             remote_path = f"{remote_dir}/{p.name}"

--- a/src/virtuoso_bridge/virtuoso/x11.py
+++ b/src/virtuoso_bridge/virtuoso/x11.py
@@ -72,7 +72,11 @@ def _detect_remote_python(runner: SSHRunner | None) -> str:
     return "python3"  # fallback, will fail with clear error
 
 
-def _ensure_helper(runner: SSHRunner | None, user: str) -> str:
+def _ensure_helper(
+    runner: SSHRunner | None,
+    user: str,
+    profile: str | None = None,
+) -> str:
     """Resolve the path to the helper script.
 
     Remote: upload under the client-scoped bridge scratch directory.
@@ -81,7 +85,7 @@ def _ensure_helper(runner: SSHRunner | None, user: str) -> str:
     """
     if runner is None:
         return str(_HELPER_SCRIPT)
-    remote_dir = default_virtuoso_bridge_dir(user, "x11", resolve_client_id())
+    remote_dir = default_virtuoso_bridge_dir(user, "x11", resolve_client_id(profile))
     remote_path = f"{remote_dir}/x11_dismiss_dialog.py"
     runner.run_command(f"mkdir -p {remote_dir}")
     runner.upload(_HELPER_SCRIPT, remote_path)
@@ -92,13 +96,14 @@ def find_dialogs(
     runner: SSHRunner | None,
     user: str,
     display: str | None = None,
+    profile: str | None = None,
 ) -> list[dict[str, Any]]:
     """Find blocking dialog windows on the X11 display.
 
     Returns list of dicts: [{"window_id", "title", "x", "y", "w", "h"}, ...]
     """
     load_vb_env()
-    script = _ensure_helper(runner, user)
+    script = _ensure_helper(runner, user, profile)
     py = _detect_remote_python(runner)
     resolved = _get_display(display)
     cmd = f"{py} {script}"
@@ -112,13 +117,14 @@ def dismiss_dialogs(
     runner: SSHRunner | None,
     user: str,
     display: str | None = None,
+    profile: str | None = None,
 ) -> list[dict[str, Any]]:
     """Find and dismiss all blocking dialog windows.
 
     Returns list of result dicts (found dialogs + dismissal results).
     """
     load_vb_env()
-    script = _ensure_helper(runner, user)
+    script = _ensure_helper(runner, user, profile)
     py = _detect_remote_python(runner)
     resolved = _get_display(display)
     env_prefix = ""

--- a/src/virtuoso_bridge/virtuoso/x11.py
+++ b/src/virtuoso_bridge/virtuoso/x11.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any
 
 from virtuoso_bridge.env import load_vb_env
+from virtuoso_bridge.transport.remote_paths import default_virtuoso_bridge_dir, resolve_client_id
 from virtuoso_bridge.transport.ssh import SSHRunner
 
 logger = logging.getLogger(__name__)
@@ -74,14 +75,14 @@ def _detect_remote_python(runner: SSHRunner | None) -> str:
 def _ensure_helper(runner: SSHRunner | None, user: str) -> str:
     """Resolve the path to the helper script.
 
-    Remote: upload to ``/tmp/virtuoso_bridge_<user>/`` if not already there.
+    Remote: upload under the client-scoped bridge scratch directory.
     Local: the helper file is part of the installed package — return its
     on-disk path directly, no copy needed.
     """
     if runner is None:
         return str(_HELPER_SCRIPT)
-    remote_path = f"/tmp/virtuoso_bridge_{user}/x11_dismiss_dialog.py"
-    remote_dir = str(Path(remote_path).parent)
+    remote_dir = default_virtuoso_bridge_dir(user, "x11", resolve_client_id())
+    remote_path = f"{remote_dir}/x11_dismiss_dialog.py"
     runner.run_command(f"mkdir -p {remote_dir}")
     runner.upload(_HELPER_SCRIPT, remote_path)
     return remote_path

--- a/tests/test_profile_resolver.py
+++ b/tests/test_profile_resolver.py
@@ -18,6 +18,8 @@ from virtuoso_bridge.virtuoso.basic.bridge import VirtuosoClient
 def _isolate_profile_env(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.delenv("VB_PROFILE", raising=False)
     monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    monkeypatch.setattr(sys, "prefix", str(tmp_path / "base-python"))
+    monkeypatch.setattr(sys, "base_prefix", str(tmp_path / "base-python"))
     monkeypatch.setattr(
         "virtuoso_bridge.profile.default_user_env_path",
         lambda: tmp_path / "missing-user.env",

--- a/tests/test_remote_paths.py
+++ b/tests/test_remote_paths.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from virtuoso_bridge.transport.remote_paths import (
+    default_virtuoso_bridge_dir,
+    default_remote_spectre_work_dir,
+    resolve_client_id,
+)
+
+
+def test_default_bridge_dir_preserves_legacy_path_without_client_id(monkeypatch) -> None:
+    monkeypatch.setattr("virtuoso_bridge.transport.remote_paths.load_vb_env", lambda: None)
+    monkeypatch.delenv("VB_REMOTE_SCRATCH_ROOT", raising=False)
+
+    assert (
+        default_virtuoso_bridge_dir("designer", "virtuoso_bridge_t28_io")
+        == "/tmp/virtuoso_bridge_designer/virtuoso_bridge_t28_io"
+    )
+
+
+def test_default_bridge_dir_can_be_client_scoped(monkeypatch) -> None:
+    monkeypatch.setattr("virtuoso_bridge.transport.remote_paths.load_vb_env", lambda: None)
+    monkeypatch.delenv("VB_REMOTE_SCRATCH_ROOT", raising=False)
+
+    assert (
+        default_virtuoso_bridge_dir("designer", "virtuoso_bridge_t28_io", "90590")
+        == "/tmp/virtuoso_bridge_designer/90590/virtuoso_bridge_t28_io"
+    )
+
+
+def test_default_spectre_dir_can_be_client_scoped(monkeypatch) -> None:
+    monkeypatch.setattr("virtuoso_bridge.transport.remote_paths.load_vb_env", lambda: None)
+    monkeypatch.delenv("VB_REMOTE_SCRATCH_ROOT", raising=False)
+
+    assert (
+        default_remote_spectre_work_dir("designer", "lab/pc:1")
+        == "/tmp/virtuoso_bridge_designer/lab_pc_1/virtuoso_bridge_spectre"
+    )
+
+
+def test_resolve_client_id_prefers_profile_env(monkeypatch) -> None:
+    monkeypatch.setattr("virtuoso_bridge.transport.remote_paths.load_vb_env", lambda: None)
+    monkeypatch.setenv("VB_CLIENT_ID", "90590")
+    monkeypatch.setenv("VB_CLIENT_ID_t28_io", "workstation_a")
+
+    assert resolve_client_id("t28_io") == "workstation_a"
+    assert resolve_client_id() == "90590"

--- a/tests/test_tunnel_profiles.py
+++ b/tests/test_tunnel_profiles.py
@@ -38,6 +38,10 @@ def test_profiled_env_key_preserves_default_and_suffixes_profiles() -> None:
 
 
 def test_remote_setup_path_and_port_are_profile_scoped(monkeypatch) -> None:
+    monkeypatch.setattr("virtuoso_bridge.transport.remote_paths.load_vb_env", lambda: None)
+    monkeypatch.delenv("VB_REMOTE_SCRATCH_ROOT", raising=False)
+    monkeypatch.delenv("VB_CLIENT_ID_t28_digital", raising=False)
+    monkeypatch.setenv("VB_CLIENT_ID", "90590")
     fake = _FakeRunner()
     client = SSHClient(
         remote_host="thu-wei",
@@ -50,15 +54,19 @@ def test_remote_setup_path_and_port_are_profile_scoped(monkeypatch) -> None:
 
     client.ensure_remote_setup()
 
-    assert client.remote_work_dir == "/tmp/virtuoso_bridge_designer/virtuoso_bridge_t28_digital"
-    setup_path = "/tmp/virtuoso_bridge_designer/virtuoso_bridge_t28_digital/virtuoso_setup.il"
+    assert client.remote_work_dir == "/tmp/virtuoso_bridge_designer/90590/virtuoso_bridge_t28_digital"
+    setup_path = "/tmp/virtuoso_bridge_designer/90590/virtuoso_bridge_t28_digital/virtuoso_setup.il"
     setup = fake.uploads[setup_path]
     assert 'setShellEnvVar("RB_PORT" "65263")' in setup
-    assert '/tmp/virtuoso_bridge_designer/virtuoso_bridge_t28_digital/ramic_bridge.il' in setup
+    assert '/tmp/virtuoso_bridge_designer/90590/virtuoso_bridge_t28_digital/ramic_bridge.il' in setup
 
 
 def test_status_infers_profile_scoped_setup_path(monkeypatch, capsys) -> None:
     monkeypatch.setattr(cli, "_load_cli_env", lambda: None)
+    monkeypatch.setattr("virtuoso_bridge.transport.remote_paths.load_vb_env", lambda: None)
+    monkeypatch.delenv("VB_REMOTE_SCRATCH_ROOT", raising=False)
+    monkeypatch.delenv("VB_CLIENT_ID_t28_io", raising=False)
+    monkeypatch.setenv("VB_CLIENT_ID", "90590")
     monkeypatch.setattr(cli, "_CLI_PROFILE", ["t28_io"])
     monkeypatch.setenv("VB_REMOTE_HOST_t28_io", "thu-wei")
     monkeypatch.setenv("VB_REMOTE_USER_t28_io", "designer")
@@ -78,6 +86,6 @@ def test_status_infers_profile_scoped_setup_path(monkeypatch, capsys) -> None:
 
     assert rc == 1
     assert (
-        'load("/tmp/virtuoso_bridge_designer/virtuoso_bridge_t28_io/virtuoso_setup.il")'
+        'load("/tmp/virtuoso_bridge_designer/90590/virtuoso_bridge_t28_io/virtuoso_setup.il")'
         in capsys.readouterr().out
     )

--- a/tests/test_x11_paths.py
+++ b/tests/test_x11_paths.py
@@ -29,3 +29,17 @@ def test_x11_helper_uses_client_scoped_bridge_dir(monkeypatch) -> None:
     assert remote_path == "/tmp/virtuoso_bridge_designer/90590/x11/x11_dismiss_dialog.py"
     assert runner.commands == ["mkdir -p /tmp/virtuoso_bridge_designer/90590/x11"]
     assert runner.uploads[0][1] == remote_path
+
+
+def test_x11_helper_uses_profile_scoped_client_id(monkeypatch) -> None:
+    monkeypatch.setattr("virtuoso_bridge.transport.remote_paths.load_vb_env", lambda: None)
+    monkeypatch.delenv("VB_REMOTE_SCRATCH_ROOT", raising=False)
+    monkeypatch.setenv("VB_CLIENT_ID", "90590")
+    monkeypatch.setenv("VB_CLIENT_ID_t28_io", "workstation_a")
+    runner = _FakeRunner()
+
+    remote_path = x11._ensure_helper(runner, "designer", profile="t28_io")
+
+    assert remote_path == "/tmp/virtuoso_bridge_designer/workstation_a/x11/x11_dismiss_dialog.py"
+    assert runner.commands == ["mkdir -p /tmp/virtuoso_bridge_designer/workstation_a/x11"]
+    assert runner.uploads[0][1] == remote_path

--- a/tests/test_x11_paths.py
+++ b/tests/test_x11_paths.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from virtuoso_bridge.virtuoso import x11
+
+
+class _FakeRunner:
+    def __init__(self) -> None:
+        self.commands: list[str] = []
+        self.uploads: list[tuple[Path, str]] = []
+
+    def run_command(self, command: str, timeout=None):
+        self.commands.append(command)
+
+    def upload(self, local_path: Path, remote_path: str):
+        self.uploads.append((local_path, remote_path))
+
+
+def test_x11_helper_uses_client_scoped_bridge_dir(monkeypatch) -> None:
+    monkeypatch.setattr("virtuoso_bridge.transport.remote_paths.load_vb_env", lambda: None)
+    monkeypatch.delenv("VB_REMOTE_SCRATCH_ROOT", raising=False)
+    monkeypatch.delenv("VB_CLIENT_ID_t28_io", raising=False)
+    monkeypatch.setenv("VB_CLIENT_ID", "90590")
+    runner = _FakeRunner()
+
+    remote_path = x11._ensure_helper(runner, "designer")
+
+    assert remote_path == "/tmp/virtuoso_bridge_designer/90590/x11/x11_dismiss_dialog.py"
+    assert runner.commands == ["mkdir -p /tmp/virtuoso_bridge_designer/90590/x11"]
+    assert runner.uploads[0][1] == remote_path


### PR DESCRIPTION
## Summary
- add a local client identity segment to default remote scratch paths
- allow VB_CLIENT_ID / VB_CLIENT_ID_<profile> overrides, falling back to the local account
- apply client-scoped paths to tunnel setup, Spectre work dirs, status load hints, screenshots, X11 helper uploads, and examples

## Tests
- `..\.venv\Scripts\python.exe -m pytest`
