### PR TITLE
Parse single-point Maestro detail CSV

### DIFF
--- a/src/virtuoso_bridge/virtuoso/maestro/reader/runs.py
+++ b/src/virtuoso_bridge/virtuoso/maestro/reader/runs.py
@@ -226,12 +226,17 @@ def _parse_detail_csv(text: str, *, history: str) -> dict:
     points: list[dict] = []
     current: dict | None = None
     tests_seen: set[str] = set()
+    no_point_detail = False
 
     reader = csv.reader(text.splitlines())
     for row in reader:
         if not row or not any(c.strip() for c in row):
             continue
         first = (row[0] or "").strip()
+        header = [c.strip() for c in row[:6]]
+        if header == ["Test", "Output", "Nominal", "Spec", "Weight", "Pass/Fail"]:
+            no_point_detail = True
+            continue
         if first.startswith("Parameters:"):
             # Start a new point.  Parse "Parameters: K1=V1, K2=V2, ..."
             params_text = first[len("Parameters:"):].strip()
@@ -246,7 +251,31 @@ def _parse_detail_csv(text: str, *, history: str) -> dict:
             points.append(current)
             continue
         # Skip header / non-data rows
-        if first in ("", "Point") or not first.isdigit():
+        if first in ("", "Point", "Test"):
+            if first == "Point":
+                no_point_detail = False
+            continue
+        if not first.isdigit():
+            if not no_point_detail:
+                continue
+            # Single-point runs in some Cadence versions omit the Point
+            # column and export rows as:
+            #   Test,Output,Nominal,Spec,Weight,Pass/Fail
+            cols = row + [""] * (6 - len(row))
+            test_n, name, value, spec, weight, pass_fail = cols[:6]
+            if not name.strip():
+                continue
+            if current is None:
+                current = {"point": 1, "parameters": {}, "outputs": {}}
+                points.append(current)
+            if test_n:
+                tests_seen.add(test_n.strip())
+            current["outputs"][name.strip()] = {
+                "value":     value.strip(),
+                "spec":      spec.strip(),
+                "weight":    weight.strip(),
+                "pass_fail": pass_fail.strip(),
+            }
             continue
         # Data row: point, test, output, nominal, spec, weight, pass_fail
         if current is None:

--- a/tests/test_maestro_read_results.py
+++ b/tests/test_maestro_read_results.py
@@ -42,6 +42,16 @@ SAMPLE_CSV = (
     "2,inv_test,Delay_ps,9.8,< 15p,1,passed\n"
 )
 
+SINGLE_POINT_CSV = (
+    ",Parameter,Nominal,,,\n"
+    "Title,Detail Results,,,,\n"
+    "\n"
+    "Test,Output,Nominal,Spec,Weight,Pass/Fail\n"
+    "TRAN,IN,,,,\n"
+    "TRAN,OUT,,,,\n"
+    "TRAN,out_max,822.7e-3,< 1,1,passed\n"
+)
+
 
 def test_parse_detail_csv_multi_point():
     out = _parse_detail_csv(SAMPLE_CSV, history="Interactive.7")
@@ -62,6 +72,22 @@ def test_parse_detail_csv_empty_input():
     assert out["points"] == []
     assert out["outputs"] == []
     assert out["tests"] == []
+
+
+def test_parse_detail_csv_single_point_without_point_column():
+    out = _parse_detail_csv(SINGLE_POINT_CSV, history="Interactive.0")
+    assert out["history"] == "Interactive.0"
+    assert out["tests"] == ["TRAN"]
+    assert len(out["points"]) == 1
+    assert out["points"][0]["parameters"] == {}
+    assert "Detail Results" not in out["points"][0]["outputs"]
+    assert out["points"][0]["outputs"]["out_max"] == {
+        "value": "822.7e-3",
+        "spec": "< 1",
+        "weight": "1",
+        "pass_fail": "passed",
+    }
+    assert len(out["outputs"]) == 3
 
 
 class _FakeSkillResult:


### PR DESCRIPTION
## Summary
- Parse Maestro/ADE Detail CSV exports that omit the Point column for single-point runs
- Preserve existing multi-point/sweep CSV parsing behavior
- Skip non-data metadata rows unless the no-Point detail header has been seen

## Root Cause
Some Cadence exports use a single-point Detail CSV shape with the header "Test,Output,Nominal,Spec,Weight,Pass/Fail" and rows such as "TRAN,out_max,...". The existing parser only accepted rows whose first column was numeric, so these output rows were skipped and read_results() lost the exported output values.

This change gates the no-Point parsing path on the explicit detail header, so metadata rows like "Title,Detail Results" are still ignored instead of being treated as outputs.

## Validation
- python -m pytest tests/test_maestro_read_results.py -q
- python -m pytest -q