### PR TITLE
docs: show clone path in quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ Spectre.
 ## Quick Start
 
 ```bash
+# 0. Get the source
+git clone https://github.com/Arcadia-1/virtuoso-bridge-lite.git
+cd virtuoso-bridge-lite
+
 # 1. Install in a virtual environment
 uv venv .venv
 source .venv/bin/activate
@@ -70,6 +74,9 @@ virtuoso-bridge init user@host [-J user@jump-host]
 virtuoso-bridge start          # starts tunnel and prints the CIW load(...) line
 virtuoso-bridge status         # tunnel + Virtuoso daemon + Spectre availability
 ```
+
+On Windows PowerShell, replace the activation line with
+`.\.venv\Scripts\Activate.ps1`.
 
 ```python
 from virtuoso_bridge import VirtuosoClient


### PR DESCRIPTION
## Summary
- add explicit clone and cd steps before the editable install
- keep the primary Quick Start bash/Linux-first and concise
- add a one-line PowerShell activation note

## Testing
- Not run; documentation-only change.