### PR TITLE
docs: keep quick start venv outside checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,11 @@ Spectre.
 ```bash
 # 0. Get the source
 git clone https://github.com/Arcadia-1/virtuoso-bridge-lite.git
-cd virtuoso-bridge-lite
 
 # 1. Install in a virtual environment
 uv venv .venv
 source .venv/bin/activate
-uv pip install -e .
+uv pip install -e ./virtuoso-bridge-lite
 
 # 2. Create ~/.virtuoso-bridge/.env
 virtuoso-bridge init user@host [-J user@jump-host]


### PR DESCRIPTION
## Summary
- keep the quick start virtualenv outside the cloned checkout
- install the editable package by pointing pip at ./virtuoso-bridge-lite
- avoid changing the Linux/macOS-first quick start structure

## Testing
- Not run; documentation-only change.