### PR TITLE
[codex] Fix X11 dismiss-dialog in local mode

### DIFF
--- a/src/virtuoso_bridge/cli.py
+++ b/src/virtuoso_bridge/cli.py
@@ -729,9 +729,17 @@ def cli_license() -> int:
 
 # -- main -------------------------------------------------------------------
 
-def _make_ssh_runner() -> tuple["SSHRunner", str]:
-    """Create an SSHRunner from .env config (for X11 commands)."""
+def _make_ssh_runner() -> tuple["SSHRunner | None", str]:
+    """Create an SSHRunner from .env config (for X11 commands).
+
+    In local mode (VB_REMOTE_HOST is this machine) return ``(None, user)`` so
+    the X11 helper runs locally via subprocess instead of trying to SSH to
+    localhost (which fails without passwordless key auth). Mirrors the local
+    detection used by the daemon/tunnel path.
+    """
     from virtuoso_bridge.transport.ssh import SSHRunner
+    from virtuoso_bridge.transport.tunnel import _is_localhost
+
     profile = _get_cli_profile()
     suffix = f"_{profile}" if profile else ""
     remote_host = os.getenv(f"VB_REMOTE_HOST{suffix}", "").strip()
@@ -740,6 +748,8 @@ def _make_ssh_runner() -> tuple["SSHRunner", str]:
     jump_user = os.getenv(f"VB_JUMP_USER{suffix}", remote_user).strip() or None
     if not remote_host:
         raise SystemExit("Error: VB_REMOTE_HOST not set")
+    if _is_localhost(remote_host):
+        return None, remote_user
     return SSHRunner(host=remote_host, user=remote_user,
                      jump_host=jump_host, jump_user=jump_user), remote_user
 

--- a/src/virtuoso_bridge/resources/x11_dismiss_dialog.py
+++ b/src/virtuoso_bridge/resources/x11_dismiss_dialog.py
@@ -43,7 +43,7 @@ def find_x11_env(user=None):
         pids = subprocess.check_output(
             ["pgrep", "-u", user or os.environ.get("USER", ""), "-x", "virtuoso"],
             stderr=subprocess.PIPE
-        ).strip().splitlines()
+        ).decode().split()
         for pid in pids:
             pid = pid.strip()
             if not pid:
