### PR TITLE
Add schematic netlist export helper

### DIFF
--- a/src/virtuoso_bridge/transport/ssh.py
+++ b/src/virtuoso_bridge/transport/ssh.py
@@ -922,20 +922,21 @@ class SSHRunner:
         timeout: int,
     ) -> CommandResult:
         """Download a directory recursively using tar czf piped over SSH."""
-        # Ensure the parent of the local target exists (like scp -r does)
+        # Extract into a sibling temp directory first; replace the requested
+        # target only after both SSH and local tar have succeeded.
         local_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = local_path.with_name(f".{local_path.name}.tmp-{uuid.uuid4().hex}")
+        tmp_path.mkdir(parents=True)
 
-        # To match scp -r behavior, we compress the *directory itself* (not its contents)
-        # and extract it into local_path.parent. If local_path.name != remote basename,
-        # we will extract it then rename it.
         remote_path_q = shlex.quote(remote_path)
-        remote_parent = f"$(dirname {remote_path_q})"
-        remote_base = f"$(basename {remote_path_q})"
-        inner_cmd = f"cd {remote_parent} && tar czf - {remote_base}"
+        inner_cmd = (
+            f"p={remote_path_q}; "
+            'cd "$p" && tar czf - .'
+        )
         remote_cmd = f"sh -c {shlex.quote(inner_cmd)}"
 
         ssh_cmd = self._build_ssh_base() + [remote_cmd]
-        tar_cmd = [self._tar_cmd, "xzf", "-", "-C", str(local_path.parent).replace("\\", "/")]
+        tar_cmd = [self._tar_cmd, "xzf", "-", "-C", str(tmp_path).replace("\\", "/")]
 
         if self._verbose:
             print(f"[cmd] {' '.join(ssh_cmd)} | {' '.join(tar_cmd)}  # download {remote_path} -> {local_path}", flush=True)
@@ -963,24 +964,41 @@ class SSHRunner:
         except subprocess.TimeoutExpired:
             ssh_proc.kill()
             tar_proc.kill()
+            shutil.rmtree(tmp_path, ignore_errors=True)
             raise
 
         if ssh_proc.returncode != 0 or tar_proc.returncode != 0:
+            shutil.rmtree(tmp_path, ignore_errors=True)
             ssh_err = _as_text(ssh_proc.stderr.read()) if ssh_proc.stderr else ""
             tar_err_str = _as_text(tar_err)
             combined_err = f"SSH error: {ssh_err.strip()} | Tar error: {tar_err_str.strip()}"
             logger.warning("download (tar) failed (rc=%d/%d): %s", ssh_proc.returncode, tar_proc.returncode, combined_err)
             return CommandResult(returncode=ssh_proc.returncode or tar_proc.returncode, stdout="", stderr=combined_err)
 
-        # Handle rename if the remote basename differs from local_path.name
-        remote_basename = Path(remote_path).name
-        if remote_basename != local_path.name:
-            extracted_path = local_path.parent / remote_basename
-            if extracted_path.exists():
-                if local_path.exists():
-                    shutil.rmtree(local_path)
-                extracted_path.rename(local_path)
-
+        backup_path: Path | None = None
+        try:
+            if local_path.exists() or local_path.is_symlink():
+                backup_path = local_path.with_name(
+                    f".{local_path.name}.backup-{uuid.uuid4().hex}"
+                )
+                local_path.rename(backup_path)
+            tmp_path.rename(local_path)
+        except Exception:
+            if tmp_path.exists():
+                shutil.rmtree(tmp_path, ignore_errors=True)
+            if (
+                backup_path is not None
+                and not (local_path.exists() or local_path.is_symlink())
+                and (backup_path.exists() or backup_path.is_symlink())
+            ):
+                backup_path.rename(local_path)
+            raise
+        else:
+            if backup_path is not None and (backup_path.exists() or backup_path.is_symlink()):
+                if backup_path.is_dir() and not backup_path.is_symlink():
+                    shutil.rmtree(backup_path)
+                else:
+                    backup_path.unlink()
         return CommandResult(returncode=0, stdout="", stderr="")
 
     def _upload_via_tar(

--- a/src/virtuoso_bridge/transport/ssh.py
+++ b/src/virtuoso_bridge/transport/ssh.py
@@ -18,7 +18,7 @@ import subprocess
 import threading
 import time
 import uuid
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, NamedTuple
 
 from virtuoso_bridge.env import load_vb_env
@@ -922,21 +922,28 @@ class SSHRunner:
         timeout: int,
     ) -> CommandResult:
         """Download a directory recursively using tar czf piped over SSH."""
-        # Extract into a sibling temp directory first; replace the requested
-        # target only after both SSH and local tar have succeeded.
+        # Extract into a sibling staging directory first; replace the requested
+        # target only after both SSH and local tar have succeeded.  The archive
+        # contains the remote directory itself rather than "." so BSD tar does
+        # not try to restore metadata on the pre-created staging directory.
         local_path.parent.mkdir(parents=True, exist_ok=True)
-        tmp_path = local_path.with_name(f".{local_path.name}.tmp-{uuid.uuid4().hex}")
-        tmp_path.mkdir(parents=True)
+        stage_path = local_path.with_name(f".{local_path.name}.tmp-{uuid.uuid4().hex}")
+        stage_path.mkdir(parents=True)
+        remote_basename = PurePosixPath(remote_path.rstrip("/")).name
+        if not remote_basename:
+            shutil.rmtree(stage_path, ignore_errors=True)
+            return CommandResult(returncode=1, stdout="", stderr=f"Invalid remote directory path: {remote_path}")
 
         remote_path_q = shlex.quote(remote_path)
         inner_cmd = (
             f"p={remote_path_q}; "
-            'cd "$p" && tar czf - .'
+            'd=$(dirname "$p"); b=$(basename "$p"); '
+            'cd "$d" && tar czf - "$b"'
         )
         remote_cmd = f"sh -c {shlex.quote(inner_cmd)}"
 
         ssh_cmd = self._build_ssh_base() + [remote_cmd]
-        tar_cmd = [self._tar_cmd, "xzf", "-", "-C", str(tmp_path).replace("\\", "/")]
+        tar_cmd = [self._tar_cmd, "xzf", "-", "-C", str(stage_path).replace("\\", "/")]
 
         if self._verbose:
             print(f"[cmd] {' '.join(ssh_cmd)} | {' '.join(tar_cmd)}  # download {remote_path} -> {local_path}", flush=True)
