### PR TITLE
fix: harden Lmod/csh env handling per code review of PR #2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ reference/
 .DS_Store
 .claude/
 spectre.out
+
+# Fork-monitoring reports (scripts/monitor_forks.sh output)
+fork-reports/

--- a/docs/fork-monitoring.md
+++ b/docs/fork-monitoring.md
@@ -1,0 +1,127 @@
+# Fork Monitoring Procedure
+
+How to periodically check the `virtuoso-bridge-lite` fork network for work worth
+pulling back, and how to decide what (if anything) to take. This is a triage
+procedure, not an auto-merge — every candidate is judged by a human.
+
+Upstream (`Arcadia-1/virtuoso-bridge-lite`) is **actively maintained**. The single
+most important rule when reading any fork: **check whether the change is already
+upstream before taking it.** In the 2026-07-01 sweep, essentially every broadly
+useful change in the network had already been absorbed upstream (digital_import
+env-vars, Windows-tmp portability, SRAM auto-detect, the SKILL `q` helper,
+version-aware daemon selection, ADE Explorer, jump-host, `127.0.0.1` tunnel,
+ControlPath shortening). What remained was personal design workspaces, doc
+translations, PDK-specific code, and fork-maintenance automation — none of it a
+clean cherry-pick.
+
+## Why forks diverge here
+
+Divergence is mostly **EDA-environment adaptation**, not new features: SSH tunnel /
+jump-host handling, ports, remote hostnames, PDK paths, daemon deployment,
+OS-specific branches. A hardcoded adaptation to someone else's lab is **not**
+something to copy verbatim — generalize it into config (`.env` / a flag) or skip
+it.
+
+## Cadence
+
+- **Every 4–6 weeks**, or before any consolidation effort.
+- Also worth a run after upstream ships a notable release (forks may have already
+  solved something upstream just changed, or vice-versa).
+
+## Run it
+
+```bash
+# Quick scan: rank forks, list ahead-commits, auto-classify by files touched.
+scripts/monitor_forks.sh
+
+# Deep scan: additionally flag commits whose content is ALREADY UPSTREAM
+# (patch-id match against the last 800 upstream commits). Slower; fetches each
+# ahead fork as a temp remote and cleans them up afterward.
+scripts/monitor_forks.sh --deep
+```
+
+Output is a dated Markdown report under `fork-reports/` (git-ignored). Requires an
+authenticated `gh` and an `upstream` remote (or `UP=owner/repo`).
+
+## How the report is built (and why)
+
+1. **Rank by ahead/behind, not `pushed_at`.** Fork-sync bumps `pushed_at`, so it
+   lies about activity. The script uses the compare API
+   (`compare/main...owner:branch`) and keeps only forks with `ahead > 0`. It
+   checks each fork's **default branch**; if a promising fork shows 0 ahead,
+   check its other branches manually with
+   `gh api repos/OWNER/virtuoso-bridge-lite/branches`.
+2. **List each fork's ahead-commits** with an auto-class based on the files each
+   commit touches.
+3. **`--deep`: flag already-upstream commits** by patch-id. This is the check
+   that saves the most time — most "ahead" commits in old forks are just
+   upstream's own history that never synced.
+
+## Reading the auto-classes
+
+The class is a **hint that routes attention**, not a verdict.
+
+| Class | Signal | Default action |
+|---|---|---|
+| **CORE** | modifies existing `core/*.il` or `src/virtuoso_bridge/*.py` | Inspect + verify not upstream; if wanted, sequence & `pytest` after each |
+| **ENV** | touches SSH/tunnel/host/port/path/daemon/PDK/OS handling | **Generalize to config, or ask** — never port a site's hardcode |
+| **ADD** | only new files (examples/, skills/, tools/) | Likely safe additive — still confirm it isn't personal/site-specific |
+| **DOCS** | `docs/`, `arxiv/`, `README`, `assets/`, `*.md` | Skip unless specifically wanted |
+| **JUNK** | `.DS_Store`, `.idea/`, `*.iml`, raw sim dumps (`*.tran.tran`, `logFile`), wip/merge noise | Drop |
+| **MIXED** | spans several categories (typical of `"update"`/`"wip"` blob commits) | Read the diff; usually a personal-workspace commit that can't be cleanly cherry-picked |
+
+`[ALREADY UPSTREAM]` (deep mode) → **skip**, the content is already merged.
+
+## Verify-before-take checklist
+
+For any commit you're tempted to take:
+
+1. **Already upstream?** Deep-mode tag, or manually:
+   `git show <sha> | git patch-id --stable` and compare, or read the current
+   upstream version of the file. Upstream often has a *better* version — taking
+   the fork's would regress (this happened with Olderdriver's daemon-selection
+   commit).
+2. **Hardcoded to someone's site?** Grep the diff for hostnames, absolute paths
+   (`/home/...`), PDK names (`smic`, `12sf`), ports. If present → generalize to
+   `.env`/flag or skip. Do not commit another lab's config.
+3. **Cleanly cherry-pickable?** Work buried in `"update"/"1".."6"/"merge"` blob
+   commits (personal workspaces) usually is not — re-implement the wanted slice
+   as a fresh, focused commit instead.
+
+## If you decide to take something
+
+Follow the consolidation rules (cherry-pick only, never `git merge` a donor
+branch, never overwrite upstream to resolve a conflict, never squash/rewrite
+authorship, `pytest -q` after every core-touching pick, all work on a
+`consolidate` branch, `main` untouched). When re-implementing a generalized
+version of someone's change, credit them:
+
+```
+Co-authored-by: Original Author <email-or-noreply>
+```
+
+## Contributing back
+
+For any change that's broadly useful (not site-specific), prefer opening a PR to
+`Arcadia-1/virtuoso-bridge-lite` over only keeping it in a private fork — upstream
+is alive and most such changes belong there.
+
+## Snapshot — 2026-07-01 baseline
+
+18 forks ahead of upstream. Outcome: **nothing taken** (empty pick-list).
+
+- **11-fork "~535 behind" cluster** (`0xcdef`, `uestcxyx`, `pli512`, `hxj382125921`,
+  `chros098`, `tabooes`, `SherseaHe`, `fishtank666`, `easonchengyy`, `rxu1993`,
+  `forkkkkk`) — snapshots of upstream's own early-2026 dev chain (authors
+  `TokenZhang`/`Fabulous_Arcadia`). All already upstream.
+- **muziyangyu** (28/21) — personal design workspace; clean commits already
+  upstream; only non-upstream source is SMIC12sf-PDK-specific (`layout/pdk.py`,
+  `layout/layers.py`) + a semi-generic `self_check.py`, all buried in wip commits.
+- **DavidQyz** (12/5) — personal OTA/comparator tree with raw sim dumps + IDE
+  files (junk). One reusable-ish `render_schematic.py`.
+- **Pyrojewel-zard** (11/5) — docs + TB1/receiver-specific ADE examples.
+- **Jureka-Shiyi** (5) — Chinese translations + per-file `*.py.md` study notes.
+- **pingyi** (4/0) — only `.github/workflows/sync-fork.yml` (fork plumbing; another
+  fork had removed the same file).
+- **Fans-Lee** (3) / **Olderdriver** (2) — wip that nets to nothing / a
+  daemon-selection change already superseded upstream.

--- a/docs/hpc-setup.md
+++ b/docs/hpc-setup.md
@@ -43,46 +43,69 @@ quickstart.
   uv pip install -e .
   ```
 
-## Worked example — tailored to this machine's `~/.ssh/config`
+## Reuse the SSH-alias pattern you already have
 
-Your `~/.ssh/config` defines (user `ajithkv`, port `5148`, `ForwardAgent yes`):
+> **Note:** the `server01` / `server02` / `server01_ext` hosts in this machine's
+> `~/.ssh/config` are homelab boxes — **they do not run Virtuoso.** They're worth
+> looking at only because they already demonstrate the exact pattern you need for
+> the real HPC hosts: an **alias** carrying `User`, a **non-standard `Port`**
+> (`5148`), and `ForwardAgent yes`:
+>
+> ```sshconfig
+> Host server01_ext
+>     HostName 90.213.214.193
+>     User ajithkv
+>     Port 5148
+>     ForwardAgent yes
+> ```
+>
+> Replicate that shape for your actual EDA login + compute hosts, then point the
+> bridge at those aliases. Placeholders below: **`hpc-login`** (the gateway you
+> can reach from the laptop) and **`hpc-node`** (where Virtuoso runs).
 
-| Alias          | HostName        | Reachable from | Role in this setup            |
-|----------------|-----------------|----------------|-------------------------------|
-| `server01_ext` | 90.213.214.193  | laptop (public)| gateway / jump host           |
-| `server01`     | 192.168.0.113   | internal LAN   | internal node                 |
-| `server02`     | 192.168.0.186   | internal LAN   | internal node                 |
+First add the real hosts to `~/.ssh/config` (adjust user/port/proxy to your site):
 
-Pick the scenario that matches **where Virtuoso actually runs.**
+```sshconfig
+Host hpc-login
+    HostName login.hpc.example.edu
+    User <you>
+    # Port <n>            # only if non-standard
 
-### Scenario A — Virtuoso on an internal node, reached via the gateway
+Host hpc-node
+    HostName <compute-node-or-ip>
+    User <you>
+    ProxyJump hpc-login   # optional; the bridge can also do the jump itself
+```
 
-Virtuoso on `server02` (internal), tunnelled through `server01_ext` (public):
+Confirm it works with no prompt, then pick the scenario matching **where Virtuoso
+actually runs.**
+
+### Scenario A — Virtuoso on a compute node, reached via a gateway
 
 ```bash
-virtuoso-bridge init ajithkv@server02 -J ajithkv@server01_ext
+virtuoso-bridge init <you>@hpc-node -J <you>@hpc-login
 ```
 `~/.virtuoso-bridge/.env`:
 ```dotenv
-VB_REMOTE_HOST=server02              # alias → 192.168.0.186:5148, user ajithkv
-VB_REMOTE_USER=ajithkv
-VB_JUMP_HOST=server01_ext            # alias → 90.213.214.193:5148 (public gateway)
+VB_REMOTE_HOST=hpc-node              # alias → the machine running Virtuoso
+VB_REMOTE_USER=<you>
+VB_JUMP_HOST=hpc-login               # alias → the gateway you reach from the laptop
 # VB_REMOTE_PORT / VB_LOCAL_PORT: leave unset (auto — bridge daemon port, not SSH)
 ```
-The bridge issues `ssh -J ajithkv@server01_ext ajithkv@server02`; both aliases are
-resolved from `~/.ssh/config`, so port `5148` is applied to each hop
+The bridge issues `ssh -J <you>@hpc-login <you>@hpc-node`; both aliases are
+resolved from `~/.ssh/config`, so any custom port is applied to each hop
 automatically.
 
-### Scenario B — Virtuoso on the gateway host itself (no jump)
+### Scenario B — Virtuoso on the directly-reachable host (no jump)
 
-If Virtuoso runs on the directly-reachable host (`server01_ext`), skip the jump:
+If Virtuoso runs on a host you can SSH to directly, skip the jump:
 
 ```bash
-virtuoso-bridge init ajithkv@server01_ext
+virtuoso-bridge init <you>@hpc-login
 ```
 ```dotenv
-VB_REMOTE_HOST=server01_ext          # the machine running Virtuoso
-VB_REMOTE_USER=ajithkv
+VB_REMOTE_HOST=hpc-login             # the machine running Virtuoso
+VB_REMOTE_USER=<you>
 # no VB_JUMP_HOST
 ```
 
@@ -139,6 +162,6 @@ SKILL always goes **through** the bridge (`client.execute_skill` /
 | `[daemon] NO RESPONSE` | `load("…")` not pasted into the CIW, or Virtuoso not running on that node. Re-run `status` to reprint the line. |
 | Tunnel won't start / auth fails | `ssh -J <jump> <remote> echo ok` must work with **no prompt** — `BatchMode=yes` gives no password fallback. Fix keys/agent first. |
 | Connects to wrong host | `VB_REMOTE_HOST` = the node running Virtuoso; `VB_JUMP_HOST` = the gateway. Don't set remote host to the gateway. |
-| "Connection refused" on the SSH hop | You used a raw IP instead of the alias, so it tried port 22 — use the `~/.ssh/config` alias so port `5148` is applied. |
+| "Connection refused" on the SSH hop | You used a raw IP instead of the alias, so it tried port 22 — use the `~/.ssh/config` alias so your custom `Port` is applied. |
 | 15–30 s stalls on connect | Usually GSSAPI/Kerberos or a slow gateway; the bridge already disables GSSAPI and allows longer jump-host settle time, so first connects are just slow, not broken. |
 | Spectre `NOT FOUND` | Independent from the SKILL bridge. Set `VB_CADENCE_CSHRC` if `spectre` isn't on the remote `PATH` (see `AGENTS.md` → "How Spectre is located"). |

--- a/docs/hpc-setup.md
+++ b/docs/hpc-setup.md
@@ -1,0 +1,144 @@
+# Connecting Claude Code to a Virtuoso session on HPC (from your laptop)
+
+Drive a Virtuoso session running on a remote compute node — through a login /
+gateway host — from Claude Code on your laptop. Everything you type runs
+locally; the bridge tunnels SKILL to the remote CIW.
+
+```
+   Laptop (you + Claude Code + this repo)
+        │  virtuoso-bridge start   →  ssh -J <jump> <remote>, forward localPort → 127.0.0.1:daemonPort
+        ▼
+   Login / gateway host              ← VB_JUMP_HOST   (ProxyJump, built automatically)
+        ▼
+   Compute node running Virtuoso     ← VB_REMOTE_HOST
+        ├─ ramic_bridge daemon  (deployed by `start`)
+        └─ Virtuoso CIW  ── paste one load("…virtuoso_setup.il") line once
+```
+
+See `AGENTS.md` for the full CLI/API reference; this file is the HPC-specific
+quickstart.
+
+## Two rules that trip people up on HPC
+
+1. **Use your SSH *aliases*, not raw IPs/ports.** The bridge does **not** pass
+   `-p`; it relies on `~/.ssh/config` for `HostName`, `User`, and `Port`. If your
+   hosts use a non-standard SSH port, put the **alias** in the bridge config so
+   that port is inherited. A raw IP would default to port 22 and fail.
+2. **`VB_REMOTE_PORT` / `VB_LOCAL_PORT` are the *bridge daemon* port — not the SSH
+   port.** They're auto-derived by hashing your remote username; leave them
+   alone. Don't set them to your SSH port.
+
+## Prerequisites
+
+- **Passwordless SSH all the way to the compute node.** The tool runs `ssh` with
+  `BatchMode=yes` and will never prompt. Prove it first:
+  ```bash
+  ssh -J <jump-alias> <remote-alias> echo ok      # must print ok, no prompt
+  ```
+- **A running Virtuoso with a CIW** on the compute node (typically via VNC/X). The
+  bridge attaches to an existing session; it does not launch Virtuoso.
+- **This repo installed locally:**
+  ```bash
+  uv venv .venv && source .venv/bin/activate
+  uv pip install -e .
+  ```
+
+## Worked example — tailored to this machine's `~/.ssh/config`
+
+Your `~/.ssh/config` defines (user `ajithkv`, port `5148`, `ForwardAgent yes`):
+
+| Alias          | HostName        | Reachable from | Role in this setup            |
+|----------------|-----------------|----------------|-------------------------------|
+| `server01_ext` | 90.213.214.193  | laptop (public)| gateway / jump host           |
+| `server01`     | 192.168.0.113   | internal LAN   | internal node                 |
+| `server02`     | 192.168.0.186   | internal LAN   | internal node                 |
+
+Pick the scenario that matches **where Virtuoso actually runs.**
+
+### Scenario A — Virtuoso on an internal node, reached via the gateway
+
+Virtuoso on `server02` (internal), tunnelled through `server01_ext` (public):
+
+```bash
+virtuoso-bridge init ajithkv@server02 -J ajithkv@server01_ext
+```
+`~/.virtuoso-bridge/.env`:
+```dotenv
+VB_REMOTE_HOST=server02              # alias → 192.168.0.186:5148, user ajithkv
+VB_REMOTE_USER=ajithkv
+VB_JUMP_HOST=server01_ext            # alias → 90.213.214.193:5148 (public gateway)
+# VB_REMOTE_PORT / VB_LOCAL_PORT: leave unset (auto — bridge daemon port, not SSH)
+```
+The bridge issues `ssh -J ajithkv@server01_ext ajithkv@server02`; both aliases are
+resolved from `~/.ssh/config`, so port `5148` is applied to each hop
+automatically.
+
+### Scenario B — Virtuoso on the gateway host itself (no jump)
+
+If Virtuoso runs on the directly-reachable host (`server01_ext`), skip the jump:
+
+```bash
+virtuoso-bridge init ajithkv@server01_ext
+```
+```dotenv
+VB_REMOTE_HOST=server01_ext          # the machine running Virtuoso
+VB_REMOTE_USER=ajithkv
+# no VB_JUMP_HOST
+```
+
+## Start, load, verify
+
+```bash
+virtuoso-bridge start          # opens the tunnel + deploys the daemon
+# → prints:  load("/tmp/virtuoso_bridge_<user>/<client>/virtuoso_bridge/virtuoso_setup.il")
+```
+Paste that `load("…")` line into the **Virtuoso CIW** once (add it to the remote
+`~/.cdsinit` to auto-load on every start). Then:
+```bash
+virtuoso-bridge status         # [tunnel] running  [daemon] OK  [spectre] OK/NOT FOUND
+virtuoso-bridge eval "1+2"     # → 3
+```
+
+## Scheduler-allocated compute nodes (SLURM / LSF)
+
+If the compute node is handed out by a scheduler and its hostname changes per
+job, either:
+
+- **Update the target each allocation:** start Virtuoso on the allocated node,
+  note `$HOSTNAME`, then `virtuoso-bridge init --force ajithkv@<node> -J ajithkv@<login>`
+  and `virtuoso-bridge restart`; or
+- **Keep a stable alias** in `~/.ssh/config` (e.g. `Host vnode` with
+  `ProxyJump server01_ext`) and only edit its `HostName` when the node changes —
+  then `VB_REMOTE_HOST=vnode` never moves.
+
+(If your site allows Virtuoso on the login node, Scenario B is simplest — but many
+sites forbid EDA on login nodes.)
+
+## Using it from Claude Code
+
+Run Claude Code on your laptop **inside this repo**. Once `status` is green, the
+bridge is Claude Code's hands into the remote Virtuoso — it drives it through the
+same API/CLI, plus the bundled `skills/virtuoso`, `skills/spectre`,
+`skills/optimizer`:
+
+```python
+from virtuoso_bridge import VirtuosoClient
+client = VirtuosoClient.from_env()     # reads .env, uses the tunnel
+client.execute_skill("1+2")            # runs on the HPC CIW
+with client.schematic.edit() as s:
+    ...                                # schematic / layout / maestro helpers
+```
+
+SKILL always goes **through** the bridge (`client.execute_skill` /
+`virtuoso-bridge eval`) — never SSH in and run SKILL by hand.
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `[daemon] NO RESPONSE` | `load("…")` not pasted into the CIW, or Virtuoso not running on that node. Re-run `status` to reprint the line. |
+| Tunnel won't start / auth fails | `ssh -J <jump> <remote> echo ok` must work with **no prompt** — `BatchMode=yes` gives no password fallback. Fix keys/agent first. |
+| Connects to wrong host | `VB_REMOTE_HOST` = the node running Virtuoso; `VB_JUMP_HOST` = the gateway. Don't set remote host to the gateway. |
+| "Connection refused" on the SSH hop | You used a raw IP instead of the alias, so it tried port 22 — use the `~/.ssh/config` alias so port `5148` is applied. |
+| 15–30 s stalls on connect | Usually GSSAPI/Kerberos or a slow gateway; the bridge already disables GSSAPI and allows longer jump-host settle time, so first connects are just slow, not broken. |
+| Spectre `NOT FOUND` | Independent from the SKILL bridge. Set `VB_CADENCE_CSHRC` if `spectre` isn't on the remote `PATH` (see `AGENTS.md` → "How Spectre is located"). |

--- a/docs/hpc-setup.md
+++ b/docs/hpc-setup.md
@@ -35,8 +35,13 @@ quickstart.
   ```bash
   ssh -J <jump-alias> <remote-alias> echo ok      # must print ok, no prompt
   ```
-- **A running Virtuoso with a CIW** on the compute node (typically via VNC/X). The
-  bridge attaches to an existing session; it does not launch Virtuoso.
+- **A running Virtuoso with a CIW** on the compute node (typically via VNC/X),
+  launched by you *after* `module load` (see "Lmod modules" below). The bridge
+  attaches to an existing session; it does not launch Virtuoso.
+- **A `python3` visible in a plain (non-login) SSH shell** on the compute node —
+  the bridge probes `ssh <node> python3 --version` to pick the right daemon. If
+  Python only appears after a `module load`, add that load to your shell rc, or
+  set `RB_PYTHON_PATH` (below).
 - **This repo installed locally:**
   ```bash
   uv venv .venv && source .venv/bin/activate
@@ -137,6 +142,52 @@ job, either:
 (If your site allows Virtuoso on the login node, Scenario B is simplest — but many
 sites forbid EDA on login nodes.)
 
+## Lmod modules (fresh-shell environment)
+
+Every command the bridge runs over SSH is a **fresh, non-interactive shell** — no
+`module load` is active in it. But the two services need Cadence env in different
+ways, so this splits cleanly:
+
+**SKILL / Virtuoso — handled by you at launch, not by the bridge.** The daemon is
+spawned by `ipcBeginProcess` *inside the running CIW* (`ramic_bridge.il`), so it
+inherits whatever environment Virtuoso has. Load your modules **before** starting
+Virtuoso in the interactive job and everything downstream inherits it:
+
+```bash
+# in your interactive/VNC job on the allocated node:
+module load cadence/<ver>          # your site's Virtuoso module
+virtuoso &                          # CIW now has the full Cadence env
+```
+
+The daemon runs `python` (stripping `LD_LIBRARY_PATH`/`LD_PRELOAD` so Cadence libs
+don't shadow it). If plain `python` isn't on PATH in Virtuoso's env, set
+`RB_PYTHON_PATH` before launching Virtuoso, e.g. `setenv RB_PYTHON_PATH python3`.
+
+**Spectre — point the bridge at a csh init file.** Spectre is invoked over SSH via
+`csh -c 'source $VB_CADENCE_CSHRC; spectre …'`, so `VB_CADENCE_CSHRC` must be a
+**csh-syntax** file that initializes Lmod and loads the tools. Create one on the
+remote host:
+
+```csh
+# ~/cadence-env.csh   (csh syntax — sourced in a csh subshell)
+source /usr/share/lmod/lmod/init/csh    # defines `module` for csh; adjust path
+module load cadence/<ver> spectre/<ver>
+```
+
+Then point the bridge at it (per-profile suffixes work too, e.g.
+`VB_CADENCE_CSHRC_worker1`):
+
+```dotenv
+VB_CADENCE_CSHRC=/home/<you>/cadence-env.csh
+```
+
+The `source .../init/csh` line matters: in a bare `csh -c`, Lmod's `module`
+command isn't defined unless the init is sourced (some sites do this in
+`/etc/csh.cshrc`, in which case you can drop the line — but keeping it is safe).
+Verify with `virtuoso-bridge license` / `virtuoso-bridge status` → `[spectre] OK`.
+If your tools use a real `.cshrc` instead of Lmod, just point `VB_CADENCE_CSHRC`
+straight at that.
+
 ## Using it from Claude Code
 
 Run Claude Code on your laptop **inside this repo**. Once `status` is green, the
@@ -164,4 +215,5 @@ SKILL always goes **through** the bridge (`client.execute_skill` /
 | Connects to wrong host | `VB_REMOTE_HOST` = the node running Virtuoso; `VB_JUMP_HOST` = the gateway. Don't set remote host to the gateway. |
 | "Connection refused" on the SSH hop | You used a raw IP instead of the alias, so it tried port 22 — use the `~/.ssh/config` alias so your custom `Port` is applied. |
 | 15–30 s stalls on connect | Usually GSSAPI/Kerberos or a slow gateway; the bridge already disables GSSAPI and allows longer jump-host settle time, so first connects are just slow, not broken. |
-| Spectre `NOT FOUND` | Independent from the SKILL bridge. Set `VB_CADENCE_CSHRC` if `spectre` isn't on the remote `PATH` (see `AGENTS.md` → "How Spectre is located"). |
+| Spectre `NOT FOUND` | Independent from the SKILL bridge. Point `VB_CADENCE_CSHRC` at a csh init file that `module load`s the tools (see "Lmod modules" above). |
+| Daemon won't start / wrong Python | The daemon inherits Virtuoso's env — `module load` **before** launching Virtuoso, and set `RB_PYTHON_PATH` if plain `python` isn't on its PATH. Daemon *selection* also needs a `python3` in a bare SSH shell. |

--- a/docs/hpc-setup.md
+++ b/docs/hpc-setup.md
@@ -163,10 +163,31 @@ The daemon runs `python` (stripping `LD_LIBRARY_PATH`/`LD_PRELOAD` so Cadence li
 don't shadow it). If plain `python` isn't on PATH in Virtuoso's env, set
 `RB_PYTHON_PATH` before launching Virtuoso, e.g. `setenv RB_PYTHON_PATH python3`.
 
-**Spectre — point the bridge at a csh init file.** Spectre is invoked over SSH via
-`csh -c 'source $VB_CADENCE_CSHRC; spectre …'`, so `VB_CADENCE_CSHRC` must be a
-**csh-syntax** file that initializes Lmod and loads the tools. Create one on the
-remote host:
+**Spectre — declare your modules (recommended).** Spectre is invoked over SSH in
+a fresh csh subshell that has no modules loaded, so the bridge needs to know
+which to load. The simplest path is to list them in `.env` — no remote file
+needed:
+
+```dotenv
+VB_LMOD_MODULES=cadence/<ver> spectre/<ver>
+# Only if Lmod's csh init is not at the default /usr/share/lmod/lmod/init/csh:
+# VB_LMOD_INIT=/path/to/lmod/init/csh
+```
+
+Before every probe, license check, and real run the bridge sources
+`$VB_LMOD_INIT` and loads your modules via Lmod's backend in csh. (It calls
+`$LMOD_CMD` directly rather than the `module` alias — in a single `csh -c`,
+aliases from a sourced file aren't active on the same parse line, so `module
+load` would fail with *"module: Command not found"*; `$LMOD_CMD` is a plain
+variable and works inline.) `VB_LMOD_INIT` matters because that init is what
+defines `$LMOD_CMD`; the bridge guards the source so a wrong/absent path is
+harmless when the site already defines Lmod (e.g. via `/etc/csh.cshrc`).
+Per-profile suffixes work, e.g. `VB_LMOD_MODULES_worker1`. Verify with
+`virtuoso-bridge license` / `virtuoso-bridge status` → `[spectre] OK`.
+
+**Alternative — point the bridge at a csh init file.** If you'd rather keep the
+setup in a remote file (or your tools use a real `.cshrc` instead of Lmod), set
+`VB_CADENCE_CSHRC` to a **csh-syntax** file the bridge will `source`:
 
 ```csh
 # ~/cadence-env.csh   (csh syntax — sourced in a csh subshell)
@@ -174,19 +195,12 @@ source /usr/share/lmod/lmod/init/csh    # defines `module` for csh; adjust path
 module load cadence/<ver> spectre/<ver>
 ```
 
-Then point the bridge at it (per-profile suffixes work too, e.g.
-`VB_CADENCE_CSHRC_worker1`):
-
 ```dotenv
 VB_CADENCE_CSHRC=/home/<you>/cadence-env.csh
 ```
 
-The `source .../init/csh` line matters: in a bare `csh -c`, Lmod's `module`
-command isn't defined unless the init is sourced (some sites do this in
-`/etc/csh.cshrc`, in which case you can drop the line — but keeping it is safe).
-Verify with `virtuoso-bridge license` / `virtuoso-bridge status` → `[spectre] OK`.
-If your tools use a real `.cshrc` instead of Lmod, just point `VB_CADENCE_CSHRC`
-straight at that.
+`VB_LMOD_MODULES` and `VB_CADENCE_CSHRC` compose — modules load first, then the
+cshrc sources — so you can mix them if needed.
 
 ## Using it from Claude Code
 
@@ -215,5 +229,5 @@ SKILL always goes **through** the bridge (`client.execute_skill` /
 | Connects to wrong host | `VB_REMOTE_HOST` = the node running Virtuoso; `VB_JUMP_HOST` = the gateway. Don't set remote host to the gateway. |
 | "Connection refused" on the SSH hop | You used a raw IP instead of the alias, so it tried port 22 — use the `~/.ssh/config` alias so your custom `Port` is applied. |
 | 15–30 s stalls on connect | Usually GSSAPI/Kerberos or a slow gateway; the bridge already disables GSSAPI and allows longer jump-host settle time, so first connects are just slow, not broken. |
-| Spectre `NOT FOUND` | Independent from the SKILL bridge. Point `VB_CADENCE_CSHRC` at a csh init file that `module load`s the tools (see "Lmod modules" above). |
+| Spectre `NOT FOUND` | Independent from the SKILL bridge. Set `VB_LMOD_MODULES` to the module(s) that put spectre on PATH (or point `VB_CADENCE_CSHRC` at a csh init file that `module load`s them) — see "Lmod modules" above. |
 | Daemon won't start / wrong Python | The daemon inherits Virtuoso's env — `module load` **before** launching Virtuoso, and set `RB_PYTHON_PATH` if plain `python` isn't on its PATH. Daemon *selection* also needs a `python3` in a bare SSH shell. |

--- a/scripts/monitor_forks.sh
+++ b/scripts/monitor_forks.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+#
+# monitor_forks.sh — periodic triage of virtuoso-bridge-lite community forks.
+#
+# Surfaces which forks are AHEAD of upstream, lists their unmerged commits,
+# auto-classifies each by the files it touches, and (in --deep mode) flags
+# commits whose content is already upstream. It never modifies your tree and
+# never cherry-picks — it produces a report for a human to act on.
+#
+# See docs/fork-monitoring.md for the full procedure, cadence, and how to read
+# the output.
+#
+# Usage:
+#   scripts/monitor_forks.sh                 # quick scan -> report
+#   scripts/monitor_forks.sh --deep          # + patch-id "already upstream" check (slower)
+#   UP=Owner/repo scripts/monitor_forks.sh   # scan a different upstream
+#
+# Requirements: gh (authenticated), git, awk. Run from inside a clone that has
+# an 'upstream' remote (or set UP=owner/repo).
+
+set -uo pipefail
+
+UP="${UP:-Arcadia-1/virtuoso-bridge-lite}"
+DEEP=0
+[ "${1:-}" = "--deep" ] && DEEP=1
+
+REPO_SLUG="${UP##*/}"
+OUTDIR="${OUTDIR:-fork-reports}"
+STAMP="$(date -u +%Y-%m-%d)"
+REPORT="${OUTDIR}/${STAMP}.md"
+mkdir -p "$OUTDIR"
+
+command -v gh  >/dev/null || { echo "error: gh not found" >&2; exit 1; }
+command -v git >/dev/null || { echo "error: git not found" >&2; exit 1; }
+gh auth status >/dev/null 2>&1 || { echo "error: gh not authenticated (run: gh auth login)" >&2; exit 1; }
+
+echo "Scanning forks of $UP (deep=$DEEP) ..." >&2
+
+# ---------------------------------------------------------------------------
+# Path-based auto-classifier. Judgment still belongs to the human — this only
+# routes attention. Mirrors the classes in docs/fork-monitoring.md.
+#   CORE  : modifies existing core/*.il or src/virtuoso_bridge/*.py
+#   ENV   : touches SSH/tunnel/host/port/path/daemon/OS handling -> generalize/ask
+#   DOCS  : docs/, arxiv/, README, assets/, *.md
+#   JUNK  : .DS_Store, IDE files, raw sim dumps, wip/merge noise
+#   ADD   : only-new files elsewhere (examples/, skills/, tools/) -> likely additive
+# ---------------------------------------------------------------------------
+classify_files() {
+  # stdin: "<status>\t<filename>" lines for one commit
+  awk -F'\t' '
+    { st=$1; f=$2
+      if (f ~ /\.DS_Store$|(^|\/)\.idea\/|\.iml$|\.tran\.tran$|\/logFile$|\/logStatus$|\.sweep$/) { junk++; next }
+      if (f ~ /(^|\/)(core\/[^\/]*\.il$|src\/virtuoso_bridge\/.*\.py$)/) {
+        if (st != "added") { core++ } else { add++ }
+        if (f ~ /ssh|tunnel|daemon|transport|host|port/) env++
+        next
+      }
+      if (f ~ /ssh|tunnel|daemon|jump|cshrc|\.env|pdk|PDK/) { env++; next }
+      if (f ~ /(^|\/)(docs\/|arxiv\/|assets\/|README|.*\.md$)/) { docs++; next }
+      add++
+    }
+    END {
+      cls=""
+      if (core) cls="CORE"
+      else if (env) cls="ENV"
+      else if (add && !docs) cls="ADD"
+      else if (docs && !add) cls="DOCS"
+      else if (junk && !core && !env && !add && !docs) cls="JUNK"
+      else cls="MIXED"
+      printf "%s (core=%d env=%d add=%d docs=%d junk=%d)", cls, core+0, env+0, add+0, docs+0, junk+0
+    }'
+}
+
+# In --deep mode, precompute the set of patch-ids already in upstream/main so we
+# can flag fork commits whose content is already merged (rebased/squashed SHAs).
+UP_PIDS=""
+if [ "$DEEP" = 1 ]; then
+  git rev-parse --verify upstream/main >/dev/null 2>&1 || git fetch upstream --quiet 2>/dev/null
+  echo "  building upstream patch-id set (last 800 commits)..." >&2
+  UP_PIDS="$(mktemp)"
+  git log upstream/main -n 800 --pretty=%H | while read -r c; do
+    git show "$c" 2>/dev/null | git patch-id --stable
+  done | awk '{print $1}' | sort -u > "$UP_PIDS"
+fi
+
+{
+  echo "# Fork triage — $UP"
+  echo
+  echo "_Generated $(date -u +'%Y-%m-%d %H:%M UTC') by scripts/monitor_forks.sh (deep=$DEEP)._"
+  echo
+  echo "Auto-classes are hints only — verify before taking anything. See docs/fork-monitoring.md."
+  echo
+} > "$REPORT"
+
+# ---------------------------------------------------------------------------
+# Rank every fork by commits ahead of upstream (ahead>0 only). pushed_at is
+# unreliable (fork-sync bumps it), so compare ahead/behind instead.
+# ---------------------------------------------------------------------------
+RANK="$(mktemp)"
+gh api "repos/$UP/forks" --paginate \
+  --jq '.[] | [.full_name, .default_branch] | @tsv' |
+while IFS=$'\t' read -r fork branch; do
+  owner=${fork%%/*}
+  stats=$(gh api "repos/$UP/compare/main...${owner}:${branch}" \
+            --jq '[.ahead_by,.behind_by]|@tsv' 2>/dev/null) || continue
+  ahead=${stats%%$'\t'*}; behind=${stats##*$'\t'}
+  [ "${ahead:-0}" -gt 0 ] 2>/dev/null \
+    && printf '%d\t%d\t%s\t%s\n' "$ahead" "$behind" "$owner" "$branch"
+done | sort -rn > "$RANK"
+
+NFORKS=$(wc -l < "$RANK" | tr -d ' ')
+{
+  echo "## Forks ahead of upstream ($NFORKS)"
+  echo
+  echo "| ahead | behind | fork | branch |"
+  echo "|------:|-------:|------|--------|"
+  while IFS=$'\t' read -r ahead behind owner branch; do
+    echo "| $ahead | $behind | $owner | $branch |"
+  done < "$RANK"
+  echo
+} >> "$REPORT"
+
+# ---------------------------------------------------------------------------
+# Per-fork detail: list ahead-commits + files-touched auto-class.
+# ---------------------------------------------------------------------------
+{
+  echo "## Per-fork ahead-commits"
+  echo
+} >> "$REPORT"
+
+while IFS=$'\t' read -r ahead behind owner branch; do
+  {
+    echo "### $owner ($ahead ahead / $behind behind)"
+    echo
+  } >> "$REPORT"
+
+  # In deep mode, fetch the fork so patch-ids can be computed locally.
+  if [ "$DEEP" = 1 ]; then
+    git remote get-url "_mon_$owner" >/dev/null 2>&1 || \
+      git remote add "_mon_$owner" "https://github.com/$owner/${REPO_SLUG}.git" 2>/dev/null
+    git fetch "_mon_$owner" --quiet 2>/dev/null
+  fi
+
+  gh api "repos/$UP/compare/main...${owner}:${branch}" \
+    --jq '.commits[] | [.sha, (.commit.author.date[0:10]), .commit.author.name, (.commit.message | split("\n")[0])] | @tsv' 2>/dev/null |
+  while IFS=$'\t' read -r sha date author subject; do
+    short=${sha:0:9}
+    files=$(gh api "repos/$UP/commits/$sha" \
+              --jq '.files[] | [.status, .filename] | @tsv' 2>/dev/null)
+    cls=$(printf '%s\n' "$files" | classify_files)
+
+    tag=""
+    if [ "$DEEP" = 1 ] && [ -n "$UP_PIDS" ]; then
+      pid=$(git show "$sha" 2>/dev/null | git patch-id --stable | awk '{print $1}')
+      if [ -n "$pid" ] && grep -qx "$pid" "$UP_PIDS"; then
+        tag=" **[ALREADY UPSTREAM]**"
+      fi
+    fi
+    printf -- "- \`%s\`  %s  _%s_  %s — **%s**%s\n" \
+      "$short" "$date" "$author" "$subject" "$cls" "$tag" >> "$REPORT"
+  done
+  echo >> "$REPORT"
+done < "$RANK"
+
+# Cleanup temp remotes created in deep mode.
+if [ "$DEEP" = 1 ]; then
+  for r in $(git remote | grep '^_mon_'); do git remote remove "$r" 2>/dev/null; done
+  [ -n "$UP_PIDS" ] && rm -f "$UP_PIDS"
+fi
+rm -f "$RANK"
+
+echo "Report written to: $REPORT" >&2
+echo "$REPORT"

--- a/src/virtuoso_bridge/cli.py
+++ b/src/virtuoso_bridge/cli.py
@@ -486,8 +486,10 @@ def _print_spectre_status(profile: str | None, suffix: str) -> None:
     For remote mode: SSH-based check via SSHClient.
 
     Strategy (remote): try ``which spectre`` directly first (works when the
-    user's login shell already has Cadence on PATH).  If that fails and
-    VB_CADENCE_CSHRC is set, source it in a csh sub-shell and retry.
+    user's login shell already has Cadence on PATH).  If that fails, establish
+    the Cadence env in a csh sub-shell — loading any VB_LMOD_MODULES via Lmod
+    and/or sourcing VB_CADENCE_CSHRC/VB_MENTOR_CSHRC (see
+    cadence_env_setup_csh) — and retry.
     """
     import shutil
     import subprocess
@@ -538,15 +540,14 @@ def _print_spectre_status(profile: str | None, suffix: str) -> None:
             return
         runner._verbose = False
 
-        spectre_bin = (
-            os.getenv(f"VB_SPECTRE_BIN{suffix}", "").strip()
-            or os.getenv("VB_SPECTRE_BIN", "").strip()
-        )
+        from virtuoso_bridge.spectre.runner import _env_first
+
+        spectre_bin = _env_first("VB_SPECTRE_BIN", suffix)
 
         if spectre_bin:
             # Explicit binary path — skip auto-detection.
             quoted = shlex.quote(spectre_bin)
-            check_cmd = f"{quoted} -V 2>&1 | head -1"
+            check_cmd = f"{quoted} -V 2>&1"
             print("\n[spectre] probing...", flush=True)
             result = runner.run_command(check_cmd, timeout=60)
             stdout = result.stdout.strip()
@@ -577,12 +578,17 @@ def _print_spectre_status(profile: str | None, suffix: str) -> None:
         # meta-module emits many ``Loading module …`` chatter lines (and one
         # ``Loading module cadence/spectre/…`` that would false-match a bare
         # "/"+"spectre" scan), so a marker is the only robust anchor.
-        from virtuoso_bridge.spectre.runner import cadence_env_setup_csh
+        from virtuoso_bridge.spectre.runner import (
+            cadence_env_setup_csh,
+            remote_tool_probe,
+        )
         setup = cadence_env_setup_csh(suffix)
+        # Emit the FULL `spectre -V` output (no `head -1`): the ``@(#)$CDS:``
+        # banner the parser below scans for is usually not the first line.
         fast = (
             'sp=`which spectre 2>/dev/null`; '
             '[ -n "$sp" ] && { printf "VB_SPECTRE_PATH=%s\\n" "$sp"; '
-            'spectre -V 2>&1 | head -1; }'
+            'spectre -V 2>&1; }'
         )
         if setup:
             # Keep csh script out of bash's view — ``!`` / backticks /
@@ -600,11 +606,9 @@ def _print_spectre_status(profile: str | None, suffix: str) -> None:
                 'printf "VB_SPECTRE_PATH=%s\\n" "`which spectre`"; '
                 'spectre -V'
             )
-            slow = f"csh -f -c {shlex.quote(csh_script)} 2>&1"
-            combined = f"{{ {fast}; }} || {{ {slow}; }}"
+            check_cmd = remote_tool_probe(fast, csh_script)
         else:
-            combined = fast
-        check_cmd = f"bash -l -c {shlex.quote(combined)}"
+            check_cmd = f"bash -l -c {shlex.quote(fast)}"
         print("\n[spectre] probing...", flush=True)
         result = runner.run_command(check_cmd, timeout=60)
         stdout = result.stdout.strip()
@@ -687,8 +691,8 @@ def cli_license() -> int:
     # VB_SPECTRE_BIN, an Lmod module set (VB_LMOD_MODULES), a sourced cshrc
     # (VB_CADENCE_CSHRC/VB_MENTOR_CSHRC), or spectre already on PATH.  Only warn
     # when nothing is configured — check_license still tries a bare PATH lookup.
-    from virtuoso_bridge.spectre.runner import cadence_env_setup_csh
-    spectre_bin = os.getenv(f"VB_SPECTRE_BIN{suffix}", "").strip() or os.getenv("VB_SPECTRE_BIN", "").strip()
+    from virtuoso_bridge.spectre.runner import _env_first, cadence_env_setup_csh
+    spectre_bin = _env_first("VB_SPECTRE_BIN", suffix)
     if not spectre_bin and not cadence_env_setup_csh(suffix):
         print("No spectre env configured (VB_SPECTRE_BIN / VB_LMOD_MODULES / "
               "VB_CADENCE_CSHRC) — trying spectre on the remote PATH.")

--- a/src/virtuoso_bridge/cli.py
+++ b/src/virtuoso_bridge/cli.py
@@ -565,40 +565,42 @@ def _print_spectre_status(profile: str | None, suffix: str) -> None:
         #
         #   (A) fast path: spectre already on PATH (bash-shell login,
         #       or ssh server configured with Cadence env baked in)
-        #   (B) slow path: source VB_CADENCE_CSHRC inside csh, re-check
+        #   (B) slow path: establish the Cadence env in csh (Lmod modules
+        #       and/or cshrc files, see cadence_env_setup_csh), re-check
         #
-        # Older revisions issued these as two separate SSH calls. On
-        # congested jump hosts / Windows without ControlMaster, each
-        # SSH is a fresh TCP + sshd fork, doubling the risk of banner-
-        # exchange timeouts that manifested as spurious "NOT FOUND".
-        # Bash parses ``A || B | C`` as ``A || (B | C)`` so the
-        # ``head -5`` only applies to the csh fallback — same semantics
-        # as before, one round-trip instead of two.
-        cadence_cshrc = (
-            os.getenv(f"VB_CADENCE_CSHRC{suffix}", "").strip()
-            or os.getenv("VB_CADENCE_CSHRC", "").strip()
+        # Fused into one SSH round-trip (``{ A } || { B }``) — on congested
+        # jump hosts each extra SSH is a fresh TCP + sshd fork, doubling the
+        # risk of banner-exchange timeouts that look like spurious NOT FOUND.
+        #
+        # Both branches print the resolved path on a ``VB_SPECTRE_PATH=`` marker
+        # line rather than relying on line position.  Loading a bundled Lmod
+        # meta-module emits many ``Loading module …`` chatter lines (and one
+        # ``Loading module cadence/spectre/…`` that would false-match a bare
+        # "/"+"spectre" scan), so a marker is the only robust anchor.
+        from virtuoso_bridge.spectre.runner import cadence_env_setup_csh
+        setup = cadence_env_setup_csh(suffix)
+        fast = (
+            'sp=`which spectre 2>/dev/null`; '
+            '[ -n "$sp" ] && { printf "VB_SPECTRE_PATH=%s\\n" "$sp"; '
+            'spectre -V 2>&1 | head -1; }'
         )
-        fast = "which spectre 2>/dev/null && spectre -V 2>&1 | head -1"
-        if cadence_cshrc:
+        if setup:
             # Keep csh script out of bash's view — ``!`` / backticks /
-            # ``$?VAR`` must reach csh verbatim.
-            #
-            # Seed HOSTNAME/LD_LIBRARY_PATH with non-empty placeholders:
-            # some site cshrc files do ``setenv LD_LIBRARY_PATH
-            # ${MMSIM_HOME}/tools/lib:$LD_LIBRARY_PATH`` and csh aborts
-            # partway through when ``$LD_LIBRARY_PATH`` is undefined —
-            # leaving PATH unpatched so ``which spectre`` returns
-            # nothing.  An empty string (``""``) was found insufficient
-            # in practice; ``blank`` is a harmless throwaway that the
-            # subsequent concat safely overwrites.
+            # ``$?VAR`` must reach csh verbatim.  Seed HOSTNAME/LD_LIBRARY_PATH
+            # with non-empty placeholders: some site cshrc files do ``setenv
+            # LD_LIBRARY_PATH ${MMSIM_HOME}/tools/lib:$LD_LIBRARY_PATH`` and csh
+            # aborts when ``$LD_LIBRARY_PATH`` is undefined; ``blank`` is a
+            # harmless throwaway the subsequent concat overwrites.  csh module
+            # chatter goes to stderr and is merged (2>&1) but ignored by the
+            # marker parser below.
             csh_script = (
                 'setenv HOSTNAME `hostname`; '
                 'setenv LD_LIBRARY_PATH blank; '
-                f'source {cadence_cshrc}; '
-                'which spectre; '
+                f'{setup}; '
+                'printf "VB_SPECTRE_PATH=%s\\n" "`which spectre`"; '
                 'spectre -V'
             )
-            slow = f"csh -f -c {shlex.quote(csh_script)} 2>&1 | head -5"
+            slow = f"csh -f -c {shlex.quote(csh_script)} 2>&1"
             combined = f"{{ {fast}; }} || {{ {slow}; }}"
         else:
             combined = fast
@@ -611,10 +613,12 @@ def _print_spectre_status(profile: str | None, suffix: str) -> None:
         version = None
         for line in stdout.splitlines():
             line = line.strip()
-            if line.startswith("@(#)$CDS:"):
+            if line.startswith("VB_SPECTRE_PATH="):
+                candidate = line.split("=", 1)[1].strip()
+                if candidate and "/" in candidate:
+                    spectre_path = candidate
+            elif line.startswith("@(#)$CDS:"):
                 version = line
-            elif "/" in line and "spectre" in line.lower():
-                spectre_path = line
 
         if spectre_path:
             print("[spectre] OK")
@@ -679,10 +683,15 @@ def cli_license() -> int:
     _load_cli_env()
     profile = _get_cli_profile()
     suffix = f"_{profile}" if profile else ""
-    cadence_cshrc = os.getenv(f"VB_CADENCE_CSHRC{suffix}", "").strip() or os.getenv("VB_CADENCE_CSHRC", "").strip()
-    if not cadence_cshrc:
-        print("VB_CADENCE_CSHRC is not set.")
-        return 1
+    # The license check works with any way of locating spectre: an explicit
+    # VB_SPECTRE_BIN, an Lmod module set (VB_LMOD_MODULES), a sourced cshrc
+    # (VB_CADENCE_CSHRC/VB_MENTOR_CSHRC), or spectre already on PATH.  Only warn
+    # when nothing is configured — check_license still tries a bare PATH lookup.
+    from virtuoso_bridge.spectre.runner import cadence_env_setup_csh
+    spectre_bin = os.getenv(f"VB_SPECTRE_BIN{suffix}", "").strip() or os.getenv("VB_SPECTRE_BIN", "").strip()
+    if not spectre_bin and not cadence_env_setup_csh(suffix):
+        print("No spectre env configured (VB_SPECTRE_BIN / VB_LMOD_MODULES / "
+              "VB_CADENCE_CSHRC) — trying spectre on the remote PATH.")
 
     from virtuoso_bridge.transport.tunnel import SSHClient
     if not SSHClient.is_running(profile):

--- a/src/virtuoso_bridge/resources/.env_template
+++ b/src/virtuoso_bridge/resources/.env_template
@@ -45,3 +45,8 @@ VB_LOCAL_PORT={local_port}
 # VB_SPECTRE_BIN=/opt/cadence/SPECTRE231/bin/spectre
 # Option 2: source a cshrc that adds spectre to PATH
 # VB_CADENCE_CSHRC=/path/to/cshrc/that/sets/up/cadence/tools
+# Option 3: Lmod / environment modules (HPC clusters).  List the module(s)
+# that put spectre on PATH — the bridge loads them in a fresh csh shell.
+# VB_LMOD_MODULES=cadence/IC25.1 spectre/23.1
+# Override the Lmod csh init path only if it is not the default below:
+# VB_LMOD_INIT=/usr/share/lmod/lmod/init/csh

--- a/src/virtuoso_bridge/spectre/runner.py
+++ b/src/virtuoso_bridge/spectre/runner.py
@@ -82,7 +82,7 @@ def _env_first(name: str, suffix: str = "") -> str:
 
 
 # Default location of Lmod's csh init script.  Sourcing it defines the
-# `module` command inside a bare, non-interactive `csh -c` (which does not
+# `module` command inside a bare, non-interactive `csh -f -c` (which does not
 # inherit an interactive shell's module setup).  Override with VB_LMOD_INIT
 # when your site installs Lmod elsewhere; the `source` is guarded so a wrong
 # path is harmless when `module` is already defined (e.g. via /etc/csh.cshrc).
@@ -93,7 +93,9 @@ def cadence_env_setup_csh(suffix: str = "") -> str:
     """Build a ``;``-joined csh prelude that establishes the Cadence/Spectre
     environment in a fresh, non-interactive remote shell.
 
-    Spectre is invoked over SSH as ``csh -c '<prelude>; spectre …'``, so this
+    Spectre is invoked over SSH as ``csh -f -c '<prelude>; spectre …'`` —
+    ``-f`` skips ``~/.cshrc``, which in the Lmod use case carries no
+    tool/project variables; the env comes only from this prelude — so this
     prelude is the single place that teaches every code path (status probe,
     license check, and real runs) how to make the tools reachable.  It layers,
     in order (each optional, later layers win):
@@ -111,15 +113,18 @@ def cadence_env_setup_csh(suffix: str = "") -> str:
     lines: list[str] = []
     modules = _env_first("VB_LMOD_MODULES", suffix)
     if modules:
+        # Plain whitespace split (not shlex): module names never contain quotes
+        # or spaces, and shlex.split would raise ValueError on an unbalanced
+        # quote in user-supplied VB_LMOD_MODULES.
         names = " ".join(
-            shlex.quote(m) for m in shlex.split(modules.replace(",", " "))
+            shlex.quote(m) for m in modules.replace(",", " ").split()
         )
         if names:
             init = _env_first("VB_LMOD_INIT", suffix) or DEFAULT_LMOD_INIT_CSH
             qinit = shlex.quote(init)
             # Source Lmod's csh init to define $LMOD_CMD, then load via the
             # Lmod backend directly rather than the `module` alias.  In a
-            # single `csh -c`, aliases defined by a sourced file are NOT
+            # single `csh -f -c`, aliases defined by a sourced file are NOT
             # active for words on the same parse line (classic csh gotcha),
             # so `module load` would fail with "module: Command not found".
             # `$LMOD_CMD` is a plain variable, resolved at run time, so
@@ -128,11 +133,83 @@ def cadence_env_setup_csh(suffix: str = "") -> str:
             # via /etc/csh.cshrc) and the init file is absent.
             lines.append(f"if ( -f {qinit} ) source {qinit}")
             lines.append(f"if ( $?LMOD_CMD ) eval `$LMOD_CMD csh load {names}`")
+            # If Lmod never got initialized (init file absent AND site did not
+            # pre-define $LMOD_CMD), the load above silently no-ops.  Surface a
+            # warning on stdout so it shows up in the 2>&1-merged status output.
+            # The `virtuoso-bridge:` prefix can't be mistaken for a
+            # VB_SPECTRE_PATH=/SPECTRE_PATH=/@(#)$CDS: marker or a grep'd
+            # NAME= env line by any of the parsers.
+            lines.append(
+                'if ( ! $?LMOD_CMD ) echo "virtuoso-bridge: VB_LMOD_MODULES '
+                'set but Lmod is not initialized (set VB_LMOD_INIT)"'
+            )
     for var in ("VB_CADENCE_CSHRC", "VB_MENTOR_CSHRC"):
         cshrc = _env_first(var, suffix)
         if cshrc:
             lines.append(f"source {shlex.quote(cshrc)}")
     return "; ".join(lines)
+
+
+# sed program that rewrites `NAME=VALUE` env lines into `export NAME='VALUE'`,
+# single-quoting VALUE so values containing spaces, `$` or backticks survive a
+# bash `eval` verbatim instead of being re-expanded or truncated.  VALUE's own
+# single quotes are escaped as '\'' by the first substitution first (safe on
+# the whole line because env var NAMEs never contain single quotes).
+_ENV_EXPORT_SED = (
+    r"s/'/'\\''/g;"
+    r"s/^\([A-Za-z_][A-Za-z0-9_]*\)=\(.*\)$/export \1='\2'/"
+)
+
+
+def cadence_env_import_bash(setup_csh: str, var_pattern: str) -> str:
+    """Return a bash fragment that imports selected Cadence env vars into bash.
+
+    Runs ``csh -f -c '<setup_csh>; env'`` (the same csh prelude spectre runs
+    under), keeps only the lines whose ``NAME`` matches *var_pattern* (a
+    ``grep -E`` regex, e.g. ``^CDSHOME=``), and ``eval``s them as ``export``
+    statements so ``which spectre``/licensing see the same PATH and license
+    vars a real run would.  Each value is safely single-quoted (embedded single
+    quotes escaped), so values with spaces, ``$`` or backticks round-trip
+    exactly rather than being word-split or re-expanded by bash.
+
+    The fragment ends with ``; `` so callers can prepend it to a larger
+    command.  Returns ``""`` when *setup_csh* is empty.
+    """
+    if not setup_csh:
+        return ""
+    csh_arg = shlex.quote(f"{setup_csh}; env")
+    return (
+        'eval "$(csh -f -c ' + csh_arg + ' 2>/dev/null '
+        '| grep -E ' + shlex.quote(var_pattern) + ' '
+        '| sed ' + shlex.quote(_ENV_EXPORT_SED) + ')" 2>/dev/null; '
+    )
+
+
+def remote_tool_probe(fast_body: str, csh_body: str) -> str:
+    """Compose one remote command that probes for a Cadence tool.
+
+    Tries *fast_body* (a bash snippet assuming the tool is already on PATH)
+    and, only if it fails, falls back to *csh_body* run inside a fresh
+    ``csh -f -c`` (which establishes the Cadence environment via Lmod modules /
+    cshrc files, see :func:`cadence_env_setup_csh`).
+
+    The two are fused into a single SSH round-trip —
+    ``{ fast } || { csh -f -c '…' 2>&1 }`` wrapped in ``bash -l -c '…'`` — so
+    congested jump hosts pay one TCP + sshd handshake instead of two.  csh's
+    stderr is merged (``2>&1``) so module chatter reaches the caller's
+    marker parser without breaking the pipe.  Each caller keeps its own
+    marker conventions inside *fast_body* / *csh_body*.
+
+    Note the ``-f``: startup files (``~/.cshrc``) are deliberately skipped.
+    In the Lmod use case they carry no tool/project variables — the
+    environment must come entirely from the explicit per-project module /
+    cshrc config (``VB_LMOD_MODULES{_PROFILE}``, ``VB_CADENCE_CSHRC…``), so
+    every code path (probe, license check, real run) uses the same hermetic
+    ``csh -f`` shell and behaves identically.
+    """
+    slow = f"csh -f -c {shlex.quote(csh_body)} 2>&1"
+    combined = f"{{ {fast_body}; }} || {{ {slow}; }}"
+    return f"bash -l -c {shlex.quote(combined)}"
 
 def spectre_mode_args(mode: str) -> list[str]:
     """Return standard Spectre CLI arguments for a named simulation mode."""
@@ -312,7 +389,7 @@ def _run_spectre_remote(
     exec_cmd = (
         f"{env_setup}"
         f"mkdir -p {shlex.quote(remote_raw_dir)} && "
-        f"csh -c {shlex.quote(csh_inner)} & "
+        f"csh -f -c {shlex.quote(csh_inner)} & "
         f"SPID=$!; echo $SPID > {shlex.quote(pid_file)}; wait $SPID"
     )
 
@@ -810,13 +887,13 @@ class SpectreSimulator:
         # VB_SPECTRE_BIN is set, since modules also provide runtime libs.
         setup = cadence_env_setup_csh(suffix)
         if setup:
-            csh_arg = shlex.quote(f"{setup}; env")
             env_setup = (
                 'HOSTNAME=`hostname 2>/dev/null || echo localhost`; export HOSTNAME && '
                 'export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}" && '
-                f'eval "$(csh -c {csh_arg} 2>/dev/null '
-                f"| grep -E '^(PATH|LD_LIBRARY_PATH|LM_LICENSE_FILE|CDS_LIC_FILE|CDS)=' "
-                f"| sed 's/^/export /')\" 2>/dev/null; "
+                + cadence_env_import_bash(
+                    setup,
+                    "^(PATH|LD_LIBRARY_PATH|LM_LICENSE_FILE|CDS_LIC_FILE|CDS)=",
+                )
             )
         else:
             env_setup = ""
@@ -832,7 +909,7 @@ class SpectreSimulator:
         check_script = (
             f'{env_setup}'
             f'echo "SPECTRE_PATH={path_expr}"; '
-            f'{ver_cmd} 2>&1 | head -1; '
+            f'{ver_cmd} 2>&1; '
             'lmstat -a 2>/dev/null | grep -E "Users of" | grep "licenses in use" | grep -v "0 licenses in use"'
         )
 

--- a/src/virtuoso_bridge/spectre/runner.py
+++ b/src/virtuoso_bridge/spectre/runner.py
@@ -70,6 +70,70 @@ def _resolve_spectre_invocation(
     parts = shlex.split(spectre_cmd) if spectre_cmd.strip() else ["spectre"]
     return parts[0], parts[1:]
 
+
+def _env_first(name: str, suffix: str = "") -> str:
+    """Read env var *name* with an optional profile *suffix*, falling back to
+    the unsuffixed name.  Returns "" when neither is set."""
+    if suffix:
+        val = os.environ.get(f"{name}{suffix}", "").strip()
+        if val:
+            return val
+    return os.environ.get(name, "").strip()
+
+
+# Default location of Lmod's csh init script.  Sourcing it defines the
+# `module` command inside a bare, non-interactive `csh -c` (which does not
+# inherit an interactive shell's module setup).  Override with VB_LMOD_INIT
+# when your site installs Lmod elsewhere; the `source` is guarded so a wrong
+# path is harmless when `module` is already defined (e.g. via /etc/csh.cshrc).
+DEFAULT_LMOD_INIT_CSH = "/usr/share/lmod/lmod/init/csh"
+
+
+def cadence_env_setup_csh(suffix: str = "") -> str:
+    """Build a ``;``-joined csh prelude that establishes the Cadence/Spectre
+    environment in a fresh, non-interactive remote shell.
+
+    Spectre is invoked over SSH as ``csh -c '<prelude>; spectre …'``, so this
+    prelude is the single place that teaches every code path (status probe,
+    license check, and real runs) how to make the tools reachable.  It layers,
+    in order (each optional, later layers win):
+
+    1. **Lmod modules** — ``VB_LMOD_MODULES`` (space/comma-separated module
+       names) loaded after sourcing ``VB_LMOD_INIT`` (default
+       :data:`DEFAULT_LMOD_INIT_CSH`).  This is the HPC/module-file path.
+    2. ``VB_CADENCE_CSHRC`` — a csh file to ``source``.
+    3. ``VB_MENTOR_CSHRC`` — a csh file to ``source``.
+
+    All variables honor the optional profile *suffix* (e.g.
+    ``VB_LMOD_MODULES_worker1``) with a fallback to the unsuffixed name.
+    Returns ``""`` when nothing is configured.
+    """
+    lines: list[str] = []
+    modules = _env_first("VB_LMOD_MODULES", suffix)
+    if modules:
+        names = " ".join(
+            shlex.quote(m) for m in shlex.split(modules.replace(",", " "))
+        )
+        if names:
+            init = _env_first("VB_LMOD_INIT", suffix) or DEFAULT_LMOD_INIT_CSH
+            qinit = shlex.quote(init)
+            # Source Lmod's csh init to define $LMOD_CMD, then load via the
+            # Lmod backend directly rather than the `module` alias.  In a
+            # single `csh -c`, aliases defined by a sourced file are NOT
+            # active for words on the same parse line (classic csh gotcha),
+            # so `module load` would fail with "module: Command not found".
+            # `$LMOD_CMD` is a plain variable, resolved at run time, so
+            # `eval \`$LMOD_CMD csh load …\`` works inline.  The $?LMOD_CMD
+            # guard degrades gracefully when the site pre-defines Lmod (e.g.
+            # via /etc/csh.cshrc) and the init file is absent.
+            lines.append(f"if ( -f {qinit} ) source {qinit}")
+            lines.append(f"if ( $?LMOD_CMD ) eval `$LMOD_CMD csh load {names}`")
+    for var in ("VB_CADENCE_CSHRC", "VB_MENTOR_CSHRC"):
+        cshrc = _env_first(var, suffix)
+        if cshrc:
+            lines.append(f"source {shlex.quote(cshrc)}")
+    return "; ".join(lines)
+
 def spectre_mode_args(mode: str) -> list[str]:
     """Return standard Spectre CLI arguments for a named simulation mode."""
     key = mode.strip().lower()
@@ -203,6 +267,7 @@ def _run_spectre_remote(
     output_format: str | None = "psfascii",
     timeout: int = 600,
     keep_remote_files: bool = False,
+    profile: str | None = None,
 ) -> _SpectreRunResult:
     """Run Spectre on a remote host: upload netlist, run, download results."""
     run_id = uuid.uuid4().hex[:8]
@@ -230,14 +295,11 @@ def _run_spectre_remote(
     print(f"[Command] {spectre_command}")
     print("[Exec] Remote simulation running...")
 
-    # Source Cadence/Mentor cshrc in csh, then exec spectre — one command, no wrapper file
-    _cadence_val = os.environ.get("VB_CADENCE_CSHRC", "").strip()
-    _mentor_val = os.environ.get("VB_MENTOR_CSHRC", "").strip()
-    source_lines: list[str] = []
-    for cshrc in (_cadence_val, _mentor_val):
-        if cshrc:
-            source_lines.append(f"source {shlex.quote(cshrc)}")
-    csh_body = "; ".join(source_lines) if source_lines else ":"
+    # Establish the Cadence env in csh (Lmod modules and/or cshrc files), then
+    # exec spectre — one command, no wrapper file.  ":" is csh's no-op when
+    # nothing is configured (spectre already on PATH).
+    suffix = f"_{profile}" if profile else ""
+    csh_body = cadence_env_setup_csh(suffix) or ":"
     # Export HOSTNAME & LD_LIBRARY_PATH so csh inherits them (.cshrc may reference $HOSTNAME)
     env_setup = (
         'HOSTNAME=`hostname 2>/dev/null || echo localhost`; export HOSTNAME && '
@@ -740,28 +802,30 @@ class SpectreSimulator:
         runner = self._get_ssh_runner()
 
         suffix = f"_{self._profile}" if self._profile else ""
-        spectre_bin = (
-            os.environ.get(f"VB_SPECTRE_BIN{suffix}", "").strip()
-            or os.environ.get("VB_SPECTRE_BIN", "").strip()
-        )
+        spectre_bin = _env_first("VB_SPECTRE_BIN", suffix)
+
+        # Import the Cadence env from a csh sub-shell (Lmod modules and/or
+        # cshrc files) into this bash check, so `which spectre`/licensing see
+        # the same PATH and license vars a real run would.  Runs even when
+        # VB_SPECTRE_BIN is set, since modules also provide runtime libs.
+        setup = cadence_env_setup_csh(suffix)
+        if setup:
+            csh_arg = shlex.quote(f"{setup}; env")
+            env_setup = (
+                'HOSTNAME=`hostname 2>/dev/null || echo localhost`; export HOSTNAME && '
+                'export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}" && '
+                f'eval "$(csh -c {csh_arg} 2>/dev/null '
+                f"| grep -E '^(PATH|LD_LIBRARY_PATH|LM_LICENSE_FILE|CDS_LIC_FILE|CDS)=' "
+                f"| sed 's/^/export /')\" 2>/dev/null; "
+            )
+        else:
+            env_setup = ""
 
         if spectre_bin:
             quoted_bin = shlex.quote(spectre_bin)
-            env_setup = ""
             path_expr = spectre_bin
             ver_cmd = f"{quoted_bin} -V"
         else:
-            cadence_cshrc = shlex.quote(
-                os.environ.get(f"VB_CADENCE_CSHRC{suffix}", "")
-                or os.environ.get("VB_CADENCE_CSHRC", "")
-            )
-            env_setup = (
-                'HOSTNAME=`hostname 2>/dev/null || echo localhost`; export HOSTNAME && '
-                f'export VB_CADENCE_CSHRC={cadence_cshrc} && '
-                f'eval "$(csh -c \'source {cadence_cshrc}; env\' 2>/dev/null '
-                f'| grep -E \"^(PATH|LM_LICENSE_FILE|CDS)=\" '
-                f'| sed \'s/^/export /\')" 2>/dev/null; '
-            )
             path_expr = "$(which spectre 2>/dev/null || echo NOTFOUND)"
             ver_cmd = "spectre -V"
 
@@ -868,6 +932,7 @@ class SpectreSimulator:
             output_format=self._output_format,
             timeout=self._timeout,
             keep_remote_files=self._keep_remote_files,
+            profile=self._profile,
         )
         if not run_result.success:
             return SimulationResult(

--- a/src/virtuoso_bridge/transport/tunnel.py
+++ b/src/virtuoso_bridge/transport/tunnel.py
@@ -300,16 +300,14 @@ class SSHClient:
         # LD_LIBRARY_PATH (e.g. oss/python) would load here but then die at
         # daemon launch, and importing its PATH could shadow the system-python3
         # fallback with that unusable interpreter.
-        from virtuoso_bridge.spectre.runner import cadence_env_setup_csh
+        from virtuoso_bridge.spectre.runner import (
+            cadence_env_import_bash,
+            cadence_env_setup_csh,
+        )
         suffix = f"_{self._profile}" if self._profile else ""
         setup = cadence_env_setup_csh(suffix)
         if setup:
-            csh_arg = shlex.quote(f"{setup}; env")
-            detect_cmd = (
-                f'eval "$(csh -c {csh_arg} 2>/dev/null '
-                "| grep -E '^CDSHOME=' | sed 's/^/export /')\" 2>/dev/null; "
-                + detect_cmd
-            )
+            detect_cmd = cadence_env_import_bash(setup, "^CDSHOME=") + detect_cmd
         runner = self._require_runner()
         result = runner.run_command(detect_cmd)
         output = result.stdout.strip()

--- a/src/virtuoso_bridge/transport/tunnel.py
+++ b/src/virtuoso_bridge/transport/tunnel.py
@@ -12,6 +12,7 @@ import json
 import logging
 import os
 import re
+import shlex
 import shutil
 import socket
 import sys
@@ -288,6 +289,27 @@ class SSHClient:
             '(python2.7 --version 2>&1 && echo "CMD:python2.7") || '
             'echo "CMD:NONE"'
         )
+        # $CDSHOME is set by the Cadence env (Lmod module files / cshrc) but NOT
+        # by a bare SSH shell, so on module-based sites the preferred Cadence
+        # python is invisible here and detection falls back to system python3.
+        # Import ONLY $CDSHOME (via the same csh prelude as spectre) so the
+        # Cadence-bundled python — which is self-contained (rpath) and so
+        # survives the daemon's `env -u LD_LIBRARY_PATH` launch — is chosen as
+        # an absolute path.  We deliberately do NOT import PATH or
+        # LD_LIBRARY_PATH: a module-python whose libpython lives on
+        # LD_LIBRARY_PATH (e.g. oss/python) would load here but then die at
+        # daemon launch, and importing its PATH could shadow the system-python3
+        # fallback with that unusable interpreter.
+        from virtuoso_bridge.spectre.runner import cadence_env_setup_csh
+        suffix = f"_{self._profile}" if self._profile else ""
+        setup = cadence_env_setup_csh(suffix)
+        if setup:
+            csh_arg = shlex.quote(f"{setup}; env")
+            detect_cmd = (
+                f'eval "$(csh -c {csh_arg} 2>/dev/null '
+                "| grep -E '^CDSHOME=' | sed 's/^/export /')\" 2>/dev/null; "
+                + detect_cmd
+            )
         runner = self._require_runner()
         result = runner.run_command(detect_cmd)
         output = result.stdout.strip()

--- a/src/virtuoso_bridge/virtuoso/skill_finder/__init__.py
+++ b/src/virtuoso_bridge/virtuoso/skill_finder/__init__.py
@@ -28,6 +28,55 @@ from typing import Literal
 
 from .parser import SkillEntry, parse_fnd_directory
 
+# Matches csh's builtin `which` alias-report line, e.g.
+# "virtuoso: aliased to /tools/cadence/IC618/tools/bin/virtuoso -leaf".
+_CSH_ALIAS_RE = re.compile(r"^virtuoso:\s*aliased to\s+(.*)$")
+
+
+def _parse_virtuoso_path(stdout: str) -> str:
+    """Extract an absolute virtuoso executable path from probe *stdout*.
+
+    Accepts a bare absolute path ending in ``/virtuoso``, or extracts one
+    from a csh ``virtuoso: aliased to <definition>`` line (only if the
+    definition itself contains an absolute ``/virtuoso`` path — otherwise
+    that line is skipped rather than accepted as garbage).  Bare/relative
+    tokens (e.g. a lone ``virtuoso`` or ``bin/virtuoso``) are rejected: they
+    would otherwise feed a `dirname` walk that can spin (see
+    :func:`_build_doc_finder_walk_script`).
+    """
+    for line in (stdout or "").splitlines():
+        line = line.strip()
+        if line.startswith("/") and line.endswith("/virtuoso"):
+            return line
+        alias_match = _CSH_ALIAS_RE.match(line)
+        if alias_match:
+            for token in alias_match.group(1).split():
+                if token.startswith("/") and token.endswith("/virtuoso"):
+                    return token
+    return ""
+
+
+def _build_doc_finder_walk_script(virtuoso_path: str) -> str:
+    """Build the shell snippet that walks up from *virtuoso_path* looking
+    for ``doc/finder/SKILL``.
+
+    Terminates even if fed a relative or otherwise degenerate path: besides
+    the caller only ever passing an absolute path (see
+    :func:`_parse_virtuoso_path`), the loop itself stops as soon as
+    ``dirname`` stops making progress (``parent == p``), rather than relying
+    solely on the ``$p != "/"`` guard — a relative single-component path
+    like ``bin/virtuoso`` would otherwise dirname to ``.`` forever.
+    """
+    return (
+        f'p="{virtuoso_path}"; '
+        'while [ -n "$p" ] && [ "$p" != "/" ]; do '
+        '  if [ -d "$p/doc/finder/SKILL" ]; then echo "$p/doc/finder/SKILL"; exit 0; fi; '
+        '  parent=$(dirname "$p"); '
+        '  if [ "$parent" = "$p" ]; then break; fi; '
+        '  p="$parent"; '
+        'done; exit 1'
+    )
+
 
 class SearchMode(enum.Enum):
     """Supported search modes for SKILL Finder queries."""
@@ -118,40 +167,31 @@ class SKILLFinder:
         # 1. Establish Cadence env, then find virtuoso.  Same detection shape
         # as the spectre probe (cli._print_spectre_status): a bash fast path
         # for when virtuoso is already on PATH, falling back to a csh shell
-        # that loads modules / sources cshrc.  csh module chatter goes to
-        # stderr and is discarded (2>/dev/null).
-        from virtuoso_bridge.spectre.runner import cadence_env_setup_csh
+        # that loads modules / sources cshrc.  The composition itself is
+        # shared with the spectre probe (remote_tool_probe) — only the
+        # fast/csh bodies and the marker parsing below are specific to
+        # SKILL Finder discovery.  The probe runs ``csh -f -c`` (hermetic:
+        # ~/.cshrc carries no tool/project variables in the Lmod use case),
+        # so the environment comes solely from the per-project module /
+        # cshrc config, identically to real runs.
+        from virtuoso_bridge.spectre.runner import cadence_env_setup_csh, remote_tool_probe
 
         suffix = f"_{profile}" if profile else ""
         setup = cadence_env_setup_csh(suffix)
         fast = "which virtuoso 2>/dev/null"
         if setup:
-            csh_inner = f"{setup}; which virtuoso"
-            slow = f"csh -f -c {shlex.quote(csh_inner)} 2>/dev/null"
-            combined = f"{{ {fast}; }} || {{ {slow}; }}"
+            csh_body = f"{setup}; which virtuoso"
+            find_virtuoso_script = remote_tool_probe(fast, csh_body)
         else:
-            combined = fast
-        find_virtuoso_script = f"bash -l -c {shlex.quote(combined)}"
+            find_virtuoso_script = f"bash -l -c {shlex.quote(fast)}"
         r = runner.run_command(find_virtuoso_script, timeout=30)
 
-        virtuoso_path = ""
-        for line in (r.stdout or "").splitlines():
-            line = line.strip()
-            # Ignore any stray chatter; accept only a real virtuoso path.
-            if line.endswith("/virtuoso") or line == "virtuoso":
-                virtuoso_path = line
-                break
+        virtuoso_path = _parse_virtuoso_path(r.stdout)
         if not virtuoso_path:
             return None
 
         # 2. Walk up from virtuoso to find doc/finder/SKILL.
-        walk_script = (
-            f'p="{virtuoso_path}"; '
-            'while [ -n "$p" ] && [ "$p" != "/" ]; do '
-            '  if [ -d "$p/doc/finder/SKILL" ]; then echo "$p/doc/finder/SKILL"; exit 0; fi; '
-            '  p=$(dirname "$p"); '
-            'done; exit 1'
-        )
+        walk_script = _build_doc_finder_walk_script(virtuoso_path)
         r2 = runner.run_command(f"bash -c {shlex.quote(walk_script)}", timeout=15)
         if r2.returncode == 0 and r2.stdout.strip():
             return Path(r2.stdout.strip())

--- a/src/virtuoso_bridge/virtuoso/skill_finder/__init__.py
+++ b/src/virtuoso_bridge/virtuoso/skill_finder/__init__.py
@@ -20,7 +20,6 @@ Usage (remote mode, via VirtuosoClient)::
 from __future__ import annotations
 
 import enum
-import os
 import re
 import shlex
 from dataclasses import dataclass, field
@@ -111,32 +110,39 @@ class SKILLFinder:
     def _discover_remote(self, runner, profile: str | None) -> Path | None:
         """Find SKILL Finder root on a remote server via SSH.
 
-        Strategy: source VB_CADENCE_CSHRC to load Cadence environment, then
-        use ``which virtuoso`` to locate the binary, then walk up its parent
-        directories to find ``doc/finder/SKILL``.
+        Strategy: establish the Cadence environment (Lmod modules and/or
+        cshrc files, via cadence_env_setup_csh), then use ``which virtuoso``
+        to locate the binary, then walk up its parent directories to find
+        ``doc/finder/SKILL``.
         """
-        # 1. Source cshrc in csh to load Cadence env, then find virtuoso.
-        # If VB_CADENCE_CSHRC is empty the source command is a no-op (silent
-        # failure), which is fine — we still run ``which virtuoso`` afterwards.
+        # 1. Establish Cadence env, then find virtuoso.  Same detection shape
+        # as the spectre probe (cli._print_spectre_status): a bash fast path
+        # for when virtuoso is already on PATH, falling back to a csh shell
+        # that loads modules / sources cshrc.  csh module chatter goes to
+        # stderr and is discarded (2>/dev/null).
+        from virtuoso_bridge.spectre.runner import cadence_env_setup_csh
+
         suffix = f"_{profile}" if profile else ""
-        cadence_cshrc = os.environ.get(
-            f"VB_CADENCE_CSHRC{suffix}", ""
-        ) or os.environ.get("VB_CADENCE_CSHRC", "")
-        quoted_cshrc = shlex.quote(cadence_cshrc)
-
-        find_virtuoso_script = (
-            'HOSTNAME=`hostname 2>/dev/null || echo localhost`; '
-            'export HOSTNAME; '
-            f'eval "$(csh -c \'source {quoted_cshrc}; env\' 2>/dev/null '
-            f'| grep -E "^(PATH|LM_LICENSE_FILE|CDS)=" '
-            f'| sed \'s/^/export /\')" 2>/dev/null; '
-            'which virtuoso 2>/dev/null || echo NOTFOUND'
-        )
+        setup = cadence_env_setup_csh(suffix)
+        fast = "which virtuoso 2>/dev/null"
+        if setup:
+            csh_inner = f"{setup}; which virtuoso"
+            slow = f"csh -f -c {shlex.quote(csh_inner)} 2>/dev/null"
+            combined = f"{{ {fast}; }} || {{ {slow}; }}"
+        else:
+            combined = fast
+        find_virtuoso_script = f"bash -l -c {shlex.quote(combined)}"
         r = runner.run_command(find_virtuoso_script, timeout=30)
-        if r.returncode != 0 or "NOTFOUND" in r.stdout:
-            return None
 
-        virtuoso_path = r.stdout.strip()
+        virtuoso_path = ""
+        for line in (r.stdout or "").splitlines():
+            line = line.strip()
+            # Ignore any stray chatter; accept only a real virtuoso path.
+            if line.endswith("/virtuoso") or line == "virtuoso":
+                virtuoso_path = line
+                break
+        if not virtuoso_path:
+            return None
 
         # 2. Walk up from virtuoso to find doc/finder/SKILL.
         walk_script = (

--- a/tests/test_skill_finder.py
+++ b/tests/test_skill_finder.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
 import json
+import subprocess
+from pathlib import Path
 
 import virtuoso_bridge
 from virtuoso_bridge.cli import main
 from virtuoso_bridge.virtuoso.basic.bridge import VirtuosoClient
-from virtuoso_bridge.virtuoso.skill_finder import SKILLFinder
+from virtuoso_bridge.virtuoso.skill_finder import (
+    SKILLFinder,
+    _build_doc_finder_walk_script,
+    _parse_virtuoso_path,
+)
 
 
 class _FakeSkillClient:
@@ -159,3 +165,209 @@ def test_skill_more_info_uses_local_discovery_when_tunnel_has_no_ssh_runner(monk
     assert result is not None
     assert result["func_name"] == "dbOpenCellViewByType"
     assert "Open a cellview." in result["plain_text"]
+
+
+# ---------------------------------------------------------------------------
+# _discover_remote: virtuoso path parsing (F2, F6) and probe composition (F9)
+# ---------------------------------------------------------------------------
+
+
+class _Result:
+    def __init__(self, stdout="", stderr="", returncode=0):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = returncode
+
+
+class _FakeRemoteRunner:
+    """Records commands and returns queued canned results in order."""
+
+    def __init__(self, results):
+        self.commands: list[str] = []
+        self._results = list(results)
+
+    def run_command(self, command, timeout=None):
+        self.commands.append(command)
+        return self._results.pop(0)
+
+
+def _clear_cadence_env(monkeypatch):
+    for var in ("VB_LMOD_MODULES", "VB_CADENCE_CSHRC", "VB_MENTOR_CSHRC"):
+        monkeypatch.delenv(var, raising=False)
+
+
+# -- _parse_virtuoso_path ----------------------------------------------------
+
+
+def test_parse_virtuoso_path_accepts_absolute_path():
+    stdout = "/tools/cadence/IC618/tools/bin/virtuoso\n"
+    assert _parse_virtuoso_path(stdout) == "/tools/cadence/IC618/tools/bin/virtuoso"
+
+
+def test_parse_virtuoso_path_extracts_absolute_path_from_csh_alias():
+    stdout = "virtuoso: aliased to /tools/cadence/IC618/tools/bin/virtuoso -leaf\n"
+    assert _parse_virtuoso_path(stdout) == "/tools/cadence/IC618/tools/bin/virtuoso"
+
+
+def test_parse_virtuoso_path_ignores_alias_with_no_absolute_path():
+    # e.g. a shell-function-backed alias with no real path in the definition.
+    stdout = "virtuoso: aliased to runVirtuosoWrapper\n"
+    assert _parse_virtuoso_path(stdout) == ""
+
+
+def test_parse_virtuoso_path_rejects_bare_token():
+    assert _parse_virtuoso_path("virtuoso\n") == ""
+
+
+def test_parse_virtuoso_path_rejects_relative_path():
+    assert _parse_virtuoso_path("bin/virtuoso\n") == ""
+    assert _parse_virtuoso_path("tools/bin/virtuoso\n") == ""
+
+
+def test_parse_virtuoso_path_no_match_returns_empty():
+    assert _parse_virtuoso_path("command not found\n") == ""
+
+
+# -- _discover_remote integration -------------------------------------------
+
+
+def test_discover_remote_accepts_csh_alias_and_walks_up(monkeypatch):
+    _clear_cadence_env(monkeypatch)
+    runner = _FakeRemoteRunner([
+        _Result(stdout="virtuoso: aliased to /tools/IC618/tools/bin/virtuoso -leaf\n", returncode=0),
+        _Result(stdout="/tools/IC618/doc/finder/SKILL\n", returncode=0),
+    ])
+
+    finder = SKILLFinder()
+    result = finder._discover_remote(runner, None)
+
+    assert result == Path("/tools/IC618/doc/finder/SKILL")
+    # The walk script must be seeded with the extracted absolute path.
+    assert "/tools/IC618/tools/bin/virtuoso" in runner.commands[1]
+
+
+def test_discover_remote_returns_none_for_alias_with_no_absolute_path(monkeypatch):
+    _clear_cadence_env(monkeypatch)
+    runner = _FakeRemoteRunner([
+        _Result(stdout="virtuoso: aliased to runVirtuosoWrapper\n", returncode=0),
+    ])
+
+    finder = SKILLFinder()
+    result = finder._discover_remote(runner, None)
+
+    assert result is None
+    # No garbage path should ever reach the walk-script stage.
+    assert len(runner.commands) == 1
+
+
+def test_discover_remote_returns_none_for_bare_virtuoso_token(monkeypatch):
+    _clear_cadence_env(monkeypatch)
+    runner = _FakeRemoteRunner([_Result(stdout="virtuoso\n", returncode=0)])
+
+    finder = SKILLFinder()
+    result = finder._discover_remote(runner, None)
+
+    assert result is None
+    assert len(runner.commands) == 1
+
+
+def test_discover_remote_returns_none_for_relative_path(monkeypatch):
+    _clear_cadence_env(monkeypatch)
+    runner = _FakeRemoteRunner([_Result(stdout="bin/virtuoso\n", returncode=0)])
+
+    finder = SKILLFinder()
+    result = finder._discover_remote(runner, None)
+
+    assert result is None
+    assert len(runner.commands) == 1
+
+
+def test_discover_remote_uses_shared_probe_composition(monkeypatch):
+    # A configured cshrc makes cadence_env_setup_csh() non-empty, which
+    # routes _discover_remote through remote_tool_probe (F9).
+    _clear_cadence_env(monkeypatch)
+    monkeypatch.setenv("VB_CADENCE_CSHRC", "/opt/cadence/cshrc.csh")
+    runner = _FakeRemoteRunner([
+        _Result(stdout="/tools/bin/virtuoso\n", returncode=0),
+        _Result(stdout="", returncode=1),
+    ])
+
+    finder = SKILLFinder()
+    finder._discover_remote(runner, None)
+
+    probe_cmd = runner.commands[0]
+    assert probe_cmd.startswith("bash -l -c ")
+    assert "which virtuoso" in probe_cmd
+    # F1/F9: the csh fallback must be hermetic `csh -f -c` — ~/.cshrc holds
+    # no tool/project variables in the Lmod use case; env comes only from
+    # the per-project module/cshrc config, identically to real runs.
+    assert "csh -f -c" in probe_cmd
+
+
+def test_discover_remote_skips_probe_composition_when_no_cadence_env_configured(monkeypatch):
+    _clear_cadence_env(monkeypatch)
+    runner = _FakeRemoteRunner([_Result(stdout="", returncode=1)])
+
+    finder = SKILLFinder()
+    result = finder._discover_remote(runner, None)
+
+    assert result is None
+    probe_cmd = runner.commands[0]
+    assert probe_cmd.startswith("bash -l -c ")
+    assert "csh" not in probe_cmd
+
+
+# -- walk-script termination hardening (F6) ----------------------------------
+
+
+def test_walk_script_contains_termination_guard():
+    script = _build_doc_finder_walk_script("/tools/bin/virtuoso")
+    assert 'parent=$(dirname "$p")' in script
+    assert '"$parent" = "$p"' in script
+
+
+def test_discover_remote_walk_script_command_has_termination_guard(monkeypatch):
+    _clear_cadence_env(monkeypatch)
+    runner = _FakeRemoteRunner([
+        _Result(stdout="/tools/bin/virtuoso\n", returncode=0),
+        _Result(stdout="", returncode=1),
+    ])
+
+    finder = SKILLFinder()
+    finder._discover_remote(runner, None)
+
+    walk_cmd = runner.commands[1]
+    assert 'parent=$(dirname "$p")' in walk_cmd
+    assert '"$parent" = "$p"' in walk_cmd
+
+
+def test_walk_script_terminates_quickly_for_relative_path():
+    """Defense in depth: even if fed a relative/degenerate path, the loop
+    itself must not spin forever (dirname("bin/virtuoso") -> "." -> "."...).
+    """
+    script = _build_doc_finder_walk_script("bin/virtuoso")
+
+    result = subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+
+    assert result.returncode == 1
+    assert result.stdout.strip() == ""
+
+
+def test_walk_script_terminates_quickly_for_dot_path():
+    """Same guard exercised directly with the degenerate "." path that a
+    bare relative single-component input dirnames down to."""
+    script = _build_doc_finder_walk_script(".")
+
+    result = subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+
+    assert result.returncode == 1

--- a/tests/test_spectre_env_setup.py
+++ b/tests/test_spectre_env_setup.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+import shutil
+import subprocess
+
 import pytest
 
 from virtuoso_bridge.spectre.runner import (
     DEFAULT_LMOD_INIT_CSH,
+    cadence_env_import_bash,
     cadence_env_setup_csh,
+    remote_tool_probe,
 )
 
 _ENV_VARS = (
@@ -87,3 +92,87 @@ def test_paths_with_spaces_are_quoted(monkeypatch):
     monkeypatch.setenv("VB_LMOD_INIT", "/opt/my lmod/init/csh")
     out = cadence_env_setup_csh()
     assert "'/opt/my lmod/init/csh'" in out
+
+
+def test_stray_quote_in_modules_does_not_raise(monkeypatch):
+    # A whitespace split (not shlex) must tolerate an unbalanced quote in the
+    # user-supplied value without raising ValueError.
+    monkeypatch.setenv("VB_LMOD_MODULES", "spectre/23.1 bad'module")
+    out = cadence_env_setup_csh()  # must not raise
+    assert "csh load" in out
+    assert "spectre/23.1" in out
+
+
+def test_not_initialized_warning_present_when_modules_set(monkeypatch):
+    monkeypatch.setenv("VB_LMOD_MODULES", "spectre/23.1")
+    out = cadence_env_setup_csh()
+    # A guarded warning surfaces (on stdout, merged with 2>&1) when Lmod never
+    # gets initialized, instead of silently no-op'ing the module load.
+    assert "if ( ! $?LMOD_CMD )" in out
+    assert "Lmod is not initialized" in out
+    # The warning prefix can't be mistaken for any marker/env parser line.
+    assert "virtuoso-bridge:" in out
+
+
+def test_no_warning_when_no_modules(monkeypatch):
+    monkeypatch.setenv("VB_CADENCE_CSHRC", "/home/x/cad.cshrc")
+    out = cadence_env_setup_csh()
+    assert "Lmod is not initialized" not in out
+
+
+def test_env_import_bash_empty_when_no_setup():
+    assert cadence_env_import_bash("", "^CDSHOME=") == ""
+
+
+def test_env_import_bash_single_quotes_exports():
+    frag = cadence_env_import_bash("source /x/cad.cshrc", "^CDSHOME=")
+    # Runs the csh prelude's env through grep/sed and eval's single-quoted
+    # exports (values with spaces/$ survive verbatim).
+    assert "csh -f -c" in frag
+    assert "grep -E" in frag
+    assert "'^CDSHOME='" in frag
+    assert frag.rstrip().endswith(";")
+    # The sed program emits `export NAME='VALUE'` (single-quoted the value),
+    # not the old unquoted `s/^/export /`.  The literal single quotes are
+    # shell-escaped by shlex.quote, so the backref rewrite appears as
+    # `export \1=` (the round-trip test below proves the quoting is correct).
+    assert "export \\1=" in frag
+    assert "s/^/export /" not in frag
+
+
+def test_env_import_bash_value_round_trips_through_sed_and_bash():
+    """F5: the generated sed program must single-quote imported values so a
+    value with spaces and a ``$`` round-trips exactly through real sed+bash."""
+    if not (shutil.which("bash") and shutil.which("sed")):
+        pytest.skip("bash/sed not available")
+
+    frag = cadence_env_import_bash("source /x/cad.cshrc", "^CDSHOME=")
+    # Extract just the `sed '<program>'` portion and drive it directly, feeding
+    # a synthetic env line with spaces, a `$`, and backticks.
+    import re
+    m = re.search(r"\| sed (?P<sed>'.*')\)", frag)
+    assert m, frag
+    sed_arg = m.group("sed")
+
+    env_line = "CDSHOME=/opt/my tools/$weird `x`"
+    import shlex
+    script = (
+        "eval \"$(printf %s " + shlex.quote(env_line)
+        + " | grep -E '^CDSHOME=' | sed " + sed_arg + ")\"; "
+        'printf "%s" "$CDSHOME"'
+    )
+    r = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    assert r.returncode == 0, r.stderr
+    assert r.stdout == "/opt/my tools/$weird `x`"
+
+
+def test_remote_tool_probe_composes_fast_then_slow_hermetic_csh():
+    cmd = remote_tool_probe("which spectre", "setup; which spectre")
+    # Fused single round-trip: bash fast path OR csh fallback.
+    assert cmd.startswith("bash -l -c ")
+    assert "which spectre" in cmd
+    # F1: the csh fallback must be hermetic `csh -f -c` (~/.cshrc holds no
+    # tool/project variables in the Lmod use case; env comes only from the
+    # per-project module/cshrc config, same as real runs); stderr is merged.
+    assert "csh -f -c" in cmd
+    assert "2>&1" in cmd

--- a/tests/test_spectre_env_setup.py
+++ b/tests/test_spectre_env_setup.py
@@ -1,0 +1,89 @@
+"""Tests for the Cadence/Spectre csh environment prelude (Lmod + cshrc)."""
+
+from __future__ import annotations
+
+import pytest
+
+from virtuoso_bridge.spectre.runner import (
+    DEFAULT_LMOD_INIT_CSH,
+    cadence_env_setup_csh,
+)
+
+_ENV_VARS = (
+    "VB_LMOD_MODULES",
+    "VB_LMOD_INIT",
+    "VB_CADENCE_CSHRC",
+    "VB_MENTOR_CSHRC",
+    "VB_LMOD_MODULES_worker1",
+    "VB_CADENCE_CSHRC_worker1",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for var in _ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_empty_when_nothing_configured():
+    assert cadence_env_setup_csh() == ""
+
+
+def test_lmod_modules_use_default_init(monkeypatch):
+    monkeypatch.setenv("VB_LMOD_MODULES", "cadence/IC25.1 spectre/23.1")
+    out = cadence_env_setup_csh()
+    assert f"source {DEFAULT_LMOD_INIT_CSH}" in out
+    # Load via the Lmod backend ($LMOD_CMD), not the parse-time `module` alias.
+    assert "eval `$LMOD_CMD csh load cadence/IC25.1 spectre/23.1`" in out
+    assert "module load" not in out
+    # Guarded source so a wrong path is harmless when Lmod is already defined.
+    assert out.startswith(f"if ( -f {DEFAULT_LMOD_INIT_CSH} )")
+    assert "if ( $?LMOD_CMD )" in out
+
+
+def test_lmod_modules_accept_comma_separator(monkeypatch):
+    monkeypatch.setenv("VB_LMOD_MODULES", "cadence/IC25.1, spectre/23.1")
+    assert "csh load cadence/IC25.1 spectre/23.1`" in cadence_env_setup_csh()
+
+
+def test_lmod_init_override(monkeypatch):
+    monkeypatch.setenv("VB_LMOD_MODULES", "spectre/23.1")
+    monkeypatch.setenv("VB_LMOD_INIT", "/opt/lmod/init/csh")
+    out = cadence_env_setup_csh()
+    assert "/opt/lmod/init/csh" in out
+    assert DEFAULT_LMOD_INIT_CSH not in out
+
+
+def test_modules_then_cshrc_layering(monkeypatch):
+    monkeypatch.setenv("VB_LMOD_MODULES", "spectre/23.1")
+    monkeypatch.setenv("VB_CADENCE_CSHRC", "/home/x/cad.cshrc")
+    monkeypatch.setenv("VB_MENTOR_CSHRC", "/home/x/mentor.cshrc")
+    out = cadence_env_setup_csh()
+    # Modules load first, then cshrc files source (later layers win).
+    assert out.index("csh load") < out.index("source /home/x/cad.cshrc")
+    assert out.index("/home/x/cad.cshrc") < out.index("/home/x/mentor.cshrc")
+
+
+def test_cshrc_only_without_modules(monkeypatch):
+    monkeypatch.setenv("VB_CADENCE_CSHRC", "/home/x/cad.cshrc")
+    out = cadence_env_setup_csh()
+    assert out == "source /home/x/cad.cshrc"
+    assert "module load" not in out
+
+
+def test_profile_suffix_overrides_with_fallback(monkeypatch):
+    # Suffixed modules win; unsuffixed cshrc still falls through.
+    monkeypatch.setenv("VB_LMOD_MODULES", "spectre/base")
+    monkeypatch.setenv("VB_LMOD_MODULES_worker1", "spectre/24")
+    monkeypatch.setenv("VB_CADENCE_CSHRC", "/home/x/cad.cshrc")
+    out = cadence_env_setup_csh("_worker1")
+    assert "csh load spectre/24`" in out
+    assert "spectre/base" not in out
+    assert "source /home/x/cad.cshrc" in out
+
+
+def test_paths_with_spaces_are_quoted(monkeypatch):
+    monkeypatch.setenv("VB_LMOD_MODULES", "spectre/23.1")
+    monkeypatch.setenv("VB_LMOD_INIT", "/opt/my lmod/init/csh")
+    out = cadence_env_setup_csh()
+    assert "'/opt/my lmod/init/csh'" in out


### PR DESCRIPTION
## Summary

Applies fixes for all 10 verified findings from a multi-agent code review of PR #2 (Lmod/environment-module support), plus same-class stragglers found while fixing.

### Correctness

- **Hermetic `csh -f -c` everywhere** — the status probe, license check, real spectre run, skill-finder discovery, and tunnel python-detect previously mixed `csh -c` and `csh -f -c`, so the same config could produce contradictory diagnostics. All paths now use `csh -f -c`: in the Lmod use case `~/.cshrc` carries no tool/project variables, so the environment must come entirely from the per-project module/cshrc config (`VB_LMOD_MODULES{_PROFILE}`, `VB_CADENCE_CSHRC…`).
- **Loud module-load skip** — when `VB_LMOD_MODULES` is set but Lmod is not initialized (init script missing / non-default path), the prelude now emits `virtuoso-bridge: VB_LMOD_MODULES set but Lmod is not initialized (set VB_LMOD_INIT)` instead of silently no-oping into an unexplained NOT FOUND.
- **No more `shlex.split` crash** — a stray quote in the `VB_LMOD_MODULES` value no longer raises an uncaught `ValueError`; module lists are whitespace/comma split.
- **Safe env import** — csh env values imported into bash are now single-quoted, so values containing spaces, `$`, or backticks round-trip exactly instead of being word-split or re-expanded by `eval`.
- **skill-finder discovery** — handles csh `which` alias output (`virtuoso: aliased to /path/virtuoso …`), accepts only absolute paths, and the doc-finder walk stops when `dirname` stops progressing instead of spinning to the 15s timeout on degenerate input.
- **Version banner no longer dropped** — removed `| head -1` from all three `spectre -V` probes; the `@(#)$CDS:` line the parsers scan for is usually not the first output line.

### Cleanup

- New shared helpers in `spectre/runner.py`: `remote_tool_probe()` (fast-bash‖slow-csh probe composition, used by the spectre status probe and skill-finder) and `cadence_env_import_bash()` (quoted csh→bash env import, used by `check_license` and the tunnel python-detect) — replacing three hand-rolled near-copies.
- Two inline `VB_SPECTRE_BIN` suffix-fallback lookups in `cli.py` now call `_env_first()`; stale `_print_spectre_status` docstring refreshed.

## Testing

- Full suite: **110 passed** (was 87; 23 new tests).
- New tests include real `bash`/`sed` subprocess round-trips proving the quoting fix (a value like `/opt/my tools/$weird \`x\`` survives eval verbatim) and walk-loop termination on relative/`.` paths.
- Not covered locally: live csh behavior on the cluster (csh not installed here). A `virtuoso-bridge status` + `license` run against the remote host is the recommended end-to-end check before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)