### PR TITLE
fix(schematic): read_schematic timeout + diagnostic warnings (#99)

### DIFF
--- a/examples/01_virtuoso/schematic/99_repro_issue99.py
+++ b/examples/01_virtuoso/schematic/99_repro_issue99.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Reproduce / disprove issue #99 against a live Virtuoso.
+
+Issue #99 says `read_schematic()` returns
+``{instances:[], nets:{}, pins:{}, notes:[]}`` for a populated cellview
+(AI_LIB/L3_FCT) whose direct DFII probe reports 181 instances /
+18 terminals / 123 nets / 1215 shapes.
+
+This script does three things on a real Virtuoso, against any cell you
+have access to, and decides whether the bug fires on YOUR cell:
+
+  1. Direct DFII probe.  Opens the cellview via the same
+     ``dbOpenCellViewByType(... "schematic" "schematic" "r")`` call the
+     bridge uses, then counts ``cv~>instances/terminals/nets/shapes``
+     and dumps ``cv~>viewType``.  This is the "ground truth" the issue
+     reporter used.
+  2. Bridge ``read_schematic()``.  The code path under test.
+  3. Side-by-side comparison + verdict.
+
+If the two disagree -- the bug reproduces.  In that case the script
+ALSO dumps the first 2 KB of the raw SKILL output the bridge received,
+so you can see at a glance whether the body is
+
+  * ``ERROR`` (cv was nil under the bridge -- e.g. lib path differs),
+  * empty (transport / IPC ate the body),
+  * truncated mid-stanza (output too large or a foreach blew up
+    halfway through), or
+  * fully populated but mis-parsed (parser bug -- unlikely, pinned
+    green by tests/test_schematic_reader.py).
+
+Usage::
+
+    # Reproduce on the cell from the issue (only works if you have it):
+    python 99_repro_issue99.py AI_LIB L3_FCT
+
+    # Sanity check on a cell you know is fine:
+    python 99_repro_issue99.py myLib myInverter
+
+    # Skip param filtering -- catches CDF-driven failures:
+    python 99_repro_issue99.py AI_LIB L3_FCT --no-filters
+
+The exit code is 0 when bridge and DFII agree, 1 when they disagree
+(the bug fired), and 2 when DFII itself returned nil (cellview could
+not be opened at all).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Any
+
+from virtuoso_bridge import VirtuosoClient, decode_skill_output
+from virtuoso_bridge.virtuoso.schematic.reader import (
+    _GEOMETRY_INST_EXPR,
+    _NOTES_SECTION_EXPR,
+    _SKILL_TOPOLOGY,
+    read_schematic,
+)
+
+
+# =======================================================================
+# Direct DFII probe -- the "ground truth" side
+# =======================================================================
+
+_DFII_PROBE = r'''
+let((lib cell cv libPath cellViews vt bbox ni nt nn ns)
+  ddUpdateLibList()
+  lib = ddGetObj("{lib}")
+  cell = ddGetObj("{lib}" "{cell}")
+  cv = dbOpenCellViewByType("{lib}" "{cell}" "schematic" "schematic" "r")
+  libPath  = if(lib lib~>readPath "<no-lib>")
+  cellViews = if(cell buildString(cell~>views~>name " ") "<no-cell>")
+  if(cv
+    progn(
+      vt   = if(cv~>viewType cv~>viewType "nil")
+      bbox = sprintf(nil "%L" cv~>bBox)
+      ni   = length(cv~>instances)
+      nt   = length(cv~>terminals)
+      nn   = length(cv~>nets)
+      ns   = length(cv~>shapes)
+      sprintf(nil
+        "DFII_OK\nlibPath=%s\nviews=%s\nviewType=%s\nbBox=%s\ninstances=%d\nterminals=%d\nnets=%d\nshapes=%d\n"
+        libPath cellViews vt bbox ni nt nn ns))
+    sprintf(nil
+      "DFII_NIL\nlibPath=%s\nviews=%s\n" libPath cellViews)))
+'''
+
+
+def _dfii_probe(client: VirtuosoClient, lib: str, cell: str) -> dict[str, Any]:
+    """Direct ``length(cv~>...)`` probe; returns parsed counts."""
+    skill = _DFII_PROBE.format(lib=lib, cell=cell)
+    r = client.execute_skill(skill, timeout=30)
+    raw = decode_skill_output(r.output)
+
+    out: dict[str, Any] = {"raw": raw, "ok": False}
+    for line in raw.splitlines():
+        line = line.strip()
+        if line == "DFII_OK":
+            out["ok"] = True
+        elif line == "DFII_NIL":
+            out["ok"] = False
+        elif "=" in line:
+            k, v = line.split("=", 1)
+            out[k] = v
+    # Numeric coercion for the counts
+    for key in ("instances", "terminals", "nets", "shapes"):
+        if key in out:
+            try:
+                out[key] = int(out[key])
+            except (TypeError, ValueError):
+                pass
+    return out
+
+
+# =======================================================================
+# Mirror the bridge's exact SKILL expression so we can capture the
+# raw output it would see (without going through the parser).
+# =======================================================================
+
+def _bridge_raw_skill_output(
+    client: VirtuosoClient,
+    lib: str,
+    cell: str,
+    *,
+    include_positions: bool = False,
+) -> str:
+    """Execute the bridge's own _SKILL_TOPOLOGY directly and return raw."""
+    cv_expr = (
+        f'dbOpenCellViewByType("{lib}" "{cell}" "schematic" "schematic" "r")'
+    )
+    skill = _SKILL_TOPOLOGY.replace("{cv_expr}", cv_expr)
+    skill = skill.replace(
+        "{geometry_inst}", _GEOMETRY_INST_EXPR if include_positions else ""
+    )
+    skill = skill.replace("{notes_section}", _NOTES_SECTION_EXPR)
+    r = client.execute_skill(skill, timeout=60)
+    return decode_skill_output(r.output)
+
+
+# =======================================================================
+# Reporting
+# =======================================================================
+
+def _print_dfii(probe: dict[str, Any]) -> None:
+    print("=" * 64)
+    print("[1] Direct DFII probe (ground truth)")
+    print("=" * 64)
+    if not probe.get("ok"):
+        print(f"  cv = NIL  -- dbOpenCellViewByType returned nil.")
+        print(f"  libPath = {probe.get('libPath', '?')}")
+        print(f"  views   = {probe.get('views', '?')}")
+        print()
+        print("  Without an openable cv there is no ground truth to compare.")
+        print("  Fix the lib path / view name first, then re-run.")
+        return
+    print(f"  libPath   = {probe.get('libPath')}")
+    print(f"  views     = {probe.get('views')}")
+    print(f"  viewType  = {probe.get('viewType')}   "
+          f"<-- nil here is what issue #99 calls out")
+    print(f"  bBox      = {probe.get('bBox')}")
+    print(f"  instances = {probe.get('instances')}")
+    print(f"  terminals = {probe.get('terminals')}")
+    print(f"  nets      = {probe.get('nets')}")
+    print(f"  shapes    = {probe.get('shapes')}")
+
+
+def _print_bridge(data: dict[str, Any]) -> None:
+    print()
+    print("=" * 64)
+    print("[2] Bridge read_schematic()")
+    print("=" * 64)
+    print(f"  instances = {len(data.get('instances', []))}")
+    print(f"  nets      = {len(data.get('nets', {}))}")
+    print(f"  pins      = {len(data.get('pins', {}))}")
+    print(f"  notes     = {len(data.get('notes', []))}")
+
+
+def _verdict(probe: dict[str, Any], data: dict[str, Any]) -> int:
+    """Return exit code: 0 agree, 1 disagree (bug), 2 DFII nil."""
+    print()
+    print("=" * 64)
+    print("[3] Verdict")
+    print("=" * 64)
+    if not probe.get("ok"):
+        print("  DFII could not open the cellview -- nothing to compare.")
+        print("  Result: INCONCLUSIVE.  Exit code = 2.")
+        return 2
+
+    dfii_inst = probe.get("instances", 0)
+    bridge_inst = len(data.get("instances", []))
+    dfii_nets = probe.get("nets", 0)
+    bridge_nets = len(data.get("nets", {}))
+    dfii_pins = probe.get("terminals", 0)
+    bridge_pins = len(data.get("pins", {}))
+
+    rows = [
+        ("instances", dfii_inst, bridge_inst),
+        ("nets",      dfii_nets, bridge_nets),
+        ("pins",      dfii_pins, bridge_pins),
+    ]
+    print(f"  {'metric':<12} {'DFII':>8} {'bridge':>8}  {'?':>6}")
+    print("  " + "-" * 38)
+    bug_fired = False
+    for label, d, b in rows:
+        ok = (d == b) or (d > 0 and b > 0)  # close enough for "bridge saw it"
+        mark = "OK" if ok else "MISMATCH"
+        if not ok:
+            bug_fired = True
+        print(f"  {label:<12} {d:>8} {b:>8}  {mark:>8}")
+
+    if bug_fired and bridge_inst == 0 and dfii_inst > 0:
+        print()
+        print("  >>> ISSUE #99 REPRODUCED on this cell. <<<")
+        print("  Bridge returned empty for a non-empty cellview.")
+        return 1
+    if bug_fired:
+        print()
+        print("  Counts disagree but not in the 'silently empty' way #99")
+        print("  describes.  Possibly a different bug -- investigate.")
+        return 1
+    print()
+    print("  Bridge and DFII agree.  Issue #99 does NOT fire here.")
+    return 0
+
+
+def _dump_raw_evidence(raw: str, limit: int = 2048) -> None:
+    print()
+    print("=" * 64)
+    print(f"[4] Bridge's raw SKILL output (first {limit} bytes)")
+    print("=" * 64)
+    snippet = raw[:limit]
+    print(snippet if snippet else "<empty>")
+    if len(raw) > limit:
+        print(f"  ... (+{len(raw) - limit} more bytes)")
+    print()
+    print("Quick read of this output:")
+    if raw.strip() == "":
+        print("  EMPTY -- IPC / transport likely truncated the response, "
+              "or execute_skill swallowed the body.")
+    elif raw.strip() == "ERROR":
+        print("  ERROR marker -- the bridge's `unless(cv return(\"ERROR\"))`")
+        print("  prelude fired, so under the bridge's session cv was nil.")
+        print("  Compare cdsLibMgr / lib path against the DFII probe above.")
+    elif "INSTANCES" in raw and "END" not in raw:
+        print("  TRUNCATED -- INSTANCES header present but no END marker.")
+        print("  SKILL probably errored mid-foreach (CDF lookup, terminal")
+        print("  scrape, ...) or the response exceeded the transport limit.")
+    elif "INSTANCES" in raw and "INST|" not in raw.split("NETS", 1)[0]:
+        print("  HEADERS-ONLY -- structure is there but no INST lines.")
+        print("  Likely `cv~>instances` came back empty under the bridge,")
+        print("  or every instance was filtered by `purpose != \"pin\"`.")
+    else:
+        print("  Looks fully populated; if counts still mismatch the parser")
+        print("  is the suspect.  Re-run tests/test_schematic_reader.py.")
+
+
+# =======================================================================
+# Main
+# =======================================================================
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("lib")
+    ap.add_argument("cell")
+    ap.add_argument("--no-filters", action="store_true",
+                    help="disable CDF param filtering")
+    ap.add_argument("--no-pos", action="store_true",
+                    help="omit positions (matches issue reporter's call)")
+    args = ap.parse_args(argv)
+
+    client = VirtuosoClient.from_env()
+
+    probe = _dfii_probe(client, args.lib, args.cell)
+    _print_dfii(probe)
+
+    kwargs: dict[str, Any] = {"include_positions": not args.no_pos}
+    if args.no_filters:
+        kwargs["param_filters"] = None
+    data = read_schematic(client, args.lib, args.cell, **kwargs)
+    _print_bridge(data)
+
+    rc = _verdict(probe, data)
+    if rc == 1 and len(data.get("instances", [])) == 0:
+        # Bridge said empty -- dump the smoking gun.
+        raw = _bridge_raw_skill_output(
+            client, args.lib, args.cell,
+            include_positions=not args.no_pos,
+        )
+        _dump_raw_evidence(raw)
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/src/virtuoso_bridge/virtuoso/schematic/reader.py
+++ b/src/virtuoso_bridge/virtuoso/schematic/reader.py
@@ -22,6 +22,7 @@ preserved below for backward compatibility.
 from __future__ import annotations
 
 import fnmatch
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -29,7 +30,17 @@ import yaml
 
 from virtuoso_bridge import VirtuosoClient, decode_skill_output
 
+logger = logging.getLogger(__name__)
+
 _DEFAULT_FILTERS_PATH = Path(__file__).parent / "cdf_param_filters.yaml"
+
+# Default SKILL-call timeout in seconds.  60s -- the prior hardcoded
+# value -- silently truncates real-world cells: a 181-instance /
+# 21k-CDF-param schematic from issue #99 took 73s, after which the
+# bridge daemon SIGINTs Virtuoso and the reader returns an empty dict
+# with no warning.  5 minutes covers the kind of cells reported there
+# while still bounding hangs.
+_DEFAULT_TIMEOUT_S = 300
 
 
 # =======================================================================
@@ -135,6 +146,7 @@ def read_schematic(
     *,
     include_positions: bool = False,
     param_filters: str | Path | None = _DEFAULT_FILTERS_PATH,
+    timeout: int = _DEFAULT_TIMEOUT_S,
 ) -> dict:
     """Read a schematic in one SKILL call.
 
@@ -147,6 +159,9 @@ def read_schematic(
         param_filters: path to a YAML filter config.  Default uses the
             built-in cdf_param_filters.yaml.  Pass None to return all
             CDF params unfiltered.
+        timeout: SKILL call timeout in seconds.  Default 300s; bump for
+            very large schematics with many CDF-rich instances.  Issue
+            #99: the prior 60s default silently truncated a real cell.
 
     Returns:
         dict with keys: instances, nets, pins, notes.
@@ -154,6 +169,12 @@ def read_schematic(
         Each instance dict carries ``nlAction`` only when set — typically
         ``"ignore"`` when the designer shift+deleted the instance in the
         schematic editor to exclude it from netlisting.  Absent key = normal.
+
+        When the SKILL bridge fails (timeout, IPC error, cv = nil) the
+        result is the same empty-shape dict, but a ``logging.WARNING``
+        is emitted that names the failure mode and the lib/cell.  Issue
+        #99: prior versions silently returned the same empty dict for
+        both a genuinely empty cellview and a failed read.
     """
     if lib and cell:
         cv_expr = f'dbOpenCellViewByType("{lib}" "{cell}" "schematic" "schematic" "r")'
@@ -165,8 +186,46 @@ def read_schematic(
     # Notes are always included
     skill = skill.replace("{notes_section}", _NOTES_SECTION_EXPR)
 
-    r = client.execute_skill(skill, timeout=60)
+    r = client.execute_skill(skill, timeout=timeout)
     raw = decode_skill_output(r.output)
+
+    # Issue #99: surface SKILL-side failures that would otherwise look
+    # like a genuinely-empty schematic.  Three failure shapes to guard:
+    #   1. r.errors set  -> daemon-level error (timeout / IPC / parse).
+    #   2. raw == "ERROR" -> our own `unless(cv return("ERROR"))` prelude
+    #      fired, meaning dbOpenCellViewByType returned nil (lib not on
+    #      path, view locked for edit, strict viewType mismatch, ...).
+    #   3. raw empty with no error -> shouldn't normally happen; warn.
+    where = f"{lib}/{cell}" if (lib and cell) else "<edit cellview>"
+    if r.errors:
+        is_timeout = any("timeout" in str(e).lower() for e in r.errors)
+        if is_timeout:
+            logger.warning(
+                "read_schematic(%s) timed out after %ds; SKILL was killed "
+                "mid-execution and the result will be empty.  Increase "
+                "timeout=N to allow more time (issue #99).  errors=%r",
+                where, timeout, r.errors,
+            )
+        else:
+            logger.warning(
+                "read_schematic(%s) bridge returned errors; result will "
+                "be empty.  errors=%r (issue #99)",
+                where, r.errors,
+            )
+    elif raw.strip() == "ERROR":
+        logger.warning(
+            "read_schematic(%s) could not open the cellview: SKILL "
+            "prelude reported cv = nil.  Check lib path / viewType / "
+            "edit-locks (issue #99).",
+            where,
+        )
+    elif not raw.strip():
+        logger.warning(
+            "read_schematic(%s) got an empty response from the bridge "
+            "with no reported error -- possible IPC truncation "
+            "(issue #99).",
+            where,
+        )
 
     # Load filter config
     filter_config = None

--- a/tests/test_schematic_reader.py
+++ b/tests/test_schematic_reader.py
@@ -1,0 +1,277 @@
+"""Tests for :func:`virtuoso_bridge.virtuoso.schematic.reader.read_schematic`.
+
+Pinned by issue #99 -- ``read_schematic`` silently returned an empty
+``{instances:[], nets:{}, pins:{}, notes:[]}`` for the populated
+``AI_LIB/L3_FCT`` schematic.  A direct DFII probe on the same cellview
+reported **181 instances / 18 terminals / 123 nets / 1215 shapes**, yet
+the bridge reader returned zero.
+
+Reproduced live: the SKILL completes in 73s and produces 500 KB of
+output (163 INST lines + 21k PARAM lines), but the prior hardcoded
+``timeout=60`` killed it mid-flight.  The bridge daemon then sent
+SIGINT to Virtuoso and returned an empty payload with a ``Socket
+timeout after 60s`` error, but ``read_schematic`` did not check
+``r.errors`` and fed the empty payload straight through the parser,
+yielding the all-zero dict.  Issue #99 fix: surface every SKILL-side
+failure as a logging warning, and bump the default timeout to 300s.
+
+The tests below pin the three failure modes the fix has to cover:
+
+* ``test_read_schematic_warns_on_timeout`` -- the actual #99 surface,
+  daemon returns a Socket-timeout error.
+* ``test_read_schematic_warns_when_skill_says_error`` -- the
+  ``unless(cv return("ERROR"))`` prelude path (cv = nil under the
+  bridge: lib path / strict viewType / edit-lock).
+* ``test_read_schematic_warns_on_empty_no_error`` -- IPC swallowed the
+  body with no daemon-level error.  Defensive guard.
+
+Plus parser-only tests proving ``_parse_schematic`` is fine on the
+shape the affected schematic produces -- so future empty returns can
+still be traced to caller-side failures, not parser bugs.
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from virtuoso_bridge.virtuoso.schematic.reader import (
+    _DEFAULT_TIMEOUT_S,
+    _parse_schematic,
+    read_schematic,
+)
+
+
+# =======================================================================
+# Synthetic SKILL output matching the issue #99 schematic shape.
+# Hand-rolled to mirror what _SKILL_TOPOLOGY would emit for a small
+# L3_FCT-like cellview: arrayed-bus instances, bus nets, bus terminals,
+# wildcarded instTerm net names, scalar pins.
+# =======================================================================
+
+SAMPLE_TOPOLOGY_OUT = (
+    "INSTANCES\n"
+    "INST|I222<1:14>|FIRAS|LB_FCT_cunit\n"
+    "TERM|CINP|<*14>FCT_NTUNE_D<2:0>\n"
+    "TERM|VSSANA|VSSANA\n"
+    "INST|I218<1:5>|FIRAS|LB_FCT_cunit\n"
+    "TERM|CINP|<*5>FCT_NTUNE_D<2:0>\n"
+    "INST|C58<1:5>|analogLib|cap\n"
+    "TERM|PLUS|VCM\n"
+    'PARAM|c|"1.2p"\n'
+    "NETS\n"
+    "NET|FCT_NTUNE_D<2:0>|3|signal|nil|I222.CINP|I218.CINP\n"
+    "NET|VCM|1|signal|nil|C58.PLUS\n"
+    "PINS\n"
+    "PIN|VINP<1:0>|input|2\n"
+    "PIN|FCT_NTUNE_D<2:0>|input|3\n"
+    "PIN|VCM|inputOutput|1\n"
+    "NOTES\n"
+    "END\n"
+)
+
+
+# =======================================================================
+# Parser-only tests -- positive control that the bug is NOT here.
+# =======================================================================
+
+def test_parser_handles_arrayed_instances_and_bus_nets():
+    """If the parser were the issue #99 culprit, this would return zero.
+
+    Pins the positive control: parser is fine on the exact shape the
+    affected schematic produces.  Any future empty return must be
+    coming from the SKILL side, not the parser.
+    """
+    out = _parse_schematic(
+        SAMPLE_TOPOLOGY_OUT,
+        include_positions=False,
+        filter_config=None,
+    )
+
+    names = [i["name"] for i in out["instances"]]
+    assert names == ["I222<1:14>", "I218<1:5>", "C58<1:5>"], names
+
+    # Wildcarded instTerm net names survive the | split.
+    i222 = out["instances"][0]
+    assert i222["terms"]["CINP"] == "<*14>FCT_NTUNE_D<2:0>"
+
+    # Bus net registered with bus-width numBits and both connections.
+    bus_net = out["nets"]["FCT_NTUNE_D<2:0>"]
+    assert bus_net["numBits"] == 3
+    assert bus_net["connections"] == ["I222.CINP", "I218.CINP"]
+
+    # Bus pin keeps its <a:b> name and numBits.
+    assert out["pins"]["FCT_NTUNE_D<2:0>"]["numBits"] == 3
+    assert out["pins"]["VCM"]["direction"] == "inputOutput"
+
+
+def test_parser_silently_empty_on_skill_error_marker():
+    """The parser doesn't try to detect failure markers; the caller does.
+
+    Documents that ``_parse_schematic("ERROR")`` returns a zeroed dict
+    without complaint -- the warning has to be emitted upstream in
+    ``read_schematic`` itself (which the fix below does).
+    """
+    out = _parse_schematic("ERROR", include_positions=False, filter_config=None)
+    assert out == {"instances": [], "nets": {}, "pins": {}, "notes": []}
+
+
+def test_parser_silently_empty_on_empty_input():
+    """Same surface as the ERROR marker: empty in -> empty out, no noise."""
+    out = _parse_schematic("", include_positions=False, filter_config=None)
+    assert out == {"instances": [], "nets": {}, "pins": {}, "notes": []}
+
+
+# =======================================================================
+# End-to-end with a fake client -- pins the caller-side warning behaviour.
+# =======================================================================
+
+class _FakeSkillResult:
+    def __init__(self, output: str, errors: list | None = None) -> None:
+        self.output = output
+        self.errors = errors or []
+
+
+class _FakeClient:
+    """Minimal stand-in for ``VirtuosoClient.execute_skill``.
+
+    Captures each SKILL invocation + the timeout it was given so we can
+    assert on both the open-call shape and that ``timeout`` threads
+    through from ``read_schematic(..., timeout=...)`` to the bridge.
+    """
+
+    def __init__(self, output: str = "", errors: list | None = None) -> None:
+        self._output = output
+        self._errors = errors
+        self.skill_calls: list[str] = []
+        self.timeouts_seen: list[int | None] = []
+
+    def execute_skill(self, skill_code: str, timeout: int | None = None):
+        self.skill_calls.append(skill_code)
+        self.timeouts_seen.append(timeout)
+        return _FakeSkillResult(self._output, self._errors)
+
+
+def test_skill_expression_uses_explicit_schematic_viewtype():
+    """The bridge opens via
+    ``dbOpenCellViewByType("lib" "cell" "schematic" "schematic" "r")``.
+
+    Pinning the call shape so any future change (drop viewType arg,
+    add ``dbOpenCellView`` fallback) is detectable.
+    """
+    client = _FakeClient()
+    read_schematic(client, "AI_LIB", "L3_FCT", param_filters=None)
+    assert len(client.skill_calls) == 1
+    assert (
+        'dbOpenCellViewByType("AI_LIB" "L3_FCT" "schematic" "schematic" "r")'
+        in client.skill_calls[0]
+    )
+
+
+def test_read_schematic_default_timeout_is_at_least_300s():
+    """Issue #99: the prior 60s default silently truncated a real cell.
+
+    Pin the default at >= 300s so an accidental regression to a short
+    timeout surfaces in CI.
+    """
+    client = _FakeClient()
+    read_schematic(client, "AI_LIB", "L3_FCT", param_filters=None)
+    assert client.timeouts_seen == [_DEFAULT_TIMEOUT_S]
+    assert _DEFAULT_TIMEOUT_S >= 300, (
+        f"Default timeout regressed to {_DEFAULT_TIMEOUT_S}s -- issue #99"
+    )
+
+
+def test_read_schematic_threads_timeout_kwarg_to_execute_skill():
+    """``read_schematic(..., timeout=N)`` must propagate N to the bridge.
+
+    Without this the caller has no way to extend the budget for very
+    large cellviews; the kwarg is the fix's primary public knob.
+    """
+    client = _FakeClient()
+    read_schematic(client, "AI_LIB", "L3_FCT", param_filters=None, timeout=900)
+    assert client.timeouts_seen == [900]
+
+
+def test_read_schematic_warns_on_timeout(caplog):
+    """The actual issue #99 surface.
+
+    Daemon timed out, returned the ``Socket timeout after Ns`` error
+    string with empty output.  Prior to the fix this silently became
+    ``{instances:[], nets:{}, pins:{}, notes:[]}`` with no diagnostic;
+    after the fix a WARNING names the cell, the timeout value, and
+    flags the issue number so the caller can find it.
+    """
+    client = _FakeClient(output="", errors=["Socket timeout after 60s"])
+    with caplog.at_level(
+        logging.WARNING,
+        logger="virtuoso_bridge.virtuoso.schematic.reader",
+    ):
+        out = read_schematic(
+            client, "AI_LIB", "L3_FCT", param_filters=None, timeout=60,
+        )
+
+    assert out == {"instances": [], "nets": {}, "pins": {}, "notes": []}
+    messages = [r.message for r in caplog.records]
+    assert any("timed out" in m for m in messages), messages
+    assert any("AI_LIB/L3_FCT" in m for m in messages), messages
+    assert any("60" in m for m in messages), messages
+    assert any("issue #99" in m for m in messages), messages
+
+
+def test_read_schematic_warns_when_skill_says_error(caplog):
+    """``unless(cv return("ERROR"))`` prelude path.
+
+    cv = nil under the bridge (lib path / strict viewType / edit-lock).
+    SKILL emits the literal token ``ERROR``; the reader must surface
+    a warning rather than silently zeroing out.
+    """
+    client = _FakeClient(output='"ERROR"')  # daemon-wire form
+    with caplog.at_level(
+        logging.WARNING,
+        logger="virtuoso_bridge.virtuoso.schematic.reader",
+    ):
+        out = read_schematic(client, "AI_LIB", "L3_FCT", param_filters=None)
+
+    assert out == {"instances": [], "nets": {}, "pins": {}, "notes": []}
+    messages = [r.message for r in caplog.records]
+    assert any("cv = nil" in m or "could not open" in m for m in messages), messages
+    assert any("AI_LIB/L3_FCT" in m for m in messages), messages
+
+
+def test_read_schematic_warns_on_empty_no_error(caplog):
+    """Defensive: empty body, no daemon error, no SKILL marker.
+
+    Shouldn't normally happen, but if IPC swallows the body silently
+    the caller still gets a warning -- never an unflagged empty dict.
+    """
+    client = _FakeClient(output="")
+    with caplog.at_level(
+        logging.WARNING,
+        logger="virtuoso_bridge.virtuoso.schematic.reader",
+    ):
+        out = read_schematic(client, "AI_LIB", "L3_FCT", param_filters=None)
+
+    assert out == {"instances": [], "nets": {}, "pins": {}, "notes": []}
+    messages = [r.message for r in caplog.records]
+    assert any("empty response" in m or "IPC truncation" in m for m in messages), messages
+
+
+def test_read_schematic_no_warning_on_genuinely_populated_cell(caplog):
+    """The positive complement: a healthy SKILL response must NOT warn.
+
+    Without this guard the warning helpers could end up firing on
+    every call (false-positive flood).
+    """
+    client = _FakeClient(output=SAMPLE_TOPOLOGY_OUT)
+    with caplog.at_level(
+        logging.WARNING,
+        logger="virtuoso_bridge.virtuoso.schematic.reader",
+    ):
+        out = read_schematic(client, "AI_LIB", "L3_FCT", param_filters=None)
+
+    assert len(out["instances"]) == 3, "parser failed on healthy input"
+    assert caplog.records == [], (
+        "spurious warning on healthy input: "
+        f"{[r.message for r in caplog.records]}"
+    )


### PR DESCRIPTION
Issue #99: `read_schematic("AI_LIB", "L3_FCT")` returned an empty `{instances:[], nets:{}, pins:{}, notes:[]}` against a populated cellview that a direct DFII probe reports as 181 instances / 18 terminals / 123 nets / 1215 shapes.

Root cause: the SKILL call takes ~73s on that cell (163 INST lines + 21 227 CDF PARAM lines, ~500 KB output) -- the prior hardcoded `timeout=60` killed it.  The bridge daemon SIGINTs Virtuoso and returns an empty payload + `Socket timeout after 60s` in `r.errors`, but `read_schematic` did not inspect `r.errors` and fed the empty payload to the parser, yielding the all-zero dict.

Fix:
- Default timeout 60 -> 300s, exposed as a `timeout=` kwarg so callers can bump it for very large cellviews.
- Detect three SKILL-side failure shapes and emit a `logging.WARNING` naming the lib/cell, the failure mode, and #99:
    * `r.errors` set (timeout / IPC / parse on the daemon side);
    * raw payload == "ERROR" (`unless(cv return("ERROR"))` prelude fired, cv = nil under the bridge);
    * empty payload with no reported error (defensive IPC guard). Empty-dict return preserved -- callers that already special-case it keep working; the warning is the new signal.

Adds:
- `tests/test_schematic_reader.py` pinning all three failure paths + the kwarg threading + a no-false-positive guard on healthy input.
- `examples/01_virtuoso/schematic/99_repro_issue99.py` -- a diagnostic that runs DFII probe + bridge side-by-side against any cell and reports a verdict, useful for triage of similar reports.