### PR TITLE
[codex] Add schematic inherited connection helpers

### DIFF
--- a/src/virtuoso_bridge/virtuoso/schematic/__init__.py
+++ b/src/virtuoso_bridge/virtuoso/schematic/__init__.py
@@ -7,6 +7,7 @@ from typing import Any, TYPE_CHECKING
 from virtuoso_bridge.virtuoso.schematic.editor import SchematicEditor
 from virtuoso_bridge.virtuoso.schematic.ops import (
     schematic_check,
+    schematic_create_net_expression,
     schematic_create_inst,
     schematic_create_inst_by_master_name,
     schematic_create_pin,
@@ -16,6 +17,7 @@ from virtuoso_bridge.virtuoso.schematic.ops import (
     schematic_label_instance_term_offset,
     schematic_create_wire,
     schematic_create_wire_label,
+    schematic_set_netset_property,
 )
 
 if TYPE_CHECKING:
@@ -41,6 +43,8 @@ __all__ = [
     "schematic_create_inst_by_master_name",
     "schematic_create_wire",
     "schematic_create_wire_label",
+    "schematic_create_net_expression",
+    "schematic_set_netset_property",
     "schematic_label_instance_term",
     "schematic_label_instance_term_offset",
     "schematic_create_pin",

--- a/src/virtuoso_bridge/virtuoso/schematic/ops.py
+++ b/src/virtuoso_bridge/virtuoso/schematic/ops.py
@@ -97,6 +97,56 @@ def schematic_create_wire_label(
         f'"{escape_skill_string(style)}" {height:g} nil)'
     )
 
+def schematic_create_net_expression(
+    net_name: str,
+    net_expression: str,
+    x: float,
+    y: float,
+    *,
+    cv_expr: str = "cv",
+    justification: str = "lowerLeft",
+    rotation: str = "R0",
+    font_style: str = "stick",
+    height: float = 0.0625,
+) -> str:
+    """Build SKILL to attach an inherited-connection expression to a net wire.
+
+    Cadence inherited connections are modeled in two parts: the lower-level
+    schematic gets a net-expression label with ``schCreateNetExpression``, and
+    each upper-level instance can override that expression through a ``netSet``
+    property.
+    """
+    escaped_net = escape_skill_string(net_name)
+    return (
+        "let((rbWire rbLabel) "
+        f"rbWire = car(setof(x {cv_expr}~>shapes "
+        'x~>lpp && car(x~>lpp) == "wire" && '
+        f'x~>net && x~>net~>name == "{escaped_net}")) '
+        'unless(rbWire error("wire for net not found")) '
+        f"rbLabel = schCreateNetExpression({cv_expr} "
+        f'"{escape_skill_string(net_expression)}" rbWire {skill_point(x, y)} '
+        f'"{escape_skill_string(justification)}" '
+        f'"{escape_skill_string(rotation)}" '
+        f'"{escape_skill_string(font_style)}" {height:g}) '
+        "rbLabel)"
+    )
+
+def schematic_set_netset_property(
+    instance_name: str,
+    property_name: str,
+    net_name: str,
+    *,
+    cv_expr: str = "cv",
+) -> str:
+    """Build SKILL to set an instance inherited-connection override."""
+    return (
+        "let((rbInst) "
+        f'rbInst = car(setof(x {cv_expr}~>instances x~>name == "{escape_skill_string(instance_name)}")) '
+        'unless(rbInst error("instance not found")) '
+        f'dbReplaceProp(rbInst "{escape_skill_string(property_name)}" '
+        f'"netSet" "{escape_skill_string(net_name)}"))'
+    )
+
 def _schematic_term_center_expr(instance_name: str, term_name: str, *, cv_expr: str = "cv") -> str:
     return (
         "let((rbInst rbTerm rbPin rbFig rbBBox rbCtr) "

--- a/tests/test_schematic_ops.py
+++ b/tests/test_schematic_ops.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from virtuoso_bridge.virtuoso.schematic.ops import (
+    schematic_create_net_expression,
+    schematic_set_netset_property,
+)
+
+
+def test_schematic_create_net_expression_attaches_expression_to_net_wire() -> None:
+    skill = schematic_create_net_expression(
+        "VDD",
+        "[@vdd:%:vdd!]",
+        1.25,
+        -0.5,
+        justification="centerLeft",
+        rotation="R90",
+        font_style="stick",
+        height=0.0625,
+    )
+
+    assert 'x~>net && x~>net~>name == "VDD"' in skill
+    assert 'unless(rbWire error("wire for net not found"))' in skill
+    assert (
+        'schCreateNetExpression(cv "[@vdd:%:vdd!]" rbWire '
+        '\'(1.250 -0.500) "centerLeft" "R90" "stick" 0.0625)'
+    ) in skill
+
+
+def test_schematic_create_net_expression_accepts_custom_cellview_expr() -> None:
+    skill = schematic_create_net_expression(
+        "VSS",
+        "[@vss:%:gnd!]",
+        0,
+        0,
+        cv_expr="targetCv",
+    )
+
+    assert "targetCv~>shapes" in skill
+    assert 'schCreateNetExpression(targetCv "[@vss:%:gnd!]" rbWire' in skill
+
+
+def test_schematic_set_netset_property_writes_inherited_override() -> None:
+    skill = schematic_set_netset_property("XI0", "vdd", "VDD")
+
+    assert 'x~>name == "XI0"' in skill
+    assert 'unless(rbInst error("instance not found"))' in skill
+    assert 'dbReplaceProp(rbInst "vdd" "netSet" "VDD")' in skill
+
+
+def test_schematic_set_netset_property_escapes_string_literals() -> None:
+    skill = schematic_set_netset_property('XI"0', "bulk\\net", 'VDD"TOP')
+
+    assert 'x~>name == "XI\\"0"' in skill
+    assert 'dbReplaceProp(rbInst "bulk\\\\net" "netSet" "VDD\\"TOP")' in skill


### PR DESCRIPTION
## Summary
- Add schematic SKILL builders for inherited connection labels via `schCreateNetExpression`.
- Add a `netSet` property helper for upper-level instance overrides.
- Export the helpers from `virtuoso_bridge.virtuoso.schematic`.
- Add unit tests for generated SKILL snippets and string escaping.

## Validation
- `python -m pytest -q`