### PR TITLE
[codex] Add schematic net stub helper

### DIFF
--- a/src/virtuoso_bridge/virtuoso/schematic/__init__.py
+++ b/src/virtuoso_bridge/virtuoso/schematic/__init__.py
@@ -13,6 +13,7 @@ from virtuoso_bridge.virtuoso.schematic.ops import (
     schematic_create_pin,
     schematic_create_pin_at_instance_term,
     schematic_create_wire_between_instance_terms,
+    schematic_create_net_stub,
     schematic_label_instance_term,
     schematic_label_instance_term_offset,
     schematic_create_wire,
@@ -50,5 +51,6 @@ __all__ = [
     "schematic_create_pin",
     "schematic_create_pin_at_instance_term",
     "schematic_create_wire_between_instance_terms",
+    "schematic_create_net_stub",
     "schematic_check",
 ]

--- a/src/virtuoso_bridge/virtuoso/schematic/ops.py
+++ b/src/virtuoso_bridge/virtuoso/schematic/ops.py
@@ -97,6 +97,56 @@ def schematic_create_wire_label(
         f'"{escape_skill_string(style)}" {height:g} nil)'
     )
 
+
+_NET_STUB_DIR_OFFSETS = {
+    "up": (0.0, 1.0),
+    "down": (0.0, -1.0),
+    "left": (-1.0, 0.0),
+    "right": (1.0, 0.0),
+}
+
+
+def schematic_create_net_stub(
+    net_name: str,
+    x: float,
+    y: float,
+    *,
+    direction: str = "right",
+    length: float = 0.5,
+    cv_expr: str = "cv",
+    route_style: str = "route",
+    route_mode: str = "full",
+    justification: str = "centerCenter",
+    rotation: str | None = None,
+    style: str = "stick",
+    height: float = 0.0625,
+) -> str:
+    """Build SKILL to draw a short named net stub.
+
+    This is the generic version of the common schematic pattern: draw a small
+    wire segment and attach a wire label to it so matching labels connect
+    electrically without long crossing wires.
+    """
+    if direction not in _NET_STUB_DIR_OFFSETS:
+        raise ValueError(
+            f"direction must be one of {sorted(_NET_STUB_DIR_OFFSETS)}, got {direction!r}"
+        )
+    if length <= 0:
+        raise ValueError("length must be positive")
+    dx, dy = _NET_STUB_DIR_OFFSETS[direction]
+    end_x = x + dx * length
+    end_y = y + dy * length
+    label_x = (x + end_x) / 2.0
+    label_y = (y + end_y) / 2.0
+    label_rotation = rotation or ("R90" if direction in {"up", "down"} else "R0")
+    return (
+        "progn("
+        f"{schematic_create_wire([(x, y), (end_x, end_y)], cv_expr=cv_expr, route_style=route_style, route_mode=route_mode)} "
+        f"{schematic_create_wire_label(label_x, label_y, net_name, justification, label_rotation, cv_expr=cv_expr, style=style, height=height)}"
+        ")"
+    )
+
+
 def schematic_create_net_expression(
     net_name: str,
     net_expression: str,

--- a/tests/test_schematic_ops.py
+++ b/tests/test_schematic_ops.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import pytest
+
 from virtuoso_bridge.virtuoso.schematic.ops import (
+    schematic_create_net_stub,
     schematic_create_net_expression,
     schematic_set_netset_property,
 )
@@ -52,3 +55,34 @@ def test_schematic_set_netset_property_escapes_string_literals() -> None:
 
     assert 'x~>name == "XI\\"0"' in skill
     assert 'dbReplaceProp(rbInst "bulk\\\\net" "netSet" "VDD\\"TOP")' in skill
+
+
+def test_schematic_create_net_stub_draws_short_wire_and_label() -> None:
+    skill = schematic_create_net_stub("IN", 0, 0, direction="right", length=0.5)
+
+    assert 'schCreateWire(cv "route" "full" \'((0.000 0.000) (0.500 0.000)) 0 0 0 nil nil)' in skill
+    assert 'schCreateWireLabel(cv nil \'(0.250 0.000) "IN" "centerCenter" "R0" "stick" 0.0625 nil)' in skill
+
+
+def test_schematic_create_net_stub_auto_rotates_vertical_labels() -> None:
+    skill = schematic_create_net_stub("VDD", 1, 2, direction="up", length=0.75)
+
+    assert "'((1.000 2.000) (1.000 2.750))" in skill
+    assert '\'(1.000 2.375) "VDD" "centerCenter" "R90"' in skill
+
+
+def test_schematic_create_net_stub_escapes_label_text_and_overrides_rotation() -> None:
+    skill = schematic_create_net_stub('A"NET\\1', 0, 0, direction="up", rotation="R0")
+
+    assert '"A\\"NET\\\\1"' in skill
+    assert '\'(0.000 0.250) "A\\"NET\\\\1" "centerCenter" "R0"' in skill
+
+
+def test_schematic_create_net_stub_rejects_non_positive_length() -> None:
+    with pytest.raises(ValueError, match="length must be positive"):
+        schematic_create_net_stub("IN", 0, 0, length=0)
+
+
+def test_schematic_create_net_stub_rejects_unknown_direction() -> None:
+    with pytest.raises(ValueError, match="direction must be one of"):
+        schematic_create_net_stub("IN", 0, 0, direction="diagonal")


### PR DESCRIPTION
## Summary
- add `schematic_create_net_stub()` for generating a short labeled schematic wire stub
- export the helper from `virtuoso_bridge.virtuoso.schematic`
- cover rightward stubs, vertical label rotation, and invalid directions with unit tests

## Why
Named net stubs are a common schematic-editing pattern for connecting nets without drawing long crossing wires. This helper composes the existing wire and wire-label builders into one reusable operation while preserving the existing SKILL formatting path.

## Validation
- python -m pytest tests/test_schematic_ops.py -q
- python -m pytest -q