@@ -389,6 +389,20 @@ def dismiss_window(display, win_id_str, title="", x=0, y=0, w=0, h=0, action=Non
     xlib = ctypes.cdll.LoadLibrary(xlib_path)
     xtst = ctypes.cdll.LoadLibrary(xtst_path)
 
+    # Declare 64-bit-safe signatures. Without argtypes/restype, ctypes defaults
+    # to c_int (32-bit) and truncates Display*/Window pointers on x86_64,
+    # segfaulting inside libX11 (e.g. XRaiseWindow with a truncated display).
+    xlib.XOpenDisplay.argtypes = [ctypes.c_char_p]
+    xlib.XOpenDisplay.restype = ctypes.c_void_p
+    xlib.XCloseDisplay.argtypes = [ctypes.c_void_p]
+    xlib.XFlush.argtypes = [ctypes.c_void_p]
+    xlib.XRaiseWindow.argtypes = [ctypes.c_void_p, ctypes.c_ulong]
+    xlib.XSetInputFocus.argtypes = [ctypes.c_void_p, ctypes.c_ulong, ctypes.c_int, ctypes.c_ulong]
+    xlib.XKeysymToKeycode.argtypes = [ctypes.c_void_p, ctypes.c_ulong]
+    xlib.XKeysymToKeycode.restype = ctypes.c_uint
+    xtst.XTestFakeKeyEvent.argtypes = [ctypes.c_void_p, ctypes.c_uint, ctypes.c_int, ctypes.c_ulong]
+    xtst.XTestFakeKeyEvent.restype = ctypes.c_int
+
     dpy = xlib.XOpenDisplay(None)
     if not dpy:
         return {"error": "cannot open display %s" % display}
@@ -561,6 +575,12 @@ def main():
         xauth = x11_env.get("XAUTHORITY")
         if isinstance(xauth, string_types) and xauth:
             os.environ["XAUTHORITY"] = xauth
+
+    # Export DISPLAY so ctypes XOpenDisplay(None) and xwininfo subprocesses
+    # (which read it from the environment) connect to the right X server.
+    # Without this, auto-detected DISPLAY stays a Python variable and
+    # XOpenDisplay(None) returns NULL -> segfault.
+    os.environ["DISPLAY"] = display
 
     if dismiss_target:
         result = dismiss_window(display, dismiss_target, action=action)

--- a/tests/test_x11_window_discovery.py
+++ b/tests/test_x11_window_discovery.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import io
 import importlib.util
 from pathlib import Path
 from types import SimpleNamespace
 
+from virtuoso_bridge import cli
 from virtuoso_bridge.virtuoso import x11
 
 
@@ -95,6 +97,32 @@ xwininfo: Window id: 0xabc000 "Virtuoso Main"
     assert [d["window_id"] for d in dialogs] == ["0x4203583"]
 
 
+def test_find_x11_env_decodes_pgrep_pid_bytes(monkeypatch) -> None:
+    helper = _load_helper_module()
+    opened_paths = []
+
+    def fake_check_output(cmd, stderr=None):
+        assert cmd == ["pgrep", "-u", "designer", "-x", "virtuoso"]
+        return b"123\n"
+
+    def fake_open(path, mode="r"):
+        opened_paths.append(path)
+        if path == "/proc/123/cmdline":
+            return io.BytesIO(b"virtuoso\x00")
+        if path == "/proc/123/environ":
+            return io.BytesIO(b"DISPLAY=:7\x00XAUTHORITY=/tmp/xauth\x00")
+        raise AssertionError(f"unexpected path: {path!r}")
+
+    monkeypatch.setattr(helper.subprocess, "check_output", fake_check_output)
+    monkeypatch.setattr(helper, "open", fake_open, raising=False)
+
+    env = helper.find_x11_env(user="designer")
+
+    assert env == {"DISPLAY": ":7", "XAUTHORITY": "/tmp/xauth"}
+    assert opened_paths == ["/proc/123/cmdline", "/proc/123/environ"]
+    assert not any("b'123'" in path for path in opened_paths)
+
+
 class _Runner:
     def __init__(self, stdout_by_marker: dict[str, str]) -> None:
         self.commands: list[str] = []
@@ -133,3 +161,42 @@ def test_x11_wrapper_lists_and_dismisses_explicit_window(monkeypatch) -> None:
     assert result == [{"dismissed": "0x4203583", "action": "enter"}]
     assert any("--list-windows --json :".split()[0] in cmd for cmd in runner.commands)
     assert any("--dismiss-window 0x4203583 --action enter" in cmd for cmd in runner.commands)
+
+
+def test_make_ssh_runner_skips_ssh_for_localhost(monkeypatch) -> None:
+    def fail_if_instantiated(*args, **kwargs):
+        raise AssertionError("local X11 commands should not instantiate SSHRunner")
+
+    monkeypatch.setattr(cli, "_CLI_PROFILE", [None])
+    monkeypatch.setenv("VB_REMOTE_HOST", "localhost")
+    monkeypatch.setenv("VB_REMOTE_USER", "designer")
+    monkeypatch.setattr("virtuoso_bridge.transport.ssh.SSHRunner", fail_if_instantiated)
+
+    runner, user = cli._make_ssh_runner()
+
+    assert runner is None
+    assert user == "designer"
+
+
+def test_helper_exports_auto_detected_display(monkeypatch, capsys) -> None:
+    helper = _load_helper_module()
+    calls = []
+
+    def fake_dismiss_window(display, win_id, *args, **kwargs):
+        calls.append((display, win_id, helper.os.environ.get("DISPLAY")))
+        return {"dismissed": win_id}
+
+    monkeypatch.delenv("DISPLAY", raising=False)
+    monkeypatch.setattr(helper, "find_x11_env", lambda: {"DISPLAY": ":7", "XAUTHORITY": ""})
+    monkeypatch.setattr(helper, "dismiss_window", fake_dismiss_window)
+    monkeypatch.setattr(helper.sys, "argv", ["x11_dismiss_dialog.py", "--dismiss-window", "0xabc"])
+
+    try:
+        helper.main()
+    except SystemExit as exc:
+        assert exc.code == 0
+
+    assert calls == [(":7", "0xabc", ":7")]
+    assert helper.os.environ["DISPLAY"] == ":7"
+    out = capsys.readouterr().out
+    assert '"dismissed": "0xabc"' in out


### PR DESCRIPTION
## Summary
- run X11 dismiss/list helpers locally when VB_REMOTE_HOST points at localhost instead of opening an SSH session to localhost
- fix helper-side local execution by decoding pgrep PIDs, exporting auto-detected DISPLAY, and declaring 64-bit-safe X11/XTest ctypes signatures
- add regression tests for the local runner path and DISPLAY export behavior

## Why
In local mode, Virtuoso GUI helpers should use the local filesystem and local X11 session. Creating an SSH runner for localhost can fail on machines without passwordless localhost SSH, and the helper also needs DISPLAY in the environment for XOpenDisplay(None) and xwininfo subprocesses.

## Validation
- python -m pytest tests/test_x11_window_discovery.py tests/test_x11_paths.py -q
- python -m pytest -q
- python2 -m py_compile src/virtuoso_bridge/resources/x11_dismiss_dialog.py
- python3 -m py_compile src/virtuoso_bridge/resources/x11_dismiss_dialog.py