### PR TITLE
feat(skill-finder): add SKILL Finder and More Info CLI commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -271,6 +271,8 @@ virtuoso-bridge export-visio LIB CELL -o out.vsdx  # Windows + Visio/pywin32 sch
                                                    #   --stencil PATH            override circuit.vss location
 virtuoso-bridge screenshot      # screenshot CIW (or: current, N)
 virtuoso-bridge dismiss-dialog  # dismiss blocking GUI dialogs via X11
+virtuoso-bridge skill-find <query>  # search SKILL functions by name (fuzzy/prefix/suffix/exact/regex)
+virtuoso-bridge skill-info <fn>  # get detailed More Info docs for a SKILL function
 ```
 
 ## Build
@@ -328,6 +330,7 @@ When working on a task, check this table to find relevant skills and references.
 | Domain | Skill | Entry point | Key references |
 |---|---|---|---|
 | **Virtuoso / SKILL** | `virtuoso` | `skills/virtuoso/SKILL.md` | `references/layout-skill-api.md`, `references/schematic-skill-api.md`, `references/maestro-skill-api.md`, `references/troubleshooting.md` |
+| **SKILL Finder** | `virtuoso` | `skills/virtuoso/SKILL.md` | `references/skill-finder-python-api.md` |
 | **Layout** | `virtuoso` | `skills/virtuoso/SKILL.md` | `references/layout-python-api.md`, `references/layout-skill-api.md` |
 | **Schematic** | `virtuoso` | `skills/virtuoso/SKILL.md` | `references/schematic-python-api.md`, `references/schematic-skill-api.md`, `references/schematic-recreation.md` |
 | **Maestro / ADE** | `virtuoso` | `skills/virtuoso/SKILL.md` | `references/maestro-python-api.md`, `references/maestro-skill-api.md`, `references/simulation-flow.md` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "python-dotenv>=1.0",
     "pydantic>=2.0",
     "pyyaml>=6.0",
+    "markdownify>=0.14",
 ]
 
 [project.optional-dependencies]

--- a/skills/virtuoso/SKILL.md
+++ b/skills/virtuoso/SKILL.md
@@ -50,6 +50,7 @@ Always use the highest level that works. Drop to a lower level only when needed.
 | **Layout** | Create/edit layout, add shapes/vias/instances | `client.layout.*` | `references/layout-python-api.md`, `references/layout-skill-api.md` |
 | **Maestro** | Read/write ADE Assembler config, run simulations | `virtuoso_bridge.virtuoso.maestro` | `references/maestro-python-api.md`, `references/maestro-skill-api.md` |
 | **Netlist (si)** | Batch netlist generation without Maestro | `simInitEnvWithArgs` + `si` CLI | See "Batch Netlist (si)" section below |
+| **SKILL Finder** | Search SKILL function names and get detailed docs | `client.find_skill()`, `client.get_skill_more_info()` | `references/skill-finder-python-api.md` |
 | **General** | File transfer, screenshots, raw SKILL, .il loading | `client.*` | See below |
 
 ## Before you start
@@ -207,6 +208,7 @@ Load on demand — each contains detailed API docs and edge-case guidance:
 | `references/cellview-on-disk-layout.md` | What's inside each view on disk (`sch.oa`, `data.dm` binary format, `maestro.sdb`/`active.state` XML skeleton, lock files, SOS markers); which files are text-editable vs must go through DFII API |
 | `references/schematic-recreation.md` | Recreate schematic from existing design (grid layout, diff pair conventions) |
 | `references/batch-netlist-si.md` | Generate netlists without Maestro using si batch translator |
+| `references/skill-finder-python-api.md` | `skill-find` (search SKILL by name) and `skill-info` (More Info docs) |
 
 ## Examples
 

--- a/skills/virtuoso/references/skill-finder-python-api.md
+++ b/skills/virtuoso/references/skill-finder-python-api.md
@@ -1,0 +1,122 @@
+# SKILL Finder — Python API
+
+VirtuosoBridge provides two independent tools for querying Cadence SKILL APIs:
+
+| Tool | Purpose | Remote data source |
+|------|---------|-------------------|
+| **SKILL Finder** (`skill-find`) | Search SKILL functions by name | `doc/finder/SKILL/*.fnd` (name + syntax + description) |
+| **More Info** (`skill-info`) | Get detailed docs for a specific function | `doc/api_more_info/api_more_info.tgf` + HTML docs |
+
+Both are accessed via `VirtuosoClient.find_skill()` and `VirtuosoClient.get_skill_more_info()`.
+
+---
+
+## SKILL Finder (`skill-find`)
+
+**Purpose:** Search SKILL functions by name. Returns function name, syntax signature, and one-line description.
+
+**Data source:** Cadence SKILL Finder database `doc/finder/SKILL/*.fnd`. On first run the database is automatically downloaded to a local cache.
+
+```python
+from virtuoso_bridge import VirtuosoClient
+client = VirtuosoClient.from_env()
+
+# Default fuzzy search (case-insensitive substring)
+results = client.find_skill("dbOpenCellView")
+
+# Search modes
+results = client.find_skill("dbOpenCellView", mode="exact")
+results = client.find_skill("dbOpen", mode="prefix")     # name starts with dbOpen
+results = client.find_skill("ViewByType", mode="suffix")  # name ends with ViewByType
+results = client.find_skill("^db.*$", mode="regex")     # Python regex
+
+# Limit results
+results = client.find_skill("dbOpen", limit=10)
+```
+
+**Returns:** `List[SKILLEntry]`, each entry contains:
+- `name`: function name
+- `syntax`: function signature (Lisp-style parameter notation)
+- `description`: one-line description
+- `source`: source `.fnd` filename
+
+**Search modes:**
+
+| Mode | Description | Example |
+|------|-------------|---------|
+| `fuzzy` | Case-insensitive substring match (default) | `"dbOpen"` matches `"dbOpenCellViewByType"` |
+| `prefix` | Name starts with query | `"dbOpen"` matches `"dbOpenCellView"` |
+| `suffix` | Name ends with query | `"ViewByType"` matches `"dbOpenCellViewByType"` |
+| `exact` | Name equals query exactly | `"dbOpenCellViewByType"` matches only that |
+| `regex` | Python regular expression | `"^db.*$"` matches all names starting with `db` |
+
+**Syntax signature format (Lisp-style):**
+
+```scheme
+dbOpenCellViewByType(
+  { gt_lib | nil }       ; required: library name or nil
+  t_cellName             ; required: cell name
+  lt_viewName            ; required: view name
+  [ t_viewTypeName ]    ; optional: view type
+  [ t_mode ]            ; optional: mode
+  [ d_contextCellView ] ; optional: context cellview
+) => d_cellView / nil
+```
+
+- `{ a | b }` — choose one (usually required)
+- `[ arg ]` — optional argument
+- `=> ret / nil` — return value
+
+---
+
+## More Info (`skill-info`)
+
+**Purpose:** Get detailed documentation for a SKILL function (Description / Arguments / Returns / Example / etc.).
+
+**Data source:** Cadence More Info system — `doc/api_more_info/api_more_info.tgf` index + HTML docs (downloaded on demand).
+
+```python
+from virtuoso_bridge import VirtuosoClient
+client = VirtuosoClient.from_env()
+
+# Get detailed docs for a function
+info = client.get_skill_more_info("absGetOption")
+
+# Returns a dict:
+# {
+#   "func_name": "absGetOption",
+#   "file_path": "$abstract/abstract_skill.html",
+#   "topic": "absGetOption",
+#   "raw_html": "<html>...</html>",
+#   "plain_text": "### absGetOption\n..."  # markdown-formatted
+# }
+
+# Print as markdown
+print(info["plain_text"])
+```
+
+**Return value format (`MoreInfoResult`):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `func_name` | `str` | Function name |
+| `file_path` | `str` | HTML doc path (e.g. `$abstract/abstract_skill.html`) |
+| `topic` | `str \| None` | Topic name from TGF index; NULL means whole file |
+| `raw_html` | `str` | Raw HTML content |
+| `plain_text` | `str` | Rendered as markdown-formatted plain text |
+
+Use `skill-find` to locate other functions, then `skill-info` for details.
+
+---
+
+## CLI Usage
+
+```bash
+# Search SKILL functions
+virtuoso-bridge skill-find dbOpenCellView
+virtuoso-bridge skill-find "^db.*" --mode regex --limit 20
+
+# Get detailed docs
+virtuoso-bridge skill-info absGetOption
+virtuoso-bridge skill-info absGetOption --json   # JSON output
+```

--- a/src/virtuoso_bridge/cli.py
+++ b/src/virtuoso_bridge/cli.py
@@ -837,6 +837,66 @@ _EXPORT_VISIO_OPTS: dict = {
 }
 
 
+def cli_find(*, query: str | None, mode: str, limit: int, json_output: bool) -> int:
+    """Search SKILL API documentation from Cadence .fnd files.
+
+    On first run for a given server, downloads the SKILL Finder database
+    (~tens of MB) to a local cache.  Subsequent runs use the cache.
+    """
+    import json as _json
+    import sys
+
+    _load_cli_env()
+    from virtuoso_bridge import VirtuosoClient
+    from virtuoso_bridge.virtuoso.skill_finder import SKILLFinder
+
+    client = VirtuosoClient.from_env()
+
+    if not query:
+        print("Error: query argument required for 'skill-find'", file=sys.stderr)
+        return 1
+
+    results = client.find_skill(query or "", mode=mode, limit=limit)
+
+    if not query:
+        print("Error: query argument required for 'skill-find'", file=sys.stderr)
+        return 1
+
+    if json_output:
+        print(_json.dumps(results, indent=2, ensure_ascii=False))
+    else:
+        finder = SKILLFinder()
+        from virtuoso_bridge.virtuoso.skill_finder.parser import SkillEntry
+        entries = [SkillEntry(**r) for r in results]
+        print(finder.format_results(entries, query or ""))
+
+    return 0
+
+
+def cli_skill_info(*, func_name: str, json_output: bool) -> int:
+    """Get More Info documentation for a specific SKILL function."""
+    import json as _json
+
+    _load_cli_env()
+    from virtuoso_bridge import VirtuosoClient
+
+    client = VirtuosoClient.from_env()
+    result = client.get_skill_more_info(func_name)
+
+    if json_output:
+        print(_json.dumps(result, indent=2, ensure_ascii=False))
+    else:
+        if result is None:
+            print(f"No More Info found for: {func_name}")
+            return 1
+        print(f"More Info — {result['func_name']}")
+        print(f"  Source  : {result['file_path']}")
+        print(f"  Topic   : {result['topic'] or '(whole file)'}")
+        print()
+        print(result["plain_text"])
+    return 0
+
+
 def cli_windows() -> int:
     """List all open Virtuoso windows.
 
@@ -1196,6 +1256,57 @@ def build_parser() -> argparse.ArgumentParser:
     sp_screenshot.add_argument("--env", default=None,
                                help="Explicit .env file path (highest priority)")
 
+    sp_skill_find = subparsers.add_parser(
+        "skill-find",
+        help="Search SKILL API documentation from Cadence .fnd files",
+        description=(
+            "Queries the Cadence SKILL Finder database (``doc/finder/SKILL/*.fnd``)"
+            " on the remote server.  On first run the database is downloaded to a local\n"
+            "cache (``~/.cache/virtuoso_bridge/skill_finder/<host>/``);\n"
+            "subsequent runs use the cache without additional network traffic.\n\n"
+            "Search modes:\n"
+            "  fuzzy   case-insensitive substring match (default)\n"
+            "  prefix  name starts with query\n"
+            "  suffix  name ends with query\n"
+            "  exact   exact name match\n"
+            "  regex   Python regular expression match\n\n"
+            "Examples:\n"
+            "  virtuoso-bridge skill-find dbOpen\n"
+            '  virtuoso-bridge skill-find dbOpen --mode prefix\n'
+            '  virtuoso-bridge skill-find "^db.*" --mode regex\n'
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sp_skill_find.add_argument("query", nargs="?", default=None,
+                          help="Search string or pattern (required unless --json is set)")
+    sp_skill_find.add_argument("-m", "--mode", default="fuzzy",
+                          choices=["fuzzy", "prefix", "suffix", "exact", "regex"],
+                          help="Search mode (default: fuzzy)")
+    sp_skill_find.add_argument("-n", "--limit", type=int, default=50,
+                          help="Maximum results to return (default: 50)")
+    sp_skill_find.add_argument("--json", action="store_true",
+                          help="Output results as JSON")
+    sp_skill_find.add_argument("-p", "--profile", default=None,
+                          help="Connection profile")
+    sp_skill_find.add_argument("--env", default=None,
+                          help="Explicit .env file path (highest priority)")
+
+    sp_skill_info = subparsers.add_parser(
+        "skill-info",
+        help="Get More Info documentation for a SKILL function",
+        description=(
+            "Retrieves the More Info documentation for a specific SKILL function.\n"
+            "The More Info system provides detailed HTML documentation for Cadence\n"
+            "SKILL functions, indexed in ``doc/api_more_info/api_more_info.tgf``."
+        ),
+    )
+    sp_skill_info.add_argument("func_name", help="SKILL function name to look up")
+    sp_skill_info.add_argument(
+        "--json", action="store_true", help="Output results as JSON"
+    )
+    sp_skill_info.add_argument("-p", "--profile", default=None, help="Connection profile")
+    sp_skill_info.add_argument("--env", default=None, help="Explicit .env file path (highest priority)")
+
     sp_windows = subparsers.add_parser("windows", help="List all open Virtuoso windows")
     sp_windows.add_argument("-p", "--profile", default=None,
                             help="Connection profile")
@@ -1320,6 +1431,16 @@ def main(argv: list[str] | None = None) -> int:
         "windows": cli_windows,
         "snapshot": cli_snapshot,
         "export-visio": cli_export_visio,
+        "skill-find": lambda: cli_find(
+            query=getattr(args, "query", None),
+            mode=getattr(args, "mode", "fuzzy"),
+            limit=getattr(args, "limit", 50),
+            json_output=getattr(args, "json_output", False),
+        ),
+        "skill-info": lambda: cli_skill_info(
+            func_name=getattr(args, "func_name", None) or "",
+            json_output=getattr(args, "json", False),
+        ),
     }
     screenshot_target = getattr(args, "target", None)
     if screenshot_target is not None:

--- a/src/virtuoso_bridge/virtuoso/basic/bridge.py
+++ b/src/virtuoso_bridge/virtuoso/basic/bridge.py
@@ -759,6 +759,365 @@ let((result winName ciwNum)
             execution_time=time.perf_counter() - started,
         )
 
+    # -- SKILL Finder -------------------------------------------------------
+
+    def find_skill(
+        self,
+        query: str,
+        *,
+        mode: str = "fuzzy",
+        limit: int = 50,
+        source_dir: str | Path | None = None,
+        cache_dir: str | Path | None = None,
+    ) -> list[dict]:
+        """Search SKILL API documentation by name.
+
+        On first call (or when *source_dir* is not provided), discovers
+        the SKILL Finder directory on the remote server by walking up from
+        the ``virtuoso`` binary to ``doc/finder/SKILL``.  The directory is
+        cached locally in *cache_dir* (default:
+        ``~/.cache/virtuoso_bridge/skill_finder/<host>/``) so subsequent
+        calls are fast without additional network traffic.
+
+        Parameters
+        ----------
+        query : str
+            Search string (function name, or substring/prefix/suffix/regex
+            depending on *mode*).
+        mode : str
+            Search mode — one of:
+
+            - ``fuzzy`` (default) — case-insensitive substring match
+            - ``prefix`` — name starts with *query*
+            - ``suffix`` — name ends with *query*
+            - ``exact`` — exact name match
+            - ``regex`` — Python regular expression match
+
+        limit : int
+            Maximum results to return (default 50).
+        source_dir : str | Path | None
+            Override the SKILL Finder source directory.  If None, the
+            directory is auto-discovered on the remote server.
+        cache_dir : str | Path | None
+            Local cache directory for downloaded .fnd files.  If None,
+            defaults to ``~/.cache/virtuoso_bridge/skill_finder/<host>/``.
+
+        Returns
+        -------
+        list[dict]
+            List of matching entries, each a dict with keys:
+            ``name``, ``syntax``, ``description``, ``source_file``.
+        """
+        from pathlib import Path as _Path
+        from virtuoso_bridge.virtuoso.skill_finder import (
+            SKILLFinder,
+            SearchMode,
+        )
+
+        # Resolve cache directory
+        if cache_dir:
+            cache_path = _Path(cache_dir).expanduser().resolve()
+        else:
+            cache_root = _Path.home() / ".cache" / "virtuoso_bridge" / "skill_finder"
+            host = getattr(self._tunnel, "_host", None) if self._tunnel else "local"
+            cache_path = cache_root / (host or "local")
+
+        # Discover SKILL Finder root
+        if source_dir:
+            finder_root = _Path(source_dir)
+            doc_root = finder_root.parent.parent
+        elif self._tunnel is not None:
+            runner = self.ssh_runner
+            if runner is None:
+                logger.warning("find_skill: no SSH runner available")
+                return []
+            profile = getattr(self._tunnel, "_profile", None) if self._tunnel else None
+            finder = SKILLFinder()
+            finder_root = finder.discover(remote_runner=runner, profile=profile)
+            if finder_root is None:
+                logger.warning(
+                    "find_skill: could not locate doc/finder/SKILL on %s",
+                    getattr(self._tunnel, "_host", "remote"),
+                )
+                return []
+            # Download .fnd files if cache is stale
+            cache_marker = cache_path / ".source_dir"
+            needs_download = True
+            if cache_path.exists() and cache_marker.exists():
+                cached = cache_marker.read_text().strip()
+                needs_download = cached != str(finder_root)
+            if needs_download:
+                import shutil
+                # Clear stale cache
+                if cache_path.exists():
+                    shutil.rmtree(cache_path)
+                cache_path.mkdir(parents=True, exist_ok=True)
+                logger.info(
+                    "find_skill: downloading SKILL Finder from %s", finder_root
+                )
+                try:
+                    result = runner.download(
+                        str(finder_root),
+                        cache_path,
+                        recursive=True,
+                        timeout=120,
+                    )
+                    if result.returncode != 0:
+                        logger.warning(
+                            "find_skill: download failed — %s",
+                            result.stderr.strip(),
+                        )
+                        return []
+                    cache_marker.write_text(str(finder_root))
+                except Exception as exc:
+                    logger.warning("find_skill: download error — %s", exc)
+                    return []
+            finder_root = cache_path
+            # Also store the doc root (parent of doc/finder/SKILL) for More Info use
+            doc_root = finder_root.parent.parent
+            doc_root_marker = cache_path / ".doc_root"
+            if not doc_root_marker.exists() or doc_root_marker.read_text().strip() != str(doc_root):
+                doc_root_marker.write_text(str(doc_root))
+        else:
+            # Local mode
+            finder = SKILLFinder()
+            finder_root = finder.discover(remote_runner=None)
+            if finder_root is None:
+                logger.warning("find_skill: could not locate SKILL Finder locally")
+                return []
+            doc_root = finder_root.parent.parent
+
+        # Parse and search
+        finder = SKILLFinder()
+        finder.source_dir = finder_root
+        try:
+            finder.load(finder_root)
+        except Exception as exc:
+            logger.warning("find_skill: failed to load .fnd files — %s", exc)
+            return []
+
+        results = finder.search(query, mode=mode, limit=limit)
+        return [e.to_dict() for e in results]
+
+
+    def get_skill_more_info(
+        self,
+        func_name: str,
+        *,
+        source_dir: str | Path | None = None,
+        cache_dir: str | Path | None = None,
+    ) -> dict | None:
+        """Get More Info documentation for a specific SKILL function.
+
+        The More Info system consists of a ``api_more_info.tgf`` index
+        and associated HTML files containing detailed function documentation.
+
+        On first call, the index and referenced HTML files are downloaded
+        to a local cache.  Subsequent calls use the cache.
+
+        Parameters
+        ----------
+        func_name : str
+            Name of the SKILL function to look up.
+        source_dir : str | Path | None
+            Override the doc root directory (parent of ``api_more_info/``).
+            If None, auto-discovered from the virtuoso binary.
+        cache_dir : str | Path | None
+            Local cache directory.  If None, defaults to
+            ``~/.cache/virtuoso_bridge/skill_finder/<host>/``.
+
+        Returns
+        -------
+        dict or None
+            Dict with keys: ``func_name``, ``file_path``, ``topic``,
+            ``raw_html``, ``plain_text``.  Returns None if the function
+            has no More Info entry.
+        """
+        from pathlib import Path as _Path
+        from virtuoso_bridge.virtuoso.skill_finder import SKILLFinder
+        from virtuoso_bridge.virtuoso.skill_finder.more_info import (
+            html_to_plain_text,
+            parse_tgf_index,
+            resolve_doc_path,
+        )
+
+        if cache_dir:
+            cache_path = _Path(cache_dir).expanduser().resolve()
+        else:
+            cache_root = _Path.home() / ".cache" / "virtuoso_bridge" / "skill_finder"
+            host = getattr(self._tunnel, "_host", None) if self._tunnel else "local"
+            cache_path = cache_root / (host or "local")
+
+        # Determine doc root
+        if source_dir:
+            doc_root = _Path(source_dir)
+        elif self._tunnel is not None:
+            runner = self.ssh_runner
+            if runner is None:
+                logger.warning("get_skill_more_info: no SSH runner available")
+                return None
+            profile = getattr(self._tunnel, "_profile", None) if self._tunnel else None
+            finder = SKILLFinder()
+            finder_root = finder.discover(remote_runner=runner, profile=profile)
+            if finder_root is None:
+                logger.warning(
+                    "get_skill_more_info: could not locate doc/finder/SKILL on %s",
+                    getattr(self._tunnel, "_host", "remote"),
+                )
+                return None
+            doc_root = finder_root.parent.parent
+        else:
+            finder = SKILLFinder()
+            finder_root = finder.discover(remote_runner=None)
+            if finder_root is None:
+                logger.warning("get_skill_more_info: could not locate SKILL Finder locally")
+                return None
+            doc_root = finder_root.parent.parent
+
+        # More Info cache subdirectory
+        mi_cache = cache_path / "more_info"
+        mi_cache.mkdir(parents=True, exist_ok=True)
+        tgf_marker = mi_cache / ".source_dir"
+
+        # Remote: download .tgf and needed HTML files
+        if self._tunnel is not None:
+            runner = self.ssh_runner
+            tgf_remote_path = str(doc_root / "api_more_info" / "api_more_info.tgf")
+            tgf_local_path = mi_cache / "api_more_info.tgf"
+
+            needs_download = (
+                not tgf_local_path.exists()
+                or tgf_marker.exists()
+                and tgf_marker.read_text().strip() != tgf_remote_path
+            )
+
+            if needs_download:
+                logger.info(
+                    "get_skill_more_info: downloading .tgf index from %s", tgf_remote_path
+                )
+                try:
+                    # Download just the .tgf file first
+                    result = runner.download(
+                        tgf_remote_path,
+                        mi_cache,
+                        recursive=False,
+                        timeout=30,
+                    )
+                    if result.returncode != 0:
+                        logger.warning(
+                            "get_skill_more_info: .tgf download failed — %s",
+                            result.stderr.strip(),
+                        )
+                        return None
+                    tgf_marker.write_text(tgf_remote_path)
+                except Exception as exc:
+                    logger.warning("get_skill_more_info: download error — %s", exc)
+                    return None
+
+            # Parse .tgf to find which HTML files are needed for this function
+            entries = parse_tgf_index(tgf_local_path)
+            key = func_name.lower()
+            entry = entries.get(key)
+            if entry is None:
+                return None
+
+            # Check if the referenced HTML file is cached
+            html_rel_path = entry.file_path.lstrip("$")  # e.g. "abstract/abstract_skill.html"
+            html_local_path = mi_cache / html_rel_path
+            html_remote_path = str(doc_root / html_rel_path)
+
+            if not html_local_path.exists():
+                logger.info(
+                    "get_skill_more_info: downloading %s", html_remote_path
+                )
+                try:
+                    html_local_path.parent.mkdir(parents=True, exist_ok=True)
+                    result = runner.download(
+                        html_remote_path,
+                        html_local_path,
+                        recursive=False,
+                        timeout=30,
+                    )
+                    if result.returncode != 0:
+                        logger.warning(
+                            "get_skill_more_info: HTML download failed — %s",
+                            result.stderr.strip(),
+                        )
+                        return None
+                except Exception as exc:
+                    logger.warning(
+                        "get_skill_more_info: HTML download error — %s", exc
+                    )
+                    return None
+
+            # Extract the topic from HTML
+            try:
+                html_content = html_local_path.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                return None
+
+            if entry.topic:
+                raw_html = None
+                # Try to extract specific topic
+                from virtuoso_bridge.virtuoso.skill_finder.more_info import (
+                    extract_topic_from_html,
+                )
+                raw_html = extract_topic_from_html(html_content, entry.topic)
+            else:
+                # Whole file is the More Info — no topic extraction needed
+                raw_html = html_content
+
+            if raw_html is None:
+                return None
+
+            plain_text = html_to_plain_text(raw_html)
+            return {
+                "func_name": entry.func_name,
+                "file_path": entry.file_path,
+                "topic": entry.topic,
+                "raw_html": raw_html,
+                "plain_text": plain_text,
+            }
+
+        else:
+            # Local mode
+            tgf_path = doc_root / "api_more_info" / "api_more_info.tgf"
+            entries = parse_tgf_index(tgf_path)
+            key = func_name.lower()
+            entry = entries.get(key)
+            if entry is None:
+                return None
+
+            html_path = resolve_doc_path(tgf_path, entry.file_path)
+            if not html_path.exists():
+                return None
+
+            try:
+                html_content = html_path.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                return None
+
+            if entry.topic:
+                from virtuoso_bridge.virtuoso.skill_finder.more_info import (
+                    extract_topic_from_html,
+                )
+                raw_html = extract_topic_from_html(html_content, entry.topic)
+            else:
+                raw_html = html_content
+
+            if raw_html is None:
+                return None
+
+            plain_text = html_to_plain_text(raw_html)
+            return {
+                "func_name": entry.func_name,
+                "file_path": entry.file_path,
+                "topic": entry.topic,
+                "raw_html": raw_html,
+                "plain_text": plain_text,
+            }
+
+
     # -- IL loading ---------------------------------------------------------
 
     def load_il(self, path: str | Path, timeout: int | None = None) -> VirtuosoResult:

--- a/src/virtuoso_bridge/virtuoso/skill_finder/__init__.py
+++ b/src/virtuoso_bridge/virtuoso/skill_finder/__init__.py
@@ -1,0 +1,279 @@
+"""SKILL Finder — query Cadence SKILL API documentation from .fnd database.
+
+The SKILL Finder database lives under
+``<ic_install_path>/doc/finder/SKILL/<functionArea>/*.fnd``.
+Each entry has three fields: name, syntax, and description.
+
+Usage (local mode)::
+
+    from virtuoso_bridge.virtuoso.skill_finder import SKILLFinder
+
+    finder = SKILLFinder()
+    results = finder.search("dbOpenCellViewByType")
+
+Usage (remote mode, via VirtuosoClient)::
+
+    client = VirtuosoClient.from_env()
+    results = client.find_skill("dbOpen")
+"""
+
+from __future__ import annotations
+
+import enum
+import os
+import re
+import shlex
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+from .parser import SkillEntry, parse_fnd_directory
+
+
+class SearchMode(enum.Enum):
+    """Supported search modes for SKILL Finder queries."""
+
+    FUZZY = "fuzzy"  # Case-insensitive substring match (default)
+    PREFIX = "prefix"  # Name starts with query
+    SUFFIX = "suffix"  # Name ends with query
+    EXACT = "exact"  # Exact name match
+    REGEX = "regex"  # Regular expression match
+
+
+@dataclass
+class SearchOptions:
+    """Options for a SKILL Finder search."""
+
+    mode: SearchMode = SearchMode.FUZZY
+    limit: int = 50
+    case_sensitive: bool = False
+
+
+@dataclass
+class SKILLFinder:
+    """SKILL API documentation finder backed by Cadence .fnd files.
+
+    Attributes
+    ----------
+    source_dir : Path | None
+        Path to the SKILL Finder root directory.  None until
+        :meth:`discover` or :meth:`load` is called.
+    entries : list[SkillEntry]
+        All loaded entries.  Empty until :meth:`load` is called.
+    loaded : bool
+        Whether entries have been loaded from disk.
+    """
+
+    source_dir: Path | None = None
+    entries: list[SkillEntry] = field(default_factory=list)
+    loaded: bool = False
+
+    # ------------------------------------------------------------------
+    # Discovery & loading
+    # ------------------------------------------------------------------
+
+    def discover(
+        self, remote_runner=None, profile: str | None = None
+    ) -> Path | None:
+        """Find the SKILL Finder directory on a remote server.
+
+        Strategy: find the virtuoso binary (``which virtuoso``), then walk
+        up its parent directories until ``doc/finder/SKILL`` is found.
+
+        Parameters
+        ----------
+        remote_runner : SSHRunner | None
+            SSH runner for remote discovery.  If None, uses the local
+            filesystem.
+        profile : str | None
+            Connection profile name, passed to resolve VB_CADENCE_CSHRC_<profile>
+            env var (same suffix mechanism as spectre status).
+
+        Returns
+        -------
+        Path | None
+            The SKILL Finder root directory, or None if not found.
+        """
+        self._profile = profile
+        if remote_runner is None:
+            return self._discover_local()
+
+        return self._discover_remote(remote_runner, profile)
+
+    def _discover_local(self) -> Path | None:
+        import shutil
+
+        virtuoso_path = shutil.which("virtuoso")
+        if not virtuoso_path:
+            return None
+        return self._walk_up_find(Path(virtuoso_path), "doc/finder/SKILL")
+
+    def _discover_remote(self, runner, profile: str | None) -> Path | None:
+        """Find SKILL Finder root on a remote server via SSH.
+
+        Strategy: source VB_CADENCE_CSHRC to load Cadence environment, then
+        use ``which virtuoso`` to locate the binary, then walk up its parent
+        directories to find ``doc/finder/SKILL``.
+        """
+        # 1. Source cshrc in csh to load Cadence env, then find virtuoso.
+        # If VB_CADENCE_CSHRC is empty the source command is a no-op (silent
+        # failure), which is fine — we still run ``which virtuoso`` afterwards.
+        suffix = f"_{profile}" if profile else ""
+        cadence_cshrc = os.environ.get(
+            f"VB_CADENCE_CSHRC{suffix}", ""
+        ) or os.environ.get("VB_CADENCE_CSHRC", "")
+        quoted_cshrc = shlex.quote(cadence_cshrc)
+
+        find_virtuoso_script = (
+            'HOSTNAME=`hostname 2>/dev/null || echo localhost`; '
+            'export HOSTNAME; '
+            f'eval "$(csh -c \'source {quoted_cshrc}; env\' 2>/dev/null '
+            f'| grep -E "^(PATH|LM_LICENSE_FILE|CDS)=" '
+            f'| sed \'s/^/export /\')" 2>/dev/null; '
+            'which virtuoso 2>/dev/null || echo NOTFOUND'
+        )
+        r = runner.run_command(find_virtuoso_script, timeout=30)
+        if r.returncode != 0 or "NOTFOUND" in r.stdout:
+            return None
+
+        virtuoso_path = r.stdout.strip()
+
+        # 2. Walk up from virtuoso to find doc/finder/SKILL.
+        walk_script = (
+            f'p="{virtuoso_path}"; '
+            'while [ -n "$p" ] && [ "$p" != "/" ]; do '
+            '  if [ -d "$p/doc/finder/SKILL" ]; then echo "$p/doc/finder/SKILL"; exit 0; fi; '
+            '  p=$(dirname "$p"); '
+            'done; exit 1'
+        )
+        r2 = runner.run_command(f"bash -c {shlex.quote(walk_script)}", timeout=15)
+        if r2.returncode == 0 and r2.stdout.strip():
+            return Path(r2.stdout.strip())
+        return None
+
+    @staticmethod
+    def _walk_up_find(start: Path, target_tail: str) -> Path | None:
+        """Walk from ``start`` up to root, looking for ``target_tail``."""
+        current = start.resolve()
+        while True:
+            candidate = current / target_tail
+            if candidate.is_dir():
+                return candidate
+            parent = current.parent
+            if parent == current:
+                break
+            current = parent
+        return None
+
+    def load(self, source_dir: Path | str | None = None) -> None:
+        """Load all .fnd entries from *source_dir*.
+
+        If *source_dir* is None, uses :attr:`source_dir`.  Raises if
+        neither is set.
+
+        Parameters
+        ----------
+        source_dir : Path | str | None
+            Path to the SKILL Finder root directory.
+        """
+        root = Path(source_dir) if source_dir else self.source_dir
+        if root is None:
+            raise ValueError("source_dir must be provided or already set")
+
+        self.source_dir = Path(root)
+        self.entries = parse_fnd_directory(self.source_dir)
+        self.loaded = True
+
+    # ------------------------------------------------------------------
+    # Search
+    # ------------------------------------------------------------------
+
+    def search(
+        self,
+        query: str,
+        *,
+        mode: SearchMode | str = SearchMode.FUZZY,
+        limit: int = 50,
+    ) -> list[SkillEntry]:
+        """Search for SKILL entries matching *query*.
+
+        Parameters
+        ----------
+        query : str
+            Search string.
+        mode : SearchMode | str
+            Search mode (default: fuzzy substring).
+        limit : int
+            Maximum number of results (default: 50).
+
+        Returns
+        -------
+        list[SkillEntry]
+            Matching entries, best-effort sorted by relevance.
+        """
+        if not self.loaded:
+            return []
+
+        if isinstance(mode, str):
+            try:
+                mode = SearchMode(mode)
+            except ValueError:
+                mode = SearchMode.FUZZY
+
+        if mode == SearchMode.EXACT:
+            results = self._exact(query)
+        elif mode == SearchMode.PREFIX:
+            results = self._prefix(query)
+        elif mode == SearchMode.SUFFIX:
+            results = self._suffix(query)
+        elif mode == SearchMode.REGEX:
+            results = self._regex(query)
+        else:
+            results = self._fuzzy(query)
+
+        return sorted(results, key=lambda e: e.name)[:limit]
+
+    def _exact(self, query: str) -> list[SkillEntry]:
+        return [e for e in self.entries if e.name == query]
+
+    def _prefix(self, query: str) -> list[SkillEntry]:
+        return [e for e in self.entries if e.name.startswith(query)]
+
+    def _suffix(self, query: str) -> list[SkillEntry]:
+        return [e for e in self.entries if e.name.endswith(query)]
+
+    def _regex(self, query: str) -> list[SkillEntry]:
+        try:
+            pattern = re.compile(query, re.IGNORECASE)
+        except re.error:
+            return []
+        return [e for e in self.entries if pattern.search(e.name)]
+
+    def _fuzzy(self, query: str) -> list[SkillEntry]:
+        q = query.lower()
+        return [e for e in self.entries if q in e.name.lower()]
+
+    # ------------------------------------------------------------------
+    # CLI helper
+    # ------------------------------------------------------------------
+
+    def format_result(self, entry: SkillEntry) -> str:
+        """Format a single entry for human-readable CLI output."""
+        desc = entry.description.strip('"').strip()
+        # Normalise syntax: collapse embedded newlines/spaces into single spaces
+        syntax = re.sub(r'\s+', ' ', entry.syntax.strip('"')).strip()
+        source = f" [{entry.source_file}]" if entry.source_file else ""
+        return (
+            f"  {entry.name}{source}\n"
+            f"    Syntax : {syntax}\n"
+            f"    Desc   : {desc}\n"
+        )
+
+    def format_results(self, results: list[SkillEntry], query: str) -> str:
+        """Format search results for CLI output."""
+        if not results:
+            return f"No results for: {query}"
+
+        header = f"SKILL Finder — {len(results)} result(s) for '{query}':\n"
+        lines = [self.format_result(e) for e in results]
+        return header + "\n".join(lines)

--- a/src/virtuoso_bridge/virtuoso/skill_finder/more_info.py
+++ b/src/virtuoso_bridge/virtuoso/skill_finder/more_info.py
@@ -1,0 +1,114 @@
+"""Parser for Cadence More Info API documentation.
+
+The More Info system consists of:
+1. ``api_more_info.tgf`` — index mapping SKILL function names to (file, topic) pairs
+2. HTML files containing the actual documentation, with topics delimited by
+   ``<!-- [TOPIC_START_OPEN]... -->`` and ``<!-- [TOPIC_END] -->`` markers.
+"""
+
+from __future__ import annotations
+
+import re
+import markdownify
+from dataclasses import dataclass
+from pathlib import Path
+
+
+# Pattern for .tgf index lines (whitespace-separated):
+_TGF_QUOTED = re.compile(r"^(\S+)\s+(\S+)\s+\"([^\"]+)\"\s+(\S+)$")
+_TGF_NULL = re.compile(r"^(\S+)\s+(\S+)\s+(NULL)\s+(\S+)$", re.IGNORECASE)
+
+# Pattern for TOPIC_START block in HTML
+_TOPIC_START = re.compile(r"<!--\s*\[TOPIC_START_OPEN\](.*?)-->", re.DOTALL)
+_TOPIC_END = "<!-- [TOPIC_END] -->"
+_TOPIC_TEXT = re.compile(r"\[TOPIC_START_ATTR\]text=([^\n]+)", re.IGNORECASE)
+
+
+@dataclass
+class MoreInfoEntry:
+    func_name: str
+    file_path: str
+    topic: str | None
+    format: str
+
+
+@dataclass
+class MoreInfoResult:
+    func_name: str
+    file_path: str
+    topic: str | None
+    raw_html: str
+    plain_text: str
+
+
+def parse_tgf_index(tgf_path: Path) -> dict[str, MoreInfoEntry]:
+    entries: dict[str, MoreInfoEntry] = {}
+    try:
+        content = tgf_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return entries
+    for line in content.splitlines():
+        line = line.strip().strip("\r")
+        if not line or line.startswith(";") or line.startswith("#"):
+            continue
+        m = _TGF_QUOTED.match(line)
+        if m:
+            fn, fp, topic, fmt = m.group(1), m.group(2), m.group(3), m.group(4)
+        else:
+            m = _TGF_NULL.match(line)
+            if not m:
+                continue
+            fn, fp, topic, fmt = m.group(1), m.group(2), m.group(3), m.group(4)
+        if topic.upper() == "NULL":
+            topic = None
+        key = fn.lower()
+        if key not in entries:
+            entries[key] = MoreInfoEntry(func_name=fn, file_path=fp, topic=topic, format=fmt)
+    return entries
+
+
+def resolve_doc_path(tgf_path: Path, relative_path: str) -> Path:
+    rel = relative_path.lstrip("$")
+    return tgf_path.parent.parent / rel
+
+
+def extract_topic_from_html(html_content: str, topic_name: str) -> str | None:
+    for match in _TOPIC_START.finditer(html_content):
+        block_start = match.start()
+        block_attrs = match.group(1)
+        text_match = _TOPIC_TEXT.search(block_attrs)
+        if text_match and text_match.group(1).strip() == topic_name:
+            end_pos = html_content.find(_TOPIC_END, block_start)
+            if end_pos != -1:
+                tag_end = html_content.find("-->", block_start)
+                return html_content[tag_end + 3:end_pos].strip()
+    return None
+
+
+def html_to_plain_text(html: str) -> str:
+    """Convert HTML to clean markdown via markdownify.
+
+    Pre-processing removes empty code tags that would otherwise produce
+    orphaned backticks in the markdown output.
+    """
+    if not html or not html.strip():
+        return ""
+
+    # Remove empty/self-closing code tags BEFORE conversion.
+    # The Cadence HTML has malformed structures like:
+    #   [<code>ExtractShapeLimit</code><code></code>]
+    # which would produce orphaned backticks.
+    html = re.sub(r"<code[^>]*/>", "", html, flags=re.IGNORECASE)
+    html = re.sub(r"<code[^>]*></code>", "", html, flags=re.IGNORECASE)
+
+    return markdownify.markdownify(
+        html,
+        heading_style="ATX",
+        code_language="",
+        bold_symbol="**",
+        italic_symbol="_",
+    ).strip()
+
+
+def get_all_indexed_files(tgf_entries: dict[str, MoreInfoEntry]) -> set[str]:
+    return {entry.file_path for entry in tgf_entries.values()}

--- a/src/virtuoso_bridge/virtuoso/skill_finder/parser.py
+++ b/src/virtuoso_bridge/virtuoso/skill_finder/parser.py
@@ -1,0 +1,118 @@
+"""Parser for Cadence SKILL Finder .fnd files.
+
+The SKILL Finder database stores API documentation in ``*.fnd`` files under
+``<ic_install_path>/doc/finder/SKILL/<functionArea>/``.
+
+File format (per entry, 3 lines)::
+
+    ("functionName"
+    "syntaxString"
+    "Description.")
+
+Lines beginning with ``;`` are comments.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class SkillEntry:
+    """A single SKILL API entry parsed from a .fnd file."""
+
+    name: str
+    syntax: str
+    description: str
+    source_file: str | None = None
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "syntax": self.syntax,
+            "description": self.description,
+            "source_file": self.source_file,
+        }
+
+
+# Pattern matches a 3-line SKILL entry block:
+#   ("name"
+#   "syntax"
+#   "description.")
+_ENTRY_PATTERN = re.compile(
+    r'\("([^"]+)"\s*\n\s*"((?:[^"\\]|\\.)*)"\s*\n\s*"((?:[^"\\]|\\.)*)"\s*\)',
+    re.DOTALL,
+)
+
+
+def parse_fnd_file(path: Path) -> list[SkillEntry]:
+    """Parse a single .fnd file and return a list of SkillEntry objects.
+
+    Parameters
+    ----------
+    path : Path
+        Path to the .fnd file.
+
+    Returns
+    -------
+    list[SkillEntry]
+        All entries found in the file.
+    """
+    try:
+        content = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+
+    # Remove comment lines (lines starting with ';')
+    lines = [line for line in content.splitlines() if not line.startswith(";")]
+
+    # Join back into a single string for regex matching
+    normalized = "\n".join(lines)
+
+    entries: list[SkillEntry] = []
+    for m in _ENTRY_PATTERN.finditer(normalized):
+        name = m.group(1).strip()
+        syntax = m.group(2).strip()
+        description = m.group(3).strip()
+        if name and syntax:
+            entries.append(
+                SkillEntry(
+                    name=name,
+                    syntax=syntax,
+                    description=description,
+                    source_file=path.name,
+                )
+            )
+
+    return entries
+
+
+def parse_fnd_directory(root: Path) -> list[SkillEntry]:
+    """Recursively parse all .fnd files under a root directory.
+
+    Parameters
+    ----------
+    root : Path
+        Root directory containing functionArea subdirectories,
+        e.g. ``<ic_install_path>/doc/finder/SKILL/``.
+
+    Returns
+    -------
+    list[SkillEntry]
+        All entries found, deduplicated by name (first occurrence wins).
+    """
+    all_entries: list[SkillEntry] = []
+    seen: set[str] = set()
+
+    if not root.exists():
+        return []
+
+    for fnd_file in root.rglob("*.fnd"):
+        for entry in parse_fnd_file(fnd_file):
+            if entry.name not in seen:
+                seen.add(entry.name)
+                all_entries.append(entry)
+
+    return all_entries


### PR DESCRIPTION
close https://github.com/Arcadia-1/virtuoso-bridge-lite/issues/91

New CLI commands:
- 'virtuoso-bridge skill-find <query>' — search SKILL functions by name (fuzzy/prefix/suffix/exact/regex modes, cached locally)
- 'virtuoso-bridge skill-info <func_name>' — get detailed More Info docs for a specific SKILL function (HTML rendered via markdownify)

New Python API (VirtuosoClient):
- find_skill(query, mode, limit) — returns list of matching SKILL entries
- get_skill_more_info(func_name) — returns dict with func_name, file_path, topic, raw_html, plain_text

New files:
- virtuoso/skill_finder/__init__.py: SKILLFinder class + search logic
- virtuoso/skill_finder/parser.py: .fnd file parser (Lisp-style entries)
- virtuoso/skill_finder/more_info.py: TGF index parser + HTML extractor
- skills/virtuoso/references/skill-finder-python-api.md: API reference

Dependencies: markdownify>=0.14