### PR TITLE
Add Maestro waveform viewer helper

### DIFF
--- a/src/virtuoso_bridge/virtuoso/maestro/__init__.py
+++ b/src/virtuoso_bridge/virtuoso/maestro/__init__.py
@@ -57,6 +57,10 @@ from virtuoso_bridge.virtuoso.maestro.writer import (
     # GUI
     open_maestro_gui_with_history,
 )
+from virtuoso_bridge.virtuoso.maestro.waveform_viewer import (
+    maestro_open_waveform_viewer_skill,
+    open_waveform_viewer,
+)
 
 __all__ = [
     # session
@@ -114,4 +118,6 @@ __all__ = [
     "save_setup",
     # write - GUI
     "open_maestro_gui_with_history",
+    "maestro_open_waveform_viewer_skill",
+    "open_waveform_viewer",
 ]

--- a/src/virtuoso_bridge/virtuoso/maestro/__init__.py
+++ b/src/virtuoso_bridge/virtuoso/maestro/__init__.py
@@ -58,6 +58,8 @@ from virtuoso_bridge.virtuoso.maestro.writer import (
     open_maestro_gui_with_history,
 )
 from virtuoso_bridge.virtuoso.maestro.waveform_viewer import (
+    close_waveform_viewer,
+    maestro_close_waveform_viewer_skill,
     maestro_open_waveform_viewer_skill,
     open_waveform_viewer,
 )
@@ -118,6 +120,8 @@ __all__ = [
     "save_setup",
     # write - GUI
     "open_maestro_gui_with_history",
+    "maestro_close_waveform_viewer_skill",
     "maestro_open_waveform_viewer_skill",
+    "close_waveform_viewer",
     "open_waveform_viewer",
 ]

--- a/src/virtuoso_bridge/virtuoso/maestro/waveform_viewer.py
+++ b/src/virtuoso_bridge/virtuoso/maestro/waveform_viewer.py
@@ -1,0 +1,135 @@
+"""Open ViVA/AWV waveform windows for Maestro histories."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterable
+
+from virtuoso_bridge.virtuoso.ops import escape_skill_string
+
+
+def _skill_string_list(values: Iterable[str]) -> str:
+    return "list(" + " ".join(f'"{escape_skill_string(value)}"' for value in values) + ")"
+
+
+def maestro_open_waveform_viewer_skill(
+    lib: str,
+    cell: str,
+    history: str,
+    *,
+    signals: list[str] | tuple[str, ...],
+    view: str = "maestro",
+    application: str = "Assembler",
+    test: str | None = None,
+    result: str = "tran",
+    results_dir: str | Path | None = None,
+) -> str:
+    """Build SKILL to open a ViVA/AWV plot window for explicit signals.
+
+    TODO: measurement waveform setup is intentionally not implemented here.
+    TODO: template plot restore/apply support is intentionally not implemented here.
+    """
+    if not signals:
+        raise ValueError("signals must not be empty")
+
+    escaped_lib = escape_skill_string(lib)
+    escaped_cell = escape_skill_string(cell)
+    escaped_history = escape_skill_string(history)
+    escaped_view = escape_skill_string(view)
+    escaped_application = escape_skill_string(application)
+    escaped_test = escape_skill_string(test or "")
+    escaped_result = escape_skill_string(result)
+    signal_expr = _skill_string_list(signals)
+    if results_dir is None:
+        results_dir_expr = "nil"
+        raw_open_expr = "nil"
+    else:
+        escaped_results_dir = escape_skill_string(str(results_dir))
+        results_dir_expr = f'"{escaped_results_dir}"'
+        raw_open_expr = f'car(errset(openResults("{escaped_results_dir}") nil))'
+
+    signal_blocks: list[str] = []
+    for signal in signals:
+        escaped_signal = escape_skill_string(signal)
+        output_value_expr = (
+            f'errset(maeGetOutputValue("{escaped_signal}" "{escaped_test}") nil)'
+            if test
+            else f'errset(maeGetOutputValue("{escaped_signal}" vbTestName) nil)'
+        )
+        signal_blocks.append(
+            "vbWaveform = nil "
+            "vbWaveResult = if(vbRawResultsOpen "
+            f'then errset(v("{escaped_signal}" ?result "{escaped_result}" ?resultsDir vbResultsDir) nil) '
+            f'else errset(v("{escaped_signal}" ?result "{escaped_result}") nil)) '
+            "vbWaveform = if(vbWaveResult then car(vbWaveResult) else nil) "
+            "unless(vbWaveform "
+            "when(vbTestName == \"\" "
+            "vbTestNamesResult = errset(maeGetResultTests() nil) "
+            "vbTestNames = if(vbTestNamesResult then car(vbTestNamesResult) else nil) "
+            "when(vbTestNames vbTestName = car(vbTestNames))) "
+            "when(vbTestName != \"\" "
+            f"vbOutputResult = {output_value_expr} "
+            "vbWaveform = if(vbOutputResult then car(vbOutputResult) else nil))) "
+            f'unless(vbWaveform error("missing waveform: {escaped_signal}")) '
+            "vbWaveforms = append(vbWaveforms list(vbWaveform)) "
+        )
+
+    return (
+        "let((vbSession vbResultsOpenResult vbResultsOpen vbResultsDir vbRawResultsOpen "
+        "vbWaveforms vbWaveform vbWaveResult vbTestName vbTestNamesResult vbTestNames "
+        "vbOutputResult vbWindowResult vbWindowId vbPlotResult) "
+        "unless(and(isCallable('maeOpenSetup) isCallable('maeOpenResults) "
+        "isCallable('maeGetResultTests) isCallable('maeGetOutputValue) "
+        "isCallable('maeCloseResults) isCallable('maeCloseSession) "
+        "isCallable('openResults) isCallable('awvCreatePlotWindow) "
+        "isCallable('awvPlotWaveform) isCallable('v)) "
+        'error("waveform viewer API unavailable")) '
+        f'vbSession = maeOpenSetup("{escaped_lib}" "{escaped_cell}" "{escaped_view}" '
+        f'?application "{escaped_application}" ?mode "r") '
+        'unless(vbSession error("open maestro failed")) '
+        f'vbResultsOpenResult = errset(maeOpenResults(?session vbSession ?history "{escaped_history}") nil) '
+        "vbResultsOpen = if(vbResultsOpenResult then car(vbResultsOpenResult) else nil) "
+        'unless(vbResultsOpen error("open results failed")) '
+        f"vbResultsDir = {results_dir_expr} "
+        f"vbRawResultsOpen = {raw_open_expr} "
+        f'vbTestName = "{escaped_test}" '
+        "vbWaveforms = nil "
+        f"{''.join(signal_blocks)}"
+        "vbWindowResult = errset(awvCreatePlotWindow() nil) "
+        "vbWindowId = if(vbWindowResult then car(vbWindowResult) else nil) "
+        'unless(vbWindowId error("create waveform window failed")) '
+        f"vbPlotResult = errset(awvPlotWaveform(vbWindowId vbWaveforms ?expr {signal_expr}) nil) "
+        'unless(vbPlotResult && car(vbPlotResult) error("plot waveform failed")) '
+        "errset(maeCloseResults() nil) "
+        "errset(maeCloseSession(?session vbSession ?forceClose t) nil) "
+        f'list("opened" "{escaped_lib}" "{escaped_cell}" "{escaped_view}" "{escaped_history}" vbWindowId))'
+    )
+
+
+def open_waveform_viewer(
+    client: Any,
+    lib: str,
+    cell: str,
+    history: str,
+    *,
+    signals: list[str] | tuple[str, ...],
+    view: str = "maestro",
+    application: str = "Assembler",
+    test: str | None = None,
+    result: str = "tran",
+    results_dir: str | Path | None = None,
+    timeout: int = 60,
+) -> Any:
+    """Open a ViVA/AWV plot window by executing generated SKILL."""
+    skill = maestro_open_waveform_viewer_skill(
+        lib,
+        cell,
+        history,
+        signals=signals,
+        view=view,
+        application=application,
+        test=test,
+        result=result,
+        results_dir=results_dir,
+    )
+    return client.execute_skill(skill, timeout=timeout)

--- a/src/virtuoso_bridge/virtuoso/maestro/waveform_viewer.py
+++ b/src/virtuoso_bridge/virtuoso/maestro/waveform_viewer.py
@@ -49,6 +49,13 @@ def maestro_open_waveform_viewer_skill(
     The Maestro results session is intentionally left open because AWV plot
     windows keep references to the opened result database.
 
+    Args:
+        test: Maestro test name used for maeGetOutputValue fallback.
+        result: Spectre result name, e.g. "tran".
+        results_dir: Optional raw PSF directory. When provided, openResults
+            must succeed; otherwise the generated SKILL errors instead of
+            falling back to another active results context.
+
     TODO: measurement waveform setup is intentionally not implemented here.
     TODO: template plot restore/apply support is intentionally not implemented here.
     """
@@ -117,6 +124,7 @@ def maestro_open_waveform_viewer_skill(
         'unless(vbResultsOpen error("open results failed")) '
         f"vbResultsDir = {results_dir_expr} "
         f"vbRawResultsOpen = {raw_open_expr} "
+        'when(vbResultsDir && !vbRawResultsOpen error("open raw results failed")) '
         f'vbTestName = "{escaped_test}" '
         "vbWaveforms = nil "
         f"{''.join(signal_blocks)}"
@@ -187,7 +195,13 @@ def open_waveform_viewer(
     results_dir: str | Path | None = None,
     timeout: int = 60,
 ) -> Any:
-    """Open a ViVA/AWV plot window by executing generated SKILL."""
+    """Open a ViVA/AWV plot window by executing generated SKILL.
+
+    Returns the raw VirtuosoResult from client.execute_skill(). The retained
+    Maestro session and waveform window handles are encoded in result.output
+    as a SKILL list and should be passed to close_waveform_viewer() by callers
+    that need deterministic cleanup.
+    """
     skill = maestro_open_waveform_viewer_skill(
         lib,
         cell,

--- a/src/virtuoso_bridge/virtuoso/maestro/waveform_viewer.py
+++ b/src/virtuoso_bridge/virtuoso/maestro/waveform_viewer.py
@@ -100,11 +100,14 @@ def maestro_open_waveform_viewer_skill(
     return (
         "let((vbSession vbResultsOpenResult vbResultsOpen vbResultsDir vbRawResultsOpen "
         "vbWaveforms vbWaveform vbWaveResult vbTestName vbTestNamesResult vbTestNames "
-        "vbOutputResult vbWindowResult vbWindowId vbPlotResult) "
+        "vbOutputResult vbWindowResult vbWindowId vbPlotResult vbOpenResult vbOpenOk) "
+        "vbOpenOk = nil "
+        "vbOpenResult = errset(progn("
         "unless(and(isCallable('maeOpenSetup) isCallable('maeOpenResults) "
         "isCallable('maeGetResultTests) isCallable('maeGetOutputValue) "
         "isCallable('openResults) isCallable('awvCreatePlotWindow) "
-        "isCallable('awvPlotWaveform) isCallable('v)) "
+        "isCallable('awvPlotWaveform) isCallable('v) "
+        "isCallable('hiCloseWindow) isCallable('maeCloseSession)) "
         'error("waveform viewer API unavailable")) '
         f'vbSession = maeOpenSetup("{escaped_lib}" "{escaped_cell}" "{escaped_view}" '
         f'?application "{escaped_application}" ?mode "r") '
@@ -122,7 +125,13 @@ def maestro_open_waveform_viewer_skill(
         'unless(vbWindowId error("create waveform window failed")) '
         f"vbPlotResult = errset(awvPlotWaveform(vbWindowId vbWaveforms ?expr {signal_expr}) nil) "
         'unless(vbPlotResult && car(vbPlotResult) error("plot waveform failed")) '
-        f'list("opened" "{escaped_lib}" "{escaped_cell}" "{escaped_view}" "{escaped_history}" vbSession vbWindowId))'
+        "vbOpenOk = t "
+        f'list("opened" "{escaped_lib}" "{escaped_cell}" "{escaped_view}" "{escaped_history}" vbSession vbWindowId)) nil) '
+        "unless(vbOpenOk "
+        "when(vbWindowId errset(hiCloseWindow(vbWindowId) nil)) "
+        "when(vbSession errset(maeCloseSession(?session vbSession ?forceClose t) nil))) "
+        'unless(vbOpenResult error("open waveform viewer failed")) '
+        "car(vbOpenResult))"
     )
 
 
@@ -134,15 +143,32 @@ def maestro_close_waveform_viewer_skill(
     """Build SKILL to close a waveform window and its retained Maestro session."""
     if window is None and session is None:
         raise ValueError("window or session must be provided")
+    if session is not None:
+        session = session.strip()
+        if not session:
+            raise ValueError("session must not be blank")
 
     window_expr = _skill_window_ref(window) if window is not None else "nil"
     session_expr = f'"{escape_skill_string(session)}"' if session else "nil"
     return (
-        "let((vbWindow vbSession) "
+        "let((vbWindow vbSession vbWindowCloseResult vbSessionCloseResult "
+        "vbWindowsResult vbWindowsAfter vbSessionsResult vbSessionsAfter) "
         f"vbWindow = {window_expr} "
         f"vbSession = {session_expr} "
-        "when(vbWindow errset(hiCloseWindow(vbWindow) nil)) "
-        "when(vbSession errset(maeCloseSession(?session vbSession ?forceClose t) nil)) "
+        "when(vbWindow "
+        "vbWindowCloseResult = errset(hiCloseWindow(vbWindow) nil) "
+        'unless(vbWindowCloseResult error("close waveform window failed")) '
+        "vbWindowsResult = errset(hiGetWindowList() nil) "
+        'unless(vbWindowsResult error("check waveform window close failed")) '
+        "vbWindowsAfter = car(vbWindowsResult) "
+        'when(member(vbWindow vbWindowsAfter) error("close waveform window failed"))) '
+        "when(vbSession "
+        "vbSessionCloseResult = errset(maeCloseSession(?session vbSession ?forceClose t) nil) "
+        'unless(vbSessionCloseResult error("close waveform session failed")) '
+        "vbSessionsResult = errset(maeGetSessions() nil) "
+        'unless(vbSessionsResult error("check waveform session close failed")) '
+        "vbSessionsAfter = car(vbSessionsResult) "
+        'when(member(vbSession vbSessionsAfter) error("close waveform session failed"))) '
         'list("closed" vbSession vbWindow))'
     )
 

--- a/src/virtuoso_bridge/virtuoso/maestro/waveform_viewer.py
+++ b/src/virtuoso_bridge/virtuoso/maestro/waveform_viewer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -10,6 +11,25 @@ from virtuoso_bridge.virtuoso.ops import escape_skill_string
 
 def _skill_string_list(values: Iterable[str]) -> str:
     return "list(" + " ".join(f'"{escape_skill_string(value)}"' for value in values) + ")"
+
+
+def _skill_window_ref(window: int | str) -> str:
+    if isinstance(window, int):
+        if window <= 0:
+            raise ValueError("window must be a positive window number")
+        return f"window({window})"
+    text = str(window).strip()
+    if text.isdigit():
+        if int(text) <= 0:
+            raise ValueError("window must be a positive window number")
+        return f"window({text})"
+    match = re.fullmatch(r"(?:window:(\d+)|window\((\d+)\))", text)
+    if match:
+        window_num = match.group(1) or match.group(2)
+        if int(window_num) <= 0:
+            raise ValueError("window must be a positive window number")
+        return f"window({window_num})"
+    raise ValueError("window must be a window number or window:<number>")
 
 
 def maestro_open_waveform_viewer_skill(
@@ -25,6 +45,9 @@ def maestro_open_waveform_viewer_skill(
     results_dir: str | Path | None = None,
 ) -> str:
     """Build SKILL to open a ViVA/AWV plot window for explicit signals.
+
+    The Maestro results session is intentionally left open because AWV plot
+    windows keep references to the opened result database.
 
     TODO: measurement waveform setup is intentionally not implemented here.
     TODO: template plot restore/apply support is intentionally not implemented here.
@@ -80,7 +103,6 @@ def maestro_open_waveform_viewer_skill(
         "vbOutputResult vbWindowResult vbWindowId vbPlotResult) "
         "unless(and(isCallable('maeOpenSetup) isCallable('maeOpenResults) "
         "isCallable('maeGetResultTests) isCallable('maeGetOutputValue) "
-        "isCallable('maeCloseResults) isCallable('maeCloseSession) "
         "isCallable('openResults) isCallable('awvCreatePlotWindow) "
         "isCallable('awvPlotWaveform) isCallable('v)) "
         'error("waveform viewer API unavailable")) '
@@ -100,9 +122,28 @@ def maestro_open_waveform_viewer_skill(
         'unless(vbWindowId error("create waveform window failed")) '
         f"vbPlotResult = errset(awvPlotWaveform(vbWindowId vbWaveforms ?expr {signal_expr}) nil) "
         'unless(vbPlotResult && car(vbPlotResult) error("plot waveform failed")) '
-        "errset(maeCloseResults() nil) "
-        "errset(maeCloseSession(?session vbSession ?forceClose t) nil) "
-        f'list("opened" "{escaped_lib}" "{escaped_cell}" "{escaped_view}" "{escaped_history}" vbWindowId))'
+        f'list("opened" "{escaped_lib}" "{escaped_cell}" "{escaped_view}" "{escaped_history}" vbSession vbWindowId))'
+    )
+
+
+def maestro_close_waveform_viewer_skill(
+    *,
+    window: int | str | None = None,
+    session: str | None = None,
+) -> str:
+    """Build SKILL to close a waveform window and its retained Maestro session."""
+    if window is None and session is None:
+        raise ValueError("window or session must be provided")
+
+    window_expr = _skill_window_ref(window) if window is not None else "nil"
+    session_expr = f'"{escape_skill_string(session)}"' if session else "nil"
+    return (
+        "let((vbWindow vbSession) "
+        f"vbWindow = {window_expr} "
+        f"vbSession = {session_expr} "
+        "when(vbWindow errset(hiCloseWindow(vbWindow) nil)) "
+        "when(vbSession errset(maeCloseSession(?session vbSession ?forceClose t) nil)) "
+        'list("closed" vbSession vbWindow))'
     )
 
 
@@ -132,4 +173,16 @@ def open_waveform_viewer(
         result=result,
         results_dir=results_dir,
     )
+    return client.execute_skill(skill, timeout=timeout)
+
+
+def close_waveform_viewer(
+    client: Any,
+    *,
+    window: int | str | None = None,
+    session: str | None = None,
+    timeout: int = 30,
+) -> Any:
+    """Close a waveform window and/or the Maestro session retained for it."""
+    skill = maestro_close_waveform_viewer_skill(window=window, session=session)
     return client.execute_skill(skill, timeout=timeout)

--- a/tests/test_maestro_waveform_viewer.py
+++ b/tests/test_maestro_waveform_viewer.py
@@ -80,16 +80,35 @@ def test_maestro_open_waveform_viewer_escapes_string_inputs() -> None:
     assert '/tmp/a\\"b\\\\c' in skill
 
 
+def test_maestro_open_waveform_viewer_requires_explicit_results_dir_to_open() -> None:
+    skill = maestro_open_waveform_viewer_skill(
+        "demoLib",
+        "tb_inv",
+        "Interactive.1",
+        signals=["/OUT"],
+        results_dir="/tmp/psf/tran/psf",
+    )
+
+    assert 'when(vbResultsDir && !vbRawResultsOpen error("open raw results failed"))' in skill
+
+
+def test_maestro_open_waveform_viewer_docstring_documents_test_and_result() -> None:
+    doc = maestro_open_waveform_viewer_skill.__doc__ or ""
+
+    assert "test: Maestro test name" in doc
+    assert "result: Spectre result name" in doc
+
+
 def test_maestro_open_waveform_viewer_skill_can_fallback_to_maestro_outputs() -> None:
     skill = maestro_open_waveform_viewer_skill(
         "demoLib",
         "tb_inv",
         "Interactive.1",
         signals=["vout"],
-        test="tran",
+        test="tran_test",
     )
 
-    assert 'maeGetOutputValue("vout" "tran")' in skill
+    assert 'maeGetOutputValue("vout" "tran_test")' in skill
     assert 'list("opened" "demoLib" "tb_inv" "maestro" "Interactive.1" vbSession vbWindowId)' in skill
 
 
@@ -167,6 +186,15 @@ def test_open_waveform_viewer_executes_generated_skill() -> None:
     assert client.timeout == 30
     assert client.skill is not None
     assert 'awvPlotWaveform(vbWindowId vbWaveforms ?expr list("/OUT"))' in client.skill
+
+
+def test_open_waveform_viewer_docstring_documents_raw_result_contract() -> None:
+    doc = open_waveform_viewer.__doc__ or ""
+
+    assert "raw VirtuosoResult" in doc
+    assert "output" in doc
+    assert "session" in doc
+    assert "window" in doc
 
 
 def test_close_waveform_viewer_executes_generated_skill() -> None:

--- a/tests/test_maestro_waveform_viewer.py
+++ b/tests/test_maestro_waveform_viewer.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import pytest
+
+from virtuoso_bridge.virtuoso.maestro import (
+    maestro_open_waveform_viewer_skill,
+    open_waveform_viewer,
+)
+
+
+def test_maestro_open_waveform_viewer_skill_plots_explicit_signals() -> None:
+    skill = maestro_open_waveform_viewer_skill(
+        "demoLib",
+        "tb_inv",
+        "Interactive.1",
+        signals=["/IN", "/OUT"],
+        results_dir="/tmp/psf/tran/psf",
+        result="tran",
+    )
+
+    assert "isCallable('awvCreatePlotWindow)" in skill
+    assert 'maeOpenSetup("demoLib" "tb_inv" "maestro" ?application "Assembler" ?mode "r")' in skill
+    assert 'maeOpenResults(?session vbSession ?history "Interactive.1")' in skill
+    assert 'openResults("/tmp/psf/tran/psf")' in skill
+    assert 'v("/IN" ?result "tran" ?resultsDir vbResultsDir)' in skill
+    assert 'v("/OUT" ?result "tran" ?resultsDir vbResultsDir)' in skill
+    assert "awvCreatePlotWindow()" in skill
+    assert 'awvPlotWaveform(vbWindowId vbWaveforms ?expr list("/IN" "/OUT"))' in skill
+
+
+def test_maestro_open_waveform_viewer_skill_can_fallback_to_maestro_outputs() -> None:
+    skill = maestro_open_waveform_viewer_skill(
+        "demoLib",
+        "tb_inv",
+        "Interactive.1",
+        signals=["vout"],
+        test="tran",
+    )
+
+    assert 'maeGetOutputValue("vout" "tran")' in skill
+    assert 'list("opened" "demoLib" "tb_inv" "maestro" "Interactive.1" vbWindowId)' in skill
+
+
+def test_maestro_open_waveform_viewer_requires_signals() -> None:
+    with pytest.raises(ValueError, match="signals must not be empty"):
+        maestro_open_waveform_viewer_skill("demoLib", "tb_inv", "Interactive.1", signals=[])
+
+
+def test_open_waveform_viewer_executes_generated_skill() -> None:
+    class Client:
+        skill: str | None = None
+        timeout: int | None = None
+
+        def execute_skill(self, skill: str, *, timeout: int):
+            self.skill = skill
+            self.timeout = timeout
+            return {"status": "success", "output": '("opened" "demoLib" "tb_inv")'}
+
+    client = Client()
+    result = open_waveform_viewer(
+        client,
+        "demoLib",
+        "tb_inv",
+        "Interactive.1",
+        signals=["/OUT"],
+        timeout=30,
+    )
+
+    assert result == {"status": "success", "output": '("opened" "demoLib" "tb_inv")'}
+    assert client.timeout == 30
+    assert client.skill is not None
+    assert 'awvPlotWaveform(vbWindowId vbWaveforms ?expr list("/OUT"))' in client.skill

--- a/tests/test_maestro_waveform_viewer.py
+++ b/tests/test_maestro_waveform_viewer.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import pytest
 
 from virtuoso_bridge.virtuoso.maestro import (
+    close_waveform_viewer,
+    maestro_close_waveform_viewer_skill,
     maestro_open_waveform_viewer_skill,
     open_waveform_viewer,
 )
@@ -28,6 +30,19 @@ def test_maestro_open_waveform_viewer_skill_plots_explicit_signals() -> None:
     assert 'awvPlotWaveform(vbWindowId vbWaveforms ?expr list("/IN" "/OUT"))' in skill
 
 
+def test_maestro_open_waveform_viewer_keeps_results_session_alive() -> None:
+    skill = maestro_open_waveform_viewer_skill(
+        "demoLib",
+        "tb_inv",
+        "Interactive.1",
+        signals=["/OUT"],
+        results_dir="/tmp/psf/tran/psf",
+    )
+
+    assert "maeCloseResults" not in skill
+    assert "maeCloseSession" not in skill
+
+
 def test_maestro_open_waveform_viewer_skill_can_fallback_to_maestro_outputs() -> None:
     skill = maestro_open_waveform_viewer_skill(
         "demoLib",
@@ -38,12 +53,43 @@ def test_maestro_open_waveform_viewer_skill_can_fallback_to_maestro_outputs() ->
     )
 
     assert 'maeGetOutputValue("vout" "tran")' in skill
-    assert 'list("opened" "demoLib" "tb_inv" "maestro" "Interactive.1" vbWindowId)' in skill
+    assert 'list("opened" "demoLib" "tb_inv" "maestro" "Interactive.1" vbSession vbWindowId)' in skill
 
 
 def test_maestro_open_waveform_viewer_requires_signals() -> None:
     with pytest.raises(ValueError, match="signals must not be empty"):
         maestro_open_waveform_viewer_skill("demoLib", "tb_inv", "Interactive.1", signals=[])
+
+
+def test_maestro_close_waveform_viewer_skill_closes_window_and_session() -> None:
+    skill = maestro_close_waveform_viewer_skill(window="window:7", session="fnxSession2")
+
+    assert "vbWindow = window(7)" in skill
+    assert 'vbSession = "fnxSession2"' in skill
+    assert "hiCloseWindow(vbWindow)" in skill
+    assert "maeCloseSession(?session vbSession ?forceClose t)" in skill
+
+
+def test_maestro_close_waveform_viewer_accepts_window_object_text() -> None:
+    skill = maestro_close_waveform_viewer_skill(window="window(8)")
+
+    assert "vbWindow = window(8)" in skill
+    assert "vbSession = nil" in skill
+
+
+def test_maestro_close_waveform_viewer_requires_target() -> None:
+    with pytest.raises(ValueError, match="window or session must be provided"):
+        maestro_close_waveform_viewer_skill()
+
+
+def test_maestro_close_waveform_viewer_rejects_unsafe_window_ref() -> None:
+    with pytest.raises(ValueError, match="window must be a window number"):
+        maestro_close_waveform_viewer_skill(window='window(7) hiCloseWindow(window(1))')
+
+
+def test_maestro_close_waveform_viewer_rejects_invalid_window_number() -> None:
+    with pytest.raises(ValueError, match="positive window number"):
+        maestro_close_waveform_viewer_skill(window=0)
 
 
 def test_open_waveform_viewer_executes_generated_skill() -> None:
@@ -70,3 +116,28 @@ def test_open_waveform_viewer_executes_generated_skill() -> None:
     assert client.timeout == 30
     assert client.skill is not None
     assert 'awvPlotWaveform(vbWindowId vbWaveforms ?expr list("/OUT"))' in client.skill
+
+
+def test_close_waveform_viewer_executes_generated_skill() -> None:
+    class Client:
+        skill: str | None = None
+        timeout: int | None = None
+
+        def execute_skill(self, skill: str, *, timeout: int):
+            self.skill = skill
+            self.timeout = timeout
+            return {"status": "success", "output": '("closed" "fnxSession2" window:7)'}
+
+    client = Client()
+    result = close_waveform_viewer(
+        client,
+        window=7,
+        session="fnxSession2",
+        timeout=10,
+    )
+
+    assert result == {"status": "success", "output": '("closed" "fnxSession2" window:7)'}
+    assert client.timeout == 10
+    assert client.skill is not None
+    assert "vbWindow = window(7)" in client.skill
+    assert 'vbSession = "fnxSession2"' in client.skill

--- a/tests/test_maestro_waveform_viewer.py
+++ b/tests/test_maestro_waveform_viewer.py
@@ -30,7 +30,7 @@ def test_maestro_open_waveform_viewer_skill_plots_explicit_signals() -> None:
     assert 'awvPlotWaveform(vbWindowId vbWaveforms ?expr list("/IN" "/OUT"))' in skill
 
 
-def test_maestro_open_waveform_viewer_keeps_results_session_alive() -> None:
+def test_maestro_open_waveform_viewer_keeps_results_session_alive_on_success() -> None:
     skill = maestro_open_waveform_viewer_skill(
         "demoLib",
         "tb_inv",
@@ -39,8 +39,45 @@ def test_maestro_open_waveform_viewer_keeps_results_session_alive() -> None:
         results_dir="/tmp/psf/tran/psf",
     )
 
-    assert "maeCloseResults" not in skill
-    assert "maeCloseSession" not in skill
+    assert "vbOpenOk = t" in skill
+    assert 'list("opened" "demoLib" "tb_inv" "maestro" "Interactive.1" vbSession vbWindowId)' in skill
+    assert "unless(vbOpenOk" in skill
+
+
+def test_maestro_open_waveform_viewer_cleans_up_failed_open() -> None:
+    skill = maestro_open_waveform_viewer_skill(
+        "demoLib",
+        "tb_inv",
+        "Interactive.1",
+        signals=["/OUT"],
+        results_dir="/tmp/psf/tran/psf",
+    )
+
+    assert "vbOpenResult = errset(progn(" in skill
+    assert "unless(vbOpenOk" in skill
+    assert "hiCloseWindow(vbWindowId)" in skill
+    assert "maeCloseSession(?session vbSession ?forceClose t)" in skill
+    assert 'error("open waveform viewer failed")' in skill
+
+
+def test_maestro_open_waveform_viewer_escapes_string_inputs() -> None:
+    skill = maestro_open_waveform_viewer_skill(
+        'demo"Lib\\1',
+        'tb"inv\\2',
+        'Interactive."3\\4',
+        signals=['/A"NET\\1'],
+        test='tr"an\\5',
+        result='res"ult\\6',
+        results_dir='/tmp/a"b\\c',
+    )
+
+    assert 'demo\\"Lib\\\\1' in skill
+    assert 'tb\\"inv\\\\2' in skill
+    assert 'Interactive.\\"3\\\\4' in skill
+    assert '/A\\"NET\\\\1' in skill
+    assert 'tr\\"an\\\\5' in skill
+    assert 'res\\"ult\\\\6' in skill
+    assert '/tmp/a\\"b\\\\c' in skill
 
 
 def test_maestro_open_waveform_viewer_skill_can_fallback_to_maestro_outputs() -> None:
@@ -68,6 +105,15 @@ def test_maestro_close_waveform_viewer_skill_closes_window_and_session() -> None
     assert 'vbSession = "fnxSession2"' in skill
     assert "hiCloseWindow(vbWindow)" in skill
     assert "maeCloseSession(?session vbSession ?forceClose t)" in skill
+    assert "maeGetSessions()" in skill
+    assert "member(vbSession" in skill
+    assert 'error("close waveform session failed")' in skill
+
+
+def test_maestro_close_waveform_viewer_escapes_session() -> None:
+    skill = maestro_close_waveform_viewer_skill(session='fnx"Session\\2')
+
+    assert 'vbSession = "fnx\\"Session\\\\2"' in skill
 
 
 def test_maestro_close_waveform_viewer_accepts_window_object_text() -> None:
@@ -80,6 +126,11 @@ def test_maestro_close_waveform_viewer_accepts_window_object_text() -> None:
 def test_maestro_close_waveform_viewer_requires_target() -> None:
     with pytest.raises(ValueError, match="window or session must be provided"):
         maestro_close_waveform_viewer_skill()
+
+
+def test_maestro_close_waveform_viewer_rejects_blank_session() -> None:
+    with pytest.raises(ValueError, match="session must not be blank"):
+        maestro_close_waveform_viewer_skill(session="  ")
 
 
 def test_maestro_close_waveform_viewer_rejects_unsafe_window_ref() -> None:


### PR DESCRIPTION
Summary:
- Add helpers to open existing Maestro waveform histories in ViVA/AWV from explicit signals.
- Return the raw SKILL execution result containing the retained Maestro session and waveform window handle in result.output, so callers can close them explicitly.
- Add close helpers and lifecycle tests covering cleanup, escaping, invalid handles, and results directory behavior.

Reviewer note:
- The opened AWV window depends on the Maestro results session, so the session is intentionally kept alive on successful open.
- Failed opens clean up any created window/session, and close verifies the session/window no longer remains open.
- When results_dir is provided, it is strict: openResults(results_dir) must succeed rather than falling back to another active results context.
- The test argument is a Maestro test name used for maeGetOutputValue fallback; result is the Spectre result name such as tran.

Validation:
- python -m pytest tests/test_maestro_waveform_viewer.py -q
- python -m pytest -q
- Manual local Virtuoso smoke: opened /IN and /OUT from an existing Maestro history, closed the returned window/session, and verified no leftover session or window. Also verified missing history and invalid results_dir return errors without leaking state.