@@ -964,11 +971,11 @@ class SSHRunner:
         except subprocess.TimeoutExpired:
             ssh_proc.kill()
             tar_proc.kill()
-            shutil.rmtree(tmp_path, ignore_errors=True)
+            shutil.rmtree(stage_path, ignore_errors=True)
             raise
 
         if ssh_proc.returncode != 0 or tar_proc.returncode != 0:
-            shutil.rmtree(tmp_path, ignore_errors=True)
+            shutil.rmtree(stage_path, ignore_errors=True)
             ssh_err = _as_text(ssh_proc.stderr.read()) if ssh_proc.stderr else ""
             tar_err_str = _as_text(tar_err)
             combined_err = f"SSH error: {ssh_err.strip()} | Tar error: {tar_err_str.strip()}"
@@ -976,16 +983,24 @@ class SSHRunner:
             return CommandResult(returncode=ssh_proc.returncode or tar_proc.returncode, stdout="", stderr=combined_err)
 
         backup_path: Path | None = None
+        extracted_path = stage_path / remote_basename
+        if not (extracted_path.exists() or extracted_path.is_symlink()):
+            shutil.rmtree(stage_path, ignore_errors=True)
+            return CommandResult(
+                returncode=1,
+                stdout="",
+                stderr=f"Downloaded archive did not contain expected directory: {remote_basename}",
+            )
         try:
             if local_path.exists() or local_path.is_symlink():
                 backup_path = local_path.with_name(
                     f".{local_path.name}.backup-{uuid.uuid4().hex}"
                 )
                 local_path.rename(backup_path)
-            tmp_path.rename(local_path)
+            extracted_path.rename(local_path)
         except Exception:
-            if tmp_path.exists():
-                shutil.rmtree(tmp_path, ignore_errors=True)
+            if stage_path.exists():
+                shutil.rmtree(stage_path, ignore_errors=True)
             if (
                 backup_path is not None
                 and not (local_path.exists() or local_path.is_symlink())
@@ -999,6 +1014,7 @@ class SSHRunner:
                     shutil.rmtree(backup_path)
                 else:
                     backup_path.unlink()
+            shutil.rmtree(stage_path, ignore_errors=True)
         return CommandResult(returncode=0, stdout="", stderr="")
 
     def _upload_via_tar(

--- a/src/virtuoso_bridge/virtuoso/basic/bridge.py
+++ b/src/virtuoso_bridge/virtuoso/basic/bridge.py
@@ -708,14 +708,20 @@ let((result winName ciwNum)
     # -- file transfer (delegates to tunnel) --------------------------------
 
     def download_file(self, remote_path: str | Path, local_path: str | Path,
-                      *, timeout: int | None = None) -> VirtuosoResult:
+                      *, timeout: int | None = None,
+                      recursive: bool = False) -> VirtuosoResult:
         started = time.perf_counter()
         source = _path_to_posix(remote_path)
         destination = Path(local_path)
-        destination.parent.mkdir(parents=True, exist_ok=True)
 
         if self._tunnel is not None and getattr(self._tunnel, "ssh_runner", None) is not None:
-            result = self._tunnel.download_file(source, destination, timeout=timeout)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            result = self._tunnel.download_file(
+                source,
+                destination,
+                timeout=timeout,
+                recursive=recursive,
+            )
             elapsed = time.perf_counter() - started
             if result.returncode != 0:
                 return VirtuosoResult(
@@ -734,7 +740,32 @@ let((result winName ciwNum)
         # Local mode: just copy
         import shutil
         try:
-            shutil.copy2(Path(source), destination)
+            if recursive:
+                source_path = Path(source).resolve()
+                destination_path = destination.resolve(strict=False)
+                if (
+                    source_path == destination_path
+                    or source_path.is_relative_to(destination_path)
+                    or destination_path.is_relative_to(source_path)
+                ):
+                    return VirtuosoResult(
+                        status=ExecutionStatus.ERROR,
+                        errors=[
+                            "Refusing recursive copy with overlapping "
+                            f"source and destination: {source} -> {destination}"
+                        ],
+                        execution_time=time.perf_counter() - started,
+                    )
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                if destination.exists():
+                    if destination.is_dir():
+                        shutil.rmtree(destination)
+                    else:
+                        destination.unlink()
+                shutil.copytree(Path(source), destination)
+            else:
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(Path(source), destination)
         except OSError as exc:
             return VirtuosoResult(
                 status=ExecutionStatus.ERROR,

--- a/src/virtuoso_bridge/virtuoso/schematic/__init__.py
+++ b/src/virtuoso_bridge/virtuoso/schematic/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, TYPE_CHECKING
 
 from virtuoso_bridge.virtuoso.schematic.editor import SchematicEditor
@@ -20,6 +21,11 @@ from virtuoso_bridge.virtuoso.schematic.ops import (
     schematic_create_wire_label,
     schematic_set_netset_property,
 )
+from virtuoso_bridge.virtuoso.schematic.netlist import (
+    SchematicNetlistExportResult,
+    export_schematic_netlist,
+    schematic_export_netlist_skill,
+)
 
 if TYPE_CHECKING:
     from virtuoso_bridge import VirtuosoClient
@@ -35,6 +41,35 @@ class SchematicOps:
              mode: str = "w", timeout: int = 60) -> SchematicEditor:
         """Return a SchematicEditor context manager."""
         return SchematicEditor(self._owner, lib, cell, view=view, mode=mode, timeout=timeout)
+
+    def export_netlist(
+        self,
+        lib: str,
+        cell: str,
+        output_dir: str | Path,
+        *,
+        view: str = "schematic",
+        simulator: str = "spectre",
+        recreate_all: bool = True,
+        timeout: int = 120,
+    ) -> SchematicNetlistExportResult:
+        """Export a schematic netlist package through Virtuoso's netlister.
+
+        The returned dictionary includes the Virtuoso-side ``source_file`` and
+        ``source_dir``, the local ``output_dir`` and ``input_file``, plus the raw
+        SKILL and download results. Existing ``output_dir`` contents are kept
+        until the new package has downloaded and ``input.scs`` is present.
+        """
+        return export_schematic_netlist(
+            self._owner,
+            lib,
+            cell,
+            output_dir,
+            view=view,
+            simulator=simulator,
+            recreate_all=recreate_all,
+            timeout=timeout,
+        )
 
 
 __all__ = [
@@ -53,4 +88,7 @@ __all__ = [
     "schematic_create_wire_between_instance_terms",
     "schematic_create_net_stub",
     "schematic_check",
+    "SchematicNetlistExportResult",
+    "schematic_export_netlist_skill",
+    "export_schematic_netlist",
 ]

--- a/src/virtuoso_bridge/virtuoso/schematic/netlist.py
+++ b/src/virtuoso_bridge/virtuoso/schematic/netlist.py
@@ -1,0 +1,228 @@
+"""Helpers for exporting schematic netlists through Virtuoso's netlister."""
+
+from __future__ import annotations
+
+import re
+import shutil
+import uuid
+from pathlib import Path, PurePosixPath
+from typing import Any, TypedDict
+
+from virtuoso_bridge.models import ExecutionStatus
+from virtuoso_bridge.virtuoso.ops import escape_skill_string
+
+_SKILL_SYMBOL_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+class SchematicNetlistExportResult(TypedDict):
+    """Result metadata from a schematic netlist package export."""
+
+    source_file: str
+    source_dir: str
+    output_dir: str
+    input_file: str
+    skill_result: Any
+    download_result: Any
+
+
+def _skill_bool(value: bool) -> str:
+    return "t" if value else "nil"
+
+
+def _skill_symbol(value: str, *, name: str) -> str:
+    if not _SKILL_SYMBOL_RE.fullmatch(value):
+        raise ValueError(f"{name} must be a simple SKILL symbol name")
+    return f"'{value}"
+
+
+def _result_output(result: Any) -> str:
+    if isinstance(result, dict):
+        return str(result.get("output", ""))
+    return str(getattr(result, "output", "") or "")
+
+
+def _result_ok(result: Any) -> bool:
+    if isinstance(result, dict):
+        status = result.get("status")
+        return status in ("success", ExecutionStatus.SUCCESS)
+    return bool(getattr(result, "ok", False))
+
+
+def _result_errors(result: Any) -> list[str]:
+    if isinstance(result, dict):
+        errors = result.get("errors", [])
+        return [str(error) for error in errors]
+    return [str(error) for error in getattr(result, "errors", [])]
+
+
+def _set_result_output(result: Any, output: str) -> Any:
+    if isinstance(result, dict):
+        updated = dict(result)
+        updated["output"] = output
+        return updated
+    if hasattr(result, "model_copy"):
+        return result.model_copy(update={"output": output})
+    try:
+        result.output = output
+    except Exception:
+        pass
+    return result
+
+
+def _decode_skill_string(raw: str) -> str:
+    text = (raw or "").strip()
+    if len(text) >= 2 and text[0] == '"' and text[-1] == '"':
+        return bytes(text[1:-1], "utf-8").decode("unicode_escape")
+    return text
+
+
+def _path_exists(path: Path) -> bool:
+    return path.exists() or path.is_symlink()
+
+
+def _remove_path(path: Path) -> None:
+    if path.is_dir() and not path.is_symlink():
+        shutil.rmtree(path)
+    else:
+        path.unlink()
+
+
+def _replace_path_preserving_existing(source: Path, destination: Path) -> None:
+    """Install ``source`` at ``destination`` while keeping old data recoverable."""
+    if not _path_exists(destination):
+        source.rename(destination)
+        return
+
+    backup = destination.with_name(f".{destination.name}.backup-{uuid.uuid4().hex}")
+    destination.rename(backup)
+    try:
+        source.rename(destination)
+    except Exception:
+        if not _path_exists(destination) and _path_exists(backup):
+            backup.rename(destination)
+        raise
+    else:
+        if _path_exists(backup):
+            _remove_path(backup)
+
+
+def schematic_export_netlist_skill(
+    lib: str,
+    cell: str,
+    *,
+    view: str = "schematic",
+    simulator: str = "spectre",
+    recreate_all: bool = True,
+) -> str:
+    """Build SKILL to create a schematic netlist and return ``input.scs``.
+
+    The generated SKILL uses the OCEAN netlisting flow:
+    ``simulator`` → ``design`` → ``createNetlist``. Virtuoso returns the
+    generated simulator input file. The Python wrapper downloads the
+    containing netlist directory so adjacent includes such as ``ade_e.scs``
+    stay with ``input.scs``.
+    """
+    escaped_lib = escape_skill_string(lib)
+    escaped_cell = escape_skill_string(cell)
+    escaped_view = escape_skill_string(view)
+    simulator_symbol = _skill_symbol(simulator, name="simulator")
+    recreate = _skill_bool(recreate_all)
+    return (
+        "let((vbSimResult vbDesignResult vbNetlistResult vbSourceFile) "
+        "unless(and(isCallable('simulator) isCallable('design) "
+        "isCallable('createNetlist) isCallable('simplifyFilename)) "
+        'error("netlist API unavailable")) '
+        f"vbSimResult = errset(simulator({simulator_symbol}) nil) "
+        'unless(vbSimResult && car(vbSimResult) error("simulator failed")) '
+        f'vbDesignResult = errset(design("{escaped_lib}" "{escaped_cell}" "{escaped_view}" "r") nil) '
+        'unless(vbDesignResult && car(vbDesignResult) error("design failed")) '
+        "when(isCallable('ddsRefresh) errset(ddsRefresh() nil)) "
+        f"vbNetlistResult = errset(createNetlist(?recreateAll {recreate} ?display nil) nil) "
+        "vbSourceFile = if(vbNetlistResult then car(vbNetlistResult) else nil) "
+        'unless(vbSourceFile error("createNetlist failed")) '
+        "vbSourceFile = simplifyFilename(vbSourceFile) "
+        "vbSourceFile)"
+    )
+
+
+def export_schematic_netlist(
+    client: Any,
+    lib: str,
+    cell: str,
+    output_dir: str | Path,
+    *,
+    view: str = "schematic",
+    simulator: str = "spectre",
+    recreate_all: bool = True,
+    timeout: int = 120,
+) -> SchematicNetlistExportResult:
+    """Export a schematic netlist package to ``output_dir``.
+
+    ``createNetlist`` produces an ``input.scs`` file plus adjacent support
+    files. Downloading the containing directory preserves relative includes.
+    Existing ``output_dir`` contents are replaced only after the new package
+    has downloaded and the expected input file is present.
+
+    Returns a dictionary with:
+    ``source_file`` (Virtuoso host ``input.scs``), ``source_dir`` (Virtuoso
+    host netlist package directory), ``output_dir`` (local package directory),
+    ``input_file`` (downloaded local simulator input), ``skill_result``, and
+    ``download_result``.
+    """
+    skill = schematic_export_netlist_skill(
+        lib,
+        cell,
+        view=view,
+        simulator=simulator,
+        recreate_all=recreate_all,
+    )
+    skill_result = client.execute_skill(skill, timeout=timeout)
+    if not _result_ok(skill_result):
+        errors = "; ".join(_result_errors(skill_result)) or "createNetlist failed"
+        raise RuntimeError(errors)
+
+    source_file = _decode_skill_string(_result_output(skill_result))
+    if not source_file or source_file == "nil":
+        raise RuntimeError("createNetlist did not return a netlist path")
+
+    source_path = PurePosixPath(source_file)
+    if not source_path.is_absolute():
+        raise RuntimeError(f"createNetlist returned relative netlist path: {source_file}")
+    source_dir = source_path.parent.as_posix()
+    destination = Path(output_dir)
+    tmp_destination = destination.with_name(
+        f".{destination.name}.tmp-{uuid.uuid4().hex}"
+    )
+    try:
+        download_result = client.download_file(
+            source_dir,
+            tmp_destination,
+            timeout=timeout,
+            recursive=True,
+        )
+        if not _result_ok(download_result):
+            errors = "; ".join(_result_errors(download_result)) or "netlist download failed"
+            raise RuntimeError(errors)
+
+        tmp_input_file = tmp_destination / "input.scs"
+        if not tmp_destination.is_dir() or not tmp_input_file.is_file():
+            raise RuntimeError(f"downloaded netlist is missing input.scs: {tmp_input_file}")
+
+        _replace_path_preserving_existing(tmp_destination, destination)
+        download_result = _set_result_output(download_result, str(destination))
+    except Exception:
+        if tmp_destination.exists():
+            if tmp_destination.is_dir():
+                shutil.rmtree(tmp_destination)
+            else:
+                tmp_destination.unlink()
+        raise
+
+    return {
+        "source_file": source_file,
+        "source_dir": source_dir,
+        "output_dir": str(destination),
+        "input_file": str(destination / "input.scs"),
+        "skill_result": skill_result,
+        "download_result": download_result,
+    }

--- a/src/virtuoso_bridge/wrappers.py
+++ b/src/virtuoso_bridge/wrappers.py
@@ -44,6 +44,8 @@ class SanitizingClient:
         result = self._inner.download_file(remote_path, local_path, **kwargs)
         if sanitize:
             local = Path(local_path)
+            if local.is_dir():
+                return result
             try:
                 text = local.read_text(encoding="utf-8")
             except (UnicodeDecodeError, FileNotFoundError):

--- a/tests/test_bridge_local_transfer.py
+++ b/tests/test_bridge_local_transfer.py
@@ -13,11 +13,17 @@ class _RecordingTunnel:
     port = 65432
 
     def __init__(self) -> None:
-        self.downloads: list[tuple[str, Path, int | None]] = []
+        self.downloads: list[tuple[str, Path, int | None, bool]] = []
         self.uploads: list[tuple[Path, str, int | None]] = []
 
-    def download_file(self, remote_path: str, local_path: Path, timeout: int | None = None) -> CommandResult:
-        self.downloads.append((remote_path, local_path, timeout))
+    def download_file(
+        self,
+        remote_path: str,
+        local_path: Path,
+        timeout: int | None = None,
+        recursive: bool = False,
+    ) -> CommandResult:
+        self.downloads.append((remote_path, local_path, timeout, recursive))
         local_path.parent.mkdir(parents=True, exist_ok=True)
         local_path.write_text("downloaded through tunnel\n", encoding="utf-8")
         return CommandResult(
@@ -54,6 +60,49 @@ def test_download_file_copies_directly_when_tunnel_is_local(tmp_path):
     assert target.read_text(encoding="utf-8") == "point,value\n1,0.8\n"
 
 
+def test_download_file_copies_directories_when_tunnel_is_local(tmp_path):
+    source = tmp_path / "remote_netlist"
+    target = tmp_path / "local" / "netlist"
+    source.mkdir()
+    (source / "input.scs").write_text('include "ade_e.scs"\n', encoding="utf-8")
+    (source / "ade_e.scs").write_text("simulatorOptions options\n", encoding="utf-8")
+
+    client = _local_tunnel_client()
+    result = client.download_file(source, target, recursive=True)
+
+    assert result.status == ExecutionStatus.SUCCESS
+    assert Path(result.output) == target
+    assert (target / "input.scs").read_text(encoding="utf-8") == 'include "ade_e.scs"\n'
+    assert (target / "ade_e.scs").read_text(encoding="utf-8") == "simulatorOptions options\n"
+
+
+def test_download_file_rejects_overlapping_local_recursive_paths(tmp_path):
+    source = tmp_path / "remote_netlist"
+    source.mkdir()
+    (source / "input.scs").write_text('include "ade_e.scs"\n', encoding="utf-8")
+
+    client = _local_tunnel_client()
+    same_path = client.download_file(source, source, recursive=True)
+    nested_path = client.download_file(source, source / "nested", recursive=True)
+
+    assert same_path.status == ExecutionStatus.ERROR
+    assert nested_path.status == ExecutionStatus.ERROR
+    assert (source / "input.scs").read_text(encoding="utf-8") == 'include "ade_e.scs"\n'
+
+
+def test_download_file_rejects_nested_overlap_without_creating_parent(tmp_path):
+    source = tmp_path / "remote_netlist"
+    source.mkdir()
+    (source / "input.scs").write_text('include "ade_e.scs"\n', encoding="utf-8")
+
+    client = _local_tunnel_client()
+    result = client.download_file(source, source / "nested" / "copy", recursive=True)
+
+    assert result.status == ExecutionStatus.ERROR
+    assert not (source / "nested").exists()
+    assert (source / "input.scs").read_text(encoding="utf-8") == 'include "ade_e.scs"\n'
+
+
 def test_upload_file_copies_directly_when_tunnel_is_local(tmp_path):
     source = tmp_path / "local.scs"
     target = tmp_path / "remote" / "input.scs"
@@ -75,10 +124,20 @@ def test_file_transfers_delegate_when_tunnel_has_ssh_runner(tmp_path):
     client = VirtuosoClient.from_tunnel(tunnel)
 
     download = client.download_file("/remote/result.scs", download_target, timeout=12)
+    recursive_download = client.download_file(
+        "/remote/netlist",
+        tmp_path / "downloads" / "netlist",
+        timeout=56,
+        recursive=True,
+    )
     upload = client.upload_file(source, "/remote/source.scs", timeout=34)
 
     assert download.status == ExecutionStatus.SUCCESS
+    assert recursive_download.status == ExecutionStatus.SUCCESS
     assert upload.status == ExecutionStatus.SUCCESS
-    assert tunnel.downloads == [("/remote/result.scs", download_target, 12)]
+    assert tunnel.downloads == [
+        ("/remote/result.scs", download_target, 12, False),
+        ("/remote/netlist", tmp_path / "downloads" / "netlist", 56, True),
+    ]
     assert tunnel.uploads == [(source, "/remote/source.scs", 34)]
     assert download_target.read_text(encoding="utf-8") == "downloaded through tunnel\n"

--- a/tests/test_schematic_netlist.py
+++ b/tests/test_schematic_netlist.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from virtuoso_bridge.virtuoso.schematic import (
+    SchematicOps,
+    export_schematic_netlist,
+    schematic_export_netlist_skill,
+)
+
+
+def test_schematic_export_netlist_skill_uses_ocean_netlister() -> None:
+    skill = schematic_export_netlist_skill(
+        "demoLib",
+        "tb_inv",
+        simulator="spectre",
+        recreate_all=False,
+    )
+
+    assert 'isCallable(\'createNetlist)' in skill
+    assert "simulator('spectre)" in skill
+    assert 'design("demoLib" "tb_inv" "schematic" "r")' in skill
+    assert "createNetlist(?recreateAll nil ?display nil)" in skill
+    assert "simplifyFilename(vbSourceFile)" in skill
+    assert "vbSourceFile" in skill
+
+
+def test_schematic_export_netlist_skill_escapes_skill_strings() -> None:
+    skill = schematic_export_netlist_skill(
+        'demo"Lib',
+        "tb\\inv",
+    )
+
+    assert 'design("demo\\"Lib" "tb\\\\inv" "schematic" "r")' in skill
+
+
+def test_schematic_export_netlist_skill_rejects_unsafe_simulator_symbol() -> None:
+    with pytest.raises(ValueError, match="simulator"):
+        schematic_export_netlist_skill(
+            "demoLib",
+            "tb_inv",
+            simulator='spectre") system("rm -rf /")',
+        )
+
+
+def test_export_schematic_netlist_downloads_generated_netlist_directory(tmp_path) -> None:
+    class Client:
+        skill: str | None = None
+        timeout: int | None = None
+        downloads: list[tuple[str, Path, int | None, bool]] = []
+
+        def execute_skill(self, skill: str, *, timeout: int):
+            self.skill = skill
+            self.timeout = timeout
+            return {"status": "success", "output": '"/tmp/generated/netlist/input.scs"'}
+
+        def download_file(
+            self,
+            remote_path: str,
+            local_path: Path,
+            *,
+            timeout: int | None = None,
+            recursive: bool = False,
+        ):
+            self.downloads.append((remote_path, local_path, timeout, recursive))
+            local_path.mkdir()
+            (local_path / "input.scs").write_text("simulator lang=spectre\n", encoding="utf-8")
+            return {"status": "success", "output": str(local_path)}
+
+    client = Client()
+    output_dir = tmp_path / "tb_inv_netlist"
+    result = export_schematic_netlist(
+        client,
+        "demoLib",
+        "tb_inv",
+        output_dir,
+        timeout=45,
+    )
+
+    assert result == {
+        "source_file": "/tmp/generated/netlist/input.scs",
+        "source_dir": "/tmp/generated/netlist",
+        "output_dir": str(output_dir),
+        "input_file": str(output_dir / "input.scs"),
+        "skill_result": {"status": "success", "output": '"/tmp/generated/netlist/input.scs"'},
+        "download_result": {"status": "success", "output": str(output_dir)},
+    }
+    assert client.timeout == 45
+    assert client.skill is not None
+    assert 'design("demoLib" "tb_inv" "schematic" "r")' in client.skill
+    assert len(client.downloads) == 1
+    remote_path, local_path, timeout, recursive = client.downloads[0]
+    assert remote_path == "/tmp/generated/netlist"
+    assert local_path.parent == tmp_path
+    assert local_path.name.startswith(".tb_inv_netlist.tmp-")
+    assert timeout == 45
+    assert recursive is True
+
+
+def test_schematic_ops_export_netlist_delegates_to_client(tmp_path) -> None:
+    class Client:
+        skill: str | None = None
+        timeout: int | None = None
+        downloads: list[tuple[str, Path, int | None, bool]] = []
+
+        def execute_skill(self, skill: str, *, timeout: int):
+            self.skill = skill
+            self.timeout = timeout
+            return {"status": "success", "output": '"/tmp/generated/netlist/input.scs"'}
+
+        def download_file(
+            self,
+            remote_path: str,
+            local_path: Path,
+            *,
+            timeout: int | None = None,
+            recursive: bool = False,
+        ):
+            self.downloads.append((remote_path, local_path, timeout, recursive))
+            local_path.mkdir()
+            (local_path / "input.scs").write_text("simulator lang=spectre\n", encoding="utf-8")
+            return {"status": "success", "output": str(local_path)}
+
+    client = Client()
+    output_dir = tmp_path / "tb_inv_netlist"
+    result = SchematicOps(client).export_netlist(
+        "demoLib",
+        "tb_inv",
+        output_dir,
+        timeout=75,
+    )
+
+    assert result["source_file"] == "/tmp/generated/netlist/input.scs"
+    assert result["input_file"] == str(output_dir / "input.scs")
+    assert client.timeout == 75
+    assert client.skill is not None
+    assert 'design("demoLib" "tb_inv" "schematic" "r")' in client.skill
+    assert len(client.downloads) == 1
+    remote_path, local_path, timeout, recursive = client.downloads[0]
+    assert remote_path == "/tmp/generated/netlist"
+    assert local_path.parent == tmp_path
+    assert local_path.name.startswith(".tb_inv_netlist.tmp-")
+    assert timeout == 75
+    assert recursive is True
+
+
+def test_export_schematic_netlist_replaces_existing_output_directory(tmp_path) -> None:
+    class Client:
+        def execute_skill(self, skill: str, *, timeout: int):
+            return {"status": "success", "output": '"/tmp/generated/netlist/input.scs"'}
+
+        def download_file(
+            self,
+            remote_path: str,
+            local_path: Path,
+            *,
+            timeout: int | None = None,
+            recursive: bool = False,
+        ):
+            assert recursive is True
+            assert not local_path.exists()
+            local_path.mkdir()
+            (local_path / "input.scs").write_text("simulator lang=spectre\n", encoding="utf-8")
+            return {"status": "success", "output": str(local_path)}
+
+    output_dir = tmp_path / "netlist"
+    output_dir.mkdir()
+    (output_dir / "stale.scs").write_text("old\n", encoding="utf-8")
+
+    result = export_schematic_netlist(Client(), "demoLib", "tb_inv", output_dir)
+
+    assert result["input_file"] == str(output_dir / "input.scs")
+    assert not (output_dir / "stale.scs").exists()
+    assert (output_dir / "input.scs").read_text(encoding="utf-8") == "simulator lang=spectre\n"
+
+
+def test_export_schematic_netlist_preserves_existing_output_on_download_failure(tmp_path) -> None:
+    class Client:
+        def execute_skill(self, skill: str, *, timeout: int):
+            return {"status": "success", "output": '"/tmp/generated/netlist/input.scs"'}
+
+        def download_file(
+            self,
+            remote_path: str,
+            local_path: Path,
+            *,
+            timeout: int | None = None,
+            recursive: bool = False,
+        ):
+            return {"status": "error", "errors": ["network failed"], "output": ""}
+
+    output_dir = tmp_path / "netlist"
+    output_dir.mkdir()
+    (output_dir / "input.scs").write_text("old netlist\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="network failed"):
+        export_schematic_netlist(Client(), "demoLib", "tb_inv", output_dir)
+
+    assert (output_dir / "input.scs").read_text(encoding="utf-8") == "old netlist\n"
+
+
+def test_export_schematic_netlist_requires_downloaded_input_file(tmp_path) -> None:
+    class Client:
+        def execute_skill(self, skill: str, *, timeout: int):
+            return {"status": "success", "output": '"/tmp/generated/netlist/input.scs"'}
+
+        def download_file(
+            self,
+            remote_path: str,
+            local_path: Path,
+            *,
+            timeout: int | None = None,
+            recursive: bool = False,
+        ):
+            local_path.mkdir()
+            (local_path / "ade_e.scs").write_text("simulatorOptions options\n", encoding="utf-8")
+            return {"status": "success", "output": str(local_path)}
+
+    with pytest.raises(RuntimeError, match="downloaded netlist is missing input.scs"):
+        export_schematic_netlist(Client(), "demoLib", "tb_inv", tmp_path / "netlist")
+
+
+def test_export_schematic_netlist_requires_input_scs_even_for_other_returned_file(tmp_path) -> None:
+    class Client:
+        def execute_skill(self, skill: str, *, timeout: int):
+            return {"status": "success", "output": '"/tmp/generated/netlist/other.scs"'}
+
+        def download_file(
+            self,
+            remote_path: str,
+            local_path: Path,
+            *,
+            timeout: int | None = None,
+            recursive: bool = False,
+        ):
+            local_path.mkdir()
+            (local_path / "other.scs").write_text("simulator lang=spectre\n", encoding="utf-8")
+            return {"status": "success", "output": str(local_path)}
+
+    with pytest.raises(RuntimeError, match="downloaded netlist is missing input.scs"):
+        export_schematic_netlist(Client(), "demoLib", "tb_inv", tmp_path / "netlist")
+
+
+def test_export_schematic_netlist_rejects_relative_source_path(tmp_path) -> None:
+    class Client:
+        def execute_skill(self, skill: str, *, timeout: int):
+            return {"status": "success", "output": '"input.scs"'}
+
+        def download_file(self, *args, **kwargs):
+            raise AssertionError("relative netlist path must not be downloaded")
+
+    with pytest.raises(RuntimeError, match="relative netlist path"):
+        export_schematic_netlist(Client(), "demoLib", "tb_inv", tmp_path / "netlist")
+
+
+def test_export_schematic_netlist_rejects_local_output_nested_under_source_dir(tmp_path) -> None:
+    from virtuoso_bridge import VirtuosoClient
+
+    source_dir = tmp_path / "generated" / "netlist"
+    source_dir.mkdir(parents=True)
+    (source_dir / "input.scs").write_text("simulator lang=spectre\n", encoding="utf-8")
+    client = VirtuosoClient.local()
+
+    def execute_skill(skill: str, *, timeout: int):
+        return {"status": "success", "output": f'"{source_dir.as_posix()}/input.scs"'}
+
+    client.execute_skill = execute_skill  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError, match="Refusing recursive copy with overlapping"):
+        export_schematic_netlist(
+            client,
+            "demoLib",
+            "tb_inv",
+            source_dir / "nested" / "export",
+        )
+
+    assert not (source_dir / "nested").exists()
+    assert (source_dir / "input.scs").read_text(encoding="utf-8") == "simulator lang=spectre\n"
+
+
+def test_export_schematic_netlist_restores_existing_output_when_final_replace_fails(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    class Client:
+        def execute_skill(self, skill: str, *, timeout: int):
+            return {"status": "success", "output": '"/tmp/generated/netlist/input.scs"'}
+
+        def download_file(
+            self,
+            remote_path: str,
+            local_path: Path,
+            *,
+            timeout: int | None = None,
+            recursive: bool = False,
+        ):
+            local_path.mkdir()
+            (local_path / "input.scs").write_text("new netlist\n", encoding="utf-8")
+            return {"status": "success", "output": str(local_path)}
+
+    original_rename = Path.rename
+
+    def fail_tmp_install(self: Path, target: Path):
+        if self.name.startswith(".netlist.tmp-"):
+            raise OSError("install failed")
+        return original_rename(self, target)
+
+    output_dir = tmp_path / "netlist"
+    output_dir.mkdir()
+    (output_dir / "input.scs").write_text("old netlist\n", encoding="utf-8")
+    monkeypatch.setattr(Path, "rename", fail_tmp_install)
+
+    with pytest.raises(OSError, match="install failed"):
+        export_schematic_netlist(Client(), "demoLib", "tb_inv", output_dir)
+
+    assert output_dir.is_dir()
+    assert (output_dir / "input.scs").read_text(encoding="utf-8") == "old netlist\n"

--- a/tests/test_ssh_control_master.py
+++ b/tests/test_ssh_control_master.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shlex
 from pathlib import Path
 
 import pytest
@@ -58,3 +59,209 @@ def test_remote_python_detection_error_includes_ssh_stderr() -> None:
     assert "No Python interpreter found on localhost" in msg
     assert "unix_listener" in msg
     assert "SSH return code: 255" in msg
+
+
+def test_recursive_download_quotes_remote_path_components(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr("virtuoso_bridge.transport.ssh.load_vb_env", lambda: None)
+    monkeypatch.setattr("virtuoso_bridge.transport.ssh._setup_command_log", lambda: None)
+
+    commands: list[list[str]] = []
+
+    class _Pipe:
+        def close(self) -> None:
+            pass
+
+    class _Stderr:
+        def read(self) -> bytes:
+            return b""
+
+    class _FakeProcess:
+        def __init__(self, cmd, **kwargs):
+            commands.append(cmd)
+            self.cmd = cmd
+            self.returncode = 0
+            self.stdout = _Pipe()
+            self.stderr = _Stderr()
+
+        def communicate(self, timeout=None):
+            return b"", b""
+
+        def wait(self, timeout=None):
+            self.returncode = 0
+            return 0
+
+        def kill(self) -> None:
+            self.returncode = -9
+
+    monkeypatch.setattr("virtuoso_bridge.transport.ssh.subprocess.Popen", _FakeProcess)
+
+    runner = SSHRunner(host="eda-host", user="designer", ssh_cmd="ssh", timeout=30)
+    remote_path = "/remote/sim's results/netlist dir"
+    result = runner.download(
+        remote_path,
+        tmp_path / "netlist dir",
+        recursive=True,
+    )
+
+    assert result.returncode == 0
+    remote_cmd = commands[0][-1]
+    inner_cmd = shlex.split(remote_cmd)[2]
+    assert f"p={shlex.quote(remote_path)}" in inner_cmd
+    assert 'cd "$p"' in inner_cmd
+    assert "tar czf - ." in inner_cmd
+    assert commands[1][:4] == [runner._tar_cmd, "xzf", "-", "-C"]
+    extract_dir = Path(commands[1][4])
+    assert extract_dir.parent == tmp_path
+    assert extract_dir.name.startswith(".netlist dir.tmp-")
+
+
+def test_recursive_download_extracts_into_requested_directory(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr("virtuoso_bridge.transport.ssh.load_vb_env", lambda: None)
+    monkeypatch.setattr("virtuoso_bridge.transport.ssh._setup_command_log", lambda: None)
+
+    commands: list[list[str]] = []
+
+    class _Pipe:
+        def close(self) -> None:
+            pass
+
+    class _Stderr:
+        def read(self) -> bytes:
+            return b""
+
+    class _FakeProcess:
+        def __init__(self, cmd, **kwargs):
+            commands.append(cmd)
+            self.cmd = cmd
+            self.returncode = 0
+            self.stdout = _Pipe()
+            self.stderr = _Stderr()
+
+        def communicate(self, timeout=None):
+            if self.cmd[0].endswith("tar"):
+                Path(self.cmd[4], "input.scs").write_text("new netlist\n", encoding="utf-8")
+            return b"", b""
+
+        def wait(self, timeout=None):
+            self.returncode = 0
+            return 0
+
+        def kill(self) -> None:
+            self.returncode = -9
+
+    monkeypatch.setattr("virtuoso_bridge.transport.ssh.subprocess.Popen", _FakeProcess)
+
+    runner = SSHRunner(host="eda-host", user="designer", ssh_cmd="ssh", timeout=30)
+    local_path = tmp_path / ".netlist.tmp-123"
+    result = runner.download(
+        "/remote/simulation/netlist",
+        local_path,
+        recursive=True,
+    )
+
+    assert result.returncode == 0
+    remote_cmd = commands[0][-1]
+    inner_cmd = shlex.split(remote_cmd)[2]
+    assert 'cd "$p"' in inner_cmd
+    assert "tar czf - ." in inner_cmd
+    assert commands[1][:4] == [runner._tar_cmd, "xzf", "-", "-C"]
+    extract_dir = Path(commands[1][4])
+    assert extract_dir.parent == tmp_path
+    assert extract_dir.name.startswith("..netlist.tmp-123.tmp-")
+    assert (local_path / "input.scs").read_text(encoding="utf-8") == "new netlist\n"
+
+
+def test_recursive_download_preserves_existing_target_when_tar_fails(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr("virtuoso_bridge.transport.ssh.load_vb_env", lambda: None)
+    monkeypatch.setattr("virtuoso_bridge.transport.ssh._setup_command_log", lambda: None)
+
+    class _Pipe:
+        def close(self) -> None:
+            pass
+
+    class _Stderr:
+        def read(self) -> bytes:
+            return b"remote ok"
+
+    class _FakeProcess:
+        def __init__(self, cmd, **kwargs):
+            self.cmd = cmd
+            self.stdout = _Pipe()
+            self.stderr = _Stderr()
+            self.returncode = 0 if "ssh" in cmd[0] else 2
+
+        def communicate(self, timeout=None):
+            return b"", b"tar failed"
+
+        def wait(self, timeout=None):
+            return self.returncode
+
+        def kill(self) -> None:
+            self.returncode = -9
+
+    monkeypatch.setattr("virtuoso_bridge.transport.ssh.subprocess.Popen", _FakeProcess)
+
+    existing = tmp_path / "netlist"
+    existing.mkdir()
+    (existing / "input.scs").write_text("old netlist\n", encoding="utf-8")
+    runner = SSHRunner(host="eda-host", user="designer", ssh_cmd="ssh", timeout=30)
+
+    result = runner.download("/remote/netlist", existing, recursive=True)
+
+    assert result.returncode != 0
+    assert (existing / "input.scs").read_text(encoding="utf-8") == "old netlist\n"
+
+
+def test_recursive_download_restores_existing_target_when_install_rename_fails(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setattr("virtuoso_bridge.transport.ssh.load_vb_env", lambda: None)
+    monkeypatch.setattr("virtuoso_bridge.transport.ssh._setup_command_log", lambda: None)
+
+    class _Pipe:
+        def close(self) -> None:
+            pass
+
+    class _Stderr:
+        def read(self) -> bytes:
+            return b""
+
+    class _FakeProcess:
+        def __init__(self, cmd, **kwargs):
+            self.cmd = cmd
+            self.stdout = _Pipe()
+            self.stderr = _Stderr()
+            self.returncode = 0
+
+        def communicate(self, timeout=None):
+            if self.cmd[0].endswith("tar"):
+                Path(self.cmd[4], "input.scs").write_text("new netlist\n", encoding="utf-8")
+            return b"", b""
+
+        def wait(self, timeout=None):
+            return self.returncode
+
+        def kill(self) -> None:
+            self.returncode = -9
+
+    original_rename = Path.rename
+
+    def fail_temp_install(self: Path, target: Path):
+        if self.name.startswith(".netlist.tmp-"):
+            raise OSError("install failed")
+        return original_rename(self, target)
+
+    monkeypatch.setattr("virtuoso_bridge.transport.ssh.subprocess.Popen", _FakeProcess)
+    monkeypatch.setattr(Path, "rename", fail_temp_install)
+
+    existing = tmp_path / "netlist"
+    existing.mkdir()
+    (existing / "input.scs").write_text("old netlist\n", encoding="utf-8")
+    runner = SSHRunner(host="eda-host", user="designer", ssh_cmd="ssh", timeout=30)
+
+    with pytest.raises(OSError, match="install failed"):
+        runner.download("/remote/netlist", existing, recursive=True)
+
+    assert existing.is_dir()
+    assert (existing / "input.scs").read_text(encoding="utf-8") == "old netlist\n"

--- a/tests/test_ssh_control_master.py
+++ b/tests/test_ssh_control_master.py
@@ -84,6 +84,8 @@ def test_recursive_download_quotes_remote_path_components(monkeypatch, tmp_path)
             self.stderr = _Stderr()
 
         def communicate(self, timeout=None):
+            if self.cmd[0].endswith("tar"):
+                Path(self.cmd[4], "netlist dir").mkdir()
             return b"", b""
 
         def wait(self, timeout=None):
@@ -107,8 +109,10 @@ def test_recursive_download_quotes_remote_path_components(monkeypatch, tmp_path)
     remote_cmd = commands[0][-1]
     inner_cmd = shlex.split(remote_cmd)[2]
     assert f"p={shlex.quote(remote_path)}" in inner_cmd
-    assert 'cd "$p"' in inner_cmd
-    assert "tar czf - ." in inner_cmd
+    assert 'd=$(dirname "$p")' in inner_cmd
+    assert 'b=$(basename "$p")' in inner_cmd
+    assert 'cd "$d"' in inner_cmd
+    assert 'tar czf - "$b"' in inner_cmd
     assert commands[1][:4] == [runner._tar_cmd, "xzf", "-", "-C"]
     extract_dir = Path(commands[1][4])
     assert extract_dir.parent == tmp_path
@@ -139,7 +143,9 @@ def test_recursive_download_extracts_into_requested_directory(monkeypatch, tmp_p
 
         def communicate(self, timeout=None):
             if self.cmd[0].endswith("tar"):
-                Path(self.cmd[4], "input.scs").write_text("new netlist\n", encoding="utf-8")
+                extracted = Path(self.cmd[4], "netlist")
+                extracted.mkdir()
+                (extracted / "input.scs").write_text("new netlist\n", encoding="utf-8")
             return b"", b""
 
         def wait(self, timeout=None):
@@ -162,8 +168,8 @@ def test_recursive_download_extracts_into_requested_directory(monkeypatch, tmp_p
     assert result.returncode == 0
     remote_cmd = commands[0][-1]
     inner_cmd = shlex.split(remote_cmd)[2]
-    assert 'cd "$p"' in inner_cmd
-    assert "tar czf - ." in inner_cmd
+    assert 'cd "$d"' in inner_cmd
+    assert 'tar czf - "$b"' in inner_cmd
     assert commands[1][:4] == [runner._tar_cmd, "xzf", "-", "-C"]
     extract_dir = Path(commands[1][4])
     assert extract_dir.parent == tmp_path
@@ -236,7 +242,9 @@ def test_recursive_download_restores_existing_target_when_install_rename_fails(
 
         def communicate(self, timeout=None):
             if self.cmd[0].endswith("tar"):
-                Path(self.cmd[4], "input.scs").write_text("new netlist\n", encoding="utf-8")
+                extracted = Path(self.cmd[4], "netlist")
+                extracted.mkdir()
+                (extracted / "input.scs").write_text("new netlist\n", encoding="utf-8")
             return b"", b""
 
         def wait(self, timeout=None):
@@ -248,7 +256,7 @@ def test_recursive_download_restores_existing_target_when_install_rename_fails(
     original_rename = Path.rename
 
     def fail_temp_install(self: Path, target: Path):
-        if self.name.startswith(".netlist.tmp-"):
+        if self.name == "netlist" and self.parent.name.startswith(".netlist.tmp-"):
             raise OSError("install failed")
         return original_rename(self, target)
 

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from virtuoso_bridge.models import ExecutionStatus, VirtuosoResult
+from virtuoso_bridge.wrappers import SanitizingClient
+
+
+def test_sanitizing_client_skips_recursive_directory_download(tmp_path) -> None:
+    class Client:
+        def download_file(self, remote_path, local_path, **kwargs):
+            local = Path(local_path)
+            local.mkdir()
+            (local / "input.scs").write_text("secret netlist\n", encoding="utf-8")
+            return VirtuosoResult(
+                status=ExecutionStatus.SUCCESS,
+                output=str(local),
+            )
+
+    local_path = tmp_path / "netlist"
+    client = SanitizingClient(Client(), lambda text: text.replace("secret", "REDACTED"))
+
+    result = client.download_file("/remote/netlist", local_path, recursive=True)
+
+    assert result.status == ExecutionStatus.SUCCESS
+    assert (local_path / "input.scs").read_text(encoding="utf-8") == "secret netlist\n"
+    assert not (tmp_path / "sanitized").exists()


### PR DESCRIPTION
Summary:
- Add `client.schematic.export_netlist(...)` for exporting a schematic cellview netlist package through Virtuoso `createNetlist()`.
- Download the full generated netlist directory so `input.scs` stays with support files such as `ade_e.scs`.
- Harden recursive local and SSH downloads around overlap checks, temp staging, backup/restore, and failure preservation.
- Keep wrapped directory downloads compatible with `SanitizingClient`.

Validation:
```bash
python -m pytest -q
python -m compileall -q src/virtuoso_bridge/virtuoso/schematic/__init__.py src/virtuoso_bridge/virtuoso/schematic/netlist.py src/virtuoso_bridge/virtuoso/basic/bridge.py src/virtuoso_bridge/transport/ssh.py src/virtuoso_bridge/wrappers.py tests/test_schematic_netlist.py tests/test_bridge_local_transfer.py tests/test_ssh_control_master.py tests/test_wrappers.py
git diff --check
```

Manual local Virtuoso/Spectre check:
- Exported `sinomos/inv` to `/tmp/vb_export_inv_pkg_final`.
- Confirmed the exported package contains `input.scs` and `ade_e.scs`.
- Ran Spectre on the exported `input.scs`; Spectre completed with 0 errors.