### PR TITLE
Add symbol editing and readback helpers

### DIFF
--- a/src/virtuoso_bridge/virtuoso/__init__.py
+++ b/src/virtuoso_bridge/virtuoso/__init__.py
@@ -3,6 +3,7 @@
 Subpackages:
   basic      – VirtuosoClient (SKILL execution over TCP)
   schematic  – SKILL builders for schematic editing
+  symbol     – SKILL builders for symbol editing
   layout     – SKILL builders for layout editing
   maestro    – ADE Assembler / Explorer setup + simulation reading
 

--- a/src/virtuoso_bridge/virtuoso/basic/bridge.py
+++ b/src/virtuoso_bridge/virtuoso/basic/bridge.py
@@ -27,6 +27,7 @@ from virtuoso_bridge.virtuoso.ops import (
 )
 from virtuoso_bridge.virtuoso.layout import LayoutOps
 from virtuoso_bridge.virtuoso.schematic import SchematicOps
+from virtuoso_bridge.virtuoso.symbol import SymbolOps
 
 logger = logging.getLogger(__name__)
 
@@ -88,6 +89,7 @@ class VirtuosoClient(VirtuosoInterface):
         self._log_to_ciw = log_to_ciw
         self.layout = LayoutOps(self)
         self.schematic = SchematicOps(self)
+        self.symbol = SymbolOps(self)
         self._il_upload_cache: dict[str, tuple[str, str]] = {}
         # For connect retry when jump host adds latency
         self._has_jump_host = (

--- a/src/virtuoso_bridge/virtuoso/editor.py
+++ b/src/virtuoso_bridge/virtuoso/editor.py
@@ -1,0 +1,24 @@
+"""Shared helpers for Virtuoso edit context managers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from virtuoso_bridge.models import ExecutionStatus, VirtuosoResult
+
+
+def ensure_operation_response(response: Any, *, context: str) -> None:
+    """Raise a consistent error when an edit batch fails."""
+    if isinstance(response, VirtuosoResult):
+        if response.status != ExecutionStatus.SUCCESS:
+            errors = response.errors or ["unknown failure"]
+            raise RuntimeError(f"{context} failed: {errors[0]}")
+        return
+
+    if not response.get("ok", False):
+        raise RuntimeError(f"{context} failed: {response.get('error', 'request failed')}")
+
+    result = response.get("result", {})
+    if result.get("status") != "success":
+        errors = result.get("errors") or [result.get("status", "unknown failure")]
+        raise RuntimeError(f"{context} failed: {errors[0]}")

--- a/src/virtuoso_bridge/virtuoso/layout/editor.py
+++ b/src/virtuoso_bridge/virtuoso/layout/editor.py
@@ -12,8 +12,9 @@ Usage:
 
 from __future__ import annotations
 
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
+from virtuoso_bridge.virtuoso.editor import ensure_operation_response
 from virtuoso_bridge.virtuoso.ops import (
     close_current_cellview,
     save_current_cellview,
@@ -24,21 +25,6 @@ from virtuoso_bridge.virtuoso.layout.ops import (
 
 if TYPE_CHECKING:
     from virtuoso_bridge import VirtuosoClient
-
-
-def _ensure_operation_response(response: Any, *, context: str) -> None:
-    from virtuoso_bridge.models import ExecutionStatus, VirtuosoResult
-    if isinstance(response, VirtuosoResult):
-        if response.status != ExecutionStatus.SUCCESS:
-            errors = response.errors or ["unknown failure"]
-            raise RuntimeError(f"{context} failed: {errors[0]}")
-        return
-    if not response.get("ok", False):
-        raise RuntimeError(f"{context} failed: {response.get('error', 'request failed')}")
-    result = response.get("result", {})
-    if result.get("status") != "success":
-        errors = result.get("errors") or [result.get("status", "unknown failure")]
-        raise RuntimeError(f"{context} failed: {errors[0]}")
 
 
 class LayoutEditor:
@@ -81,4 +67,4 @@ class LayoutEditor:
         if exc_type is None:
             self.commands.append(save_current_cellview())
             response = self.client.execute_operations(self.commands, timeout=self.timeout)
-            _ensure_operation_response(response, context="layout edit")
+            ensure_operation_response(response, context="layout edit")

--- a/src/virtuoso_bridge/virtuoso/maestro/reader/_parse_skill.py
+++ b/src/virtuoso_bridge/virtuoso/maestro/reader/_parse_skill.py
@@ -1,149 +1,17 @@
-"""Light SKILL output tokenizer used by ``bundle.py`` to slot the
-single big SKILL response into per-call segments, plus a small
-s-expression decoder for ``read_results`` (which returns numeric
-post-simulation values that callers actively compute on).
-
-Pure functions — no I/O.  Deliberately *not* a full SKILL alist→dict
-parser for setup data: snapshot output keeps SKILL setup as raw text
-in ``state_from_skill.txt``; consumers read it directly.
-"""
+"""Compatibility wrappers for shared SKILL output parsing helpers."""
 
 from __future__ import annotations
 
-import re
+from virtuoso_bridge.virtuoso.skill_output import (
+    parse_sexpr as _parse_sexpr,
+    parse_skill_str_list as _parse_skill_str_list,
+    scan_top_groups as _scan_top_groups,
+    tokenize_top_level as _tokenize_top_level,
+)
 
-
-def _parse_skill_str_list(raw: str) -> list[str]:
-    """Parse a flat SKILL list of strings like ``("a" "b" "c")`` →
-    ``['a', 'b', 'c']``.  Returns ``[]`` on empty / ``nil`` / no quotes."""
-    if not raw:
-        return []
-    s = raw.strip()
-    if s in ("", "nil"):
-        return []
-    return re.findall(r'"([^"]*)"', s)
-
-
-def _tokenize_top_level(body: str, *,
-                         include_groups: bool = True,
-                         include_strings: bool = False,
-                         include_atoms: bool = False,
-                         max_tokens: int | None = None) -> list[str]:
-    """Split ``body`` into top-level SKILL tokens, respecting quotes/parens.
-
-    A token is one of:
-      - a balanced ``(...)`` group (always)
-      - a double-quoted ``"..."`` string (yielded if ``include_strings``)
-      - a bare atom — a whitespace-delimited run containing no ``(``/``)`` —
-        (yielded if ``include_atoms``)
-
-    Quote and paren balancing is tracked across the whole scan; neither
-    escapes nor nested quotes fool us.  Stops early once ``max_tokens``
-    have been emitted.
-    """
-    tokens: list[str] = []
-    i, n = 0, len(body)
-    while i < n and (max_tokens is None or len(tokens) < max_tokens):
-        ch = body[i]
-        if ch.isspace():
-            i += 1
-            continue
-        if ch == '"':
-            j = i + 1
-            while j < n and not (body[j] == '"' and body[j - 1] != "\\"):
-                j += 1
-            tok = body[i:j + 1]
-            if include_strings:
-                tokens.append(tok)
-            i = j + 1
-            continue
-        if ch == "(":
-            depth = 1
-            j = i + 1
-            in_str = False
-            while j < n and depth:
-                c = body[j]
-                if in_str:
-                    if c == '"' and body[j - 1] != "\\":
-                        in_str = False
-                elif c == '"':
-                    in_str = True
-                elif c == "(":
-                    depth += 1
-                elif c == ")":
-                    depth -= 1
-                j += 1
-            tok = body[i:j]
-            if include_groups:
-                tokens.append(tok)
-            i = j
-            continue
-        # Bare atom: run until whitespace or paren.
-        j = i
-        while j < n and not body[j].isspace() and body[j] not in "()":
-            j += 1
-        if include_atoms:
-            tokens.append(body[i:j])
-        i = j
-    return tokens
-
-
-def _scan_top_groups(body: str) -> list[str]:
-    """Split at top-level parens: ``(..) (..) (..)`` → list of ``(..)`` strings."""
-    return _tokenize_top_level(body, include_groups=True,
-                                include_strings=False, include_atoms=False)
-
-
-def _parse_sexpr(tok: str):
-    """Parse one SKILL atom or list into Python.
-
-    ``"x"`` → ``"x"`` (unescaped), ``nil`` → ``None``, ``t`` → ``True``,
-    ``(a b c)`` → list[...], bare number/symbol → original string.
-
-    Used by :func:`runs.read_results` to decode post-simulation result
-    values into numeric/string atoms that callers compute on.
-    """
-    tok = (tok or "").strip()
-    if not tok:
-        return None
-    if tok == "nil":
-        return None
-    if tok == "t":
-        return True
-    if tok.startswith('"') and tok.endswith('"') and len(tok) >= 2:
-        return tok[1:-1].replace('\\"', '"').replace("\\\\", "\\")
-    if tok.startswith("(") and tok.endswith(")"):
-        inner = tok[1:-1]
-        items: list = []
-        i = 0
-        n = len(inner)
-        while i < n:
-            while i < n and inner[i].isspace():
-                i += 1
-            if i >= n:
-                break
-            if inner[i] == '"':
-                j = i + 1
-                while j < n and not (inner[j] == '"' and inner[j - 1] != "\\"):
-                    j += 1
-                items.append(_parse_sexpr(inner[i:j + 1]))
-                i = j + 1
-            elif inner[i] == "(":
-                depth = 1
-                j = i + 1
-                while j < n and depth:
-                    if inner[j] == "(":
-                        depth += 1
-                    elif inner[j] == ")":
-                        depth -= 1
-                    j += 1
-                items.append(_parse_sexpr(inner[i:j]))
-                i = j
-            else:
-                j = i
-                while j < n and not inner[j].isspace() and inner[j] not in "()":
-                    j += 1
-                items.append(_parse_sexpr(inner[i:j]))
-                i = j
-        return items
-    return tok
+__all__ = [
+    "_parse_skill_str_list",
+    "_tokenize_top_level",
+    "_scan_top_groups",
+    "_parse_sexpr",
+]

--- a/src/virtuoso_bridge/virtuoso/schematic/editor.py
+++ b/src/virtuoso_bridge/virtuoso/schematic/editor.py
@@ -15,8 +15,9 @@ Usage:
 
 from __future__ import annotations
 
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
+from virtuoso_bridge.virtuoso.editor import ensure_operation_response
 from virtuoso_bridge.virtuoso.ops import open_cell_view, save_current_cellview
 from virtuoso_bridge.virtuoso.schematic.ops import (
     schematic_check,
@@ -25,21 +26,6 @@ from virtuoso_bridge.virtuoso.schematic.ops import (
 
 if TYPE_CHECKING:
     from virtuoso_bridge import VirtuosoClient
-
-
-def _ensure_operation_response(response: Any, *, context: str) -> None:
-    from virtuoso_bridge.models import ExecutionStatus, VirtuosoResult
-    if isinstance(response, VirtuosoResult):
-        if response.status != ExecutionStatus.SUCCESS:
-            errors = response.errors or ["unknown failure"]
-            raise RuntimeError(f"{context} failed: {errors[0]}")
-        return
-    if not response.get("ok", False):
-        raise RuntimeError(f"{context} failed: {response.get('error', 'request failed')}")
-    result = response.get("result", {})
-    if result.get("status") != "success":
-        errors = result.get("errors") or [result.get("status", "unknown failure")]
-        raise RuntimeError(f"{context} failed: {errors[0]}")
 
 
 class SchematicEditor:
@@ -88,4 +74,4 @@ class SchematicEditor:
             self.commands.append(schematic_check())
             self.commands.append(save_current_cellview())
             response = self.client.execute_operations(self.commands, timeout=self.timeout)
-            _ensure_operation_response(response, context="schematic edit")
+            ensure_operation_response(response, context="schematic edit")

--- a/src/virtuoso_bridge/virtuoso/skill_output.py
+++ b/src/virtuoso_bridge/virtuoso/skill_output.py
@@ -1,0 +1,165 @@
+"""Utilities for decoding SKILL values printed with ``%L``."""
+
+from __future__ import annotations
+
+
+def parse_skill_str_list(raw: str) -> list[str]:
+    """Parse SKILL string values from a list or bare top-level strings."""
+    text = (raw or "").strip()
+    if not text or text == "nil":
+        return []
+    values: list[str] = []
+    for token in tokenize_top_level(
+        text,
+        include_groups=True,
+        include_strings=True,
+        include_atoms=False,
+    ):
+        values.extend(_collect_strings(parse_sexpr(token)))
+    return values
+
+
+def tokenize_top_level(
+    body: str,
+    *,
+    include_groups: bool = True,
+    include_strings: bool = False,
+    include_atoms: bool = False,
+    max_tokens: int | None = None,
+) -> list[str]:
+    """Split ``body`` into top-level SKILL tokens, respecting strings/parens."""
+    tokens: list[str] = []
+    i, n = 0, len(body)
+    while i < n and (max_tokens is None or len(tokens) < max_tokens):
+        ch = body[i]
+        if ch.isspace():
+            i += 1
+            continue
+        if ch == '"':
+            j = _scan_string(body, i)
+            if include_strings:
+                tokens.append(body[i:j])
+            i = j
+            continue
+        if ch == "(":
+            j = _scan_group(body, i)
+            if include_groups:
+                tokens.append(body[i:j])
+            i = j
+            continue
+        j = i
+        while j < n and not body[j].isspace() and body[j] not in "()":
+            j += 1
+        if include_atoms:
+            tokens.append(body[i:j])
+        i = j
+    return tokens
+
+
+def scan_top_groups(body: str) -> list[str]:
+    """Split top-level parenthesized groups: ``(..) (..)`` -> list of groups."""
+    return tokenize_top_level(
+        body,
+        include_groups=True,
+        include_strings=False,
+        include_atoms=False,
+    )
+
+
+def parse_sexpr(tok: str):
+    """Parse one SKILL atom or list into Python values.
+
+    Strings are unescaped, ``nil`` maps to ``None``, ``t`` maps to ``True``,
+    lists map recursively, and other atoms are returned as strings.
+    """
+    tok = (tok or "").strip()
+    if not tok:
+        return None
+    if tok == "nil":
+        return None
+    if tok == "t":
+        return True
+    if tok.startswith('"') and tok.endswith('"') and len(tok) >= 2:
+        return _unescape_skill_string(tok[1:-1])
+    if tok.startswith("(") and tok.endswith(")"):
+        inner = tok[1:-1]
+        return [
+            parse_sexpr(token)
+            for token in tokenize_top_level(
+                inner,
+                include_groups=True,
+                include_strings=True,
+                include_atoms=True,
+            )
+        ]
+    return tok
+
+
+def _scan_string(text: str, start: int) -> int:
+    i = start + 1
+    while i < len(text):
+        if text[i] == '"' and not _is_escaped(text, i):
+            return i + 1
+        i += 1
+    return len(text)
+
+
+def _scan_group(text: str, start: int) -> int:
+    depth = 1
+    i = start + 1
+    in_str = False
+    while i < len(text) and depth:
+        ch = text[i]
+        if in_str:
+            if ch == '"' and not _is_escaped(text, i):
+                in_str = False
+        elif ch == '"':
+            in_str = True
+        elif ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        i += 1
+    return i
+
+
+def _is_escaped(text: str, index: int) -> bool:
+    slash_count = 0
+    i = index - 1
+    while i >= 0 and text[i] == "\\":
+        slash_count += 1
+        i -= 1
+    return slash_count % 2 == 1
+
+
+def _unescape_skill_string(value: str) -> str:
+    chars: list[str] = []
+    i = 0
+    escapes = {
+        "n": "\n",
+        "t": "\t",
+        "r": "\r",
+        '"': '"',
+        "\\": "\\",
+    }
+    while i < len(value):
+        ch = value[i]
+        if ch == "\\" and i + 1 < len(value):
+            nxt = value[i + 1]
+            chars.append(escapes.get(nxt, "\\" + nxt))
+            i += 2
+            continue
+        chars.append(ch)
+        i += 1
+    return "".join(chars)
+
+
+def _collect_strings(value) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        values: list[str] = []
+        for item in value:
+            values.extend(_collect_strings(item))
+        return values
+    return []

--- a/src/virtuoso_bridge/virtuoso/symbol/__init__.py
+++ b/src/virtuoso_bridge/virtuoso/symbol/__init__.py
@@ -1,0 +1,87 @@
+"""SKILL builders for Cadence Virtuoso symbol editing."""
+
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING
+
+from virtuoso_bridge.virtuoso.symbol.editor import SymbolEditor
+from virtuoso_bridge.virtuoso.symbol.ops import (
+    symbol_check,
+    symbol_create_ellipse,
+    symbol_create_label,
+    symbol_create_line,
+    symbol_create_pin,
+    symbol_create_polygon,
+    symbol_create_rect,
+    symbol_set_term_order,
+)
+from virtuoso_bridge.virtuoso.symbol.reader import (
+    parse_symbol_ports_output,
+    read_symbol_ports,
+    symbol_read_ports_skill,
+)
+
+if TYPE_CHECKING:
+    from virtuoso_bridge import VirtuosoClient
+
+
+class SymbolOps:
+    """Attached to VirtuosoClient as ``client.symbol``."""
+
+    def __init__(self, owner: VirtuosoClient) -> None:
+        self._owner = owner
+
+    def edit(
+        self,
+        lib: str,
+        cell: str,
+        view: str = "symbol",
+        view_type: str = "schematicSymbol",
+        mode: str = "w",
+        timeout: int = 60,
+    ) -> SymbolEditor:
+        """Return a SymbolEditor context manager."""
+        return SymbolEditor(
+            self._owner,
+            lib,
+            cell,
+            view=view,
+            view_type=view_type,
+            mode=mode,
+            timeout=timeout,
+        )
+
+    def read_ports(
+        self,
+        lib: str,
+        cell: str,
+        view: str = "symbol",
+        view_type: str = "schematicSymbol",
+        timeout: int = 30,
+    ) -> dict[str, Any]:
+        """Read symbol terminals, labels, and term order."""
+        return read_symbol_ports(
+            self._owner,
+            lib,
+            cell,
+            view=view,
+            view_type=view_type,
+            timeout=timeout,
+        )
+
+
+__all__ = [
+    "SymbolOps",
+    "SymbolEditor",
+    "symbol_create_line",
+    "symbol_create_rect",
+    "symbol_create_polygon",
+    "symbol_create_ellipse",
+    "symbol_create_label",
+    "symbol_create_pin",
+    "symbol_set_term_order",
+    "symbol_check",
+    "symbol_read_ports_skill",
+    "parse_symbol_ports_output",
+    "read_symbol_ports",
+]

--- a/src/virtuoso_bridge/virtuoso/symbol/editor.py
+++ b/src/virtuoso_bridge/virtuoso/symbol/editor.py
@@ -1,0 +1,58 @@
+"""Symbol editor — context manager for batch SKILL operations."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from virtuoso_bridge.virtuoso.editor import ensure_operation_response
+from virtuoso_bridge.virtuoso.ops import open_cell_view, save_current_cellview
+from virtuoso_bridge.virtuoso.symbol.ops import symbol_check
+
+if TYPE_CHECKING:
+    from virtuoso_bridge import VirtuosoClient
+
+
+class SymbolEditor:
+    """Context manager: open symbol cellview → accumulate commands → check → save."""
+
+    def __init__(
+        self,
+        client: VirtuosoClient,
+        lib: str,
+        cell: str,
+        view: str = "symbol",
+        view_type: str = "schematicSymbol",
+        mode: str = "w",
+        timeout: int = 60,
+    ) -> None:
+        self.client = client
+        self.lib = lib
+        self.cell = cell
+        self.view = view
+        self.view_type = view_type
+        self.mode = mode
+        self.timeout = timeout
+        self.commands: list[str] = []
+
+    def __enter__(self) -> SymbolEditor:
+        self.commands.append(
+            open_cell_view(
+                self.lib,
+                self.cell,
+                view=self.view,
+                view_type=self.view_type,
+                mode=self.mode,
+            )
+        )
+        return self
+
+    def add(self, skill_cmd: str) -> None:
+        """Append a SKILL command to the batch."""
+        self.commands.append(skill_cmd)
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        if exc_type is None:
+            self.commands.append(symbol_check())
+            self.commands.append(save_current_cellview())
+            response = self.client.execute_operations(self.commands, timeout=self.timeout)
+            ensure_operation_response(response, context="symbol edit")

--- a/src/virtuoso_bridge/virtuoso/symbol/ops.py
+++ b/src/virtuoso_bridge/virtuoso/symbol/ops.py
@@ -1,0 +1,181 @@
+"""SKILL operation builders for symbol editing."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from virtuoso_bridge.virtuoso.ops import (
+    escape_skill_string,
+    skill_point,
+    skill_point_list,
+)
+
+
+def _lpp_expr(layer: str, purpose: str) -> str:
+    """Render a layer-purpose pair."""
+    return f'list("{escape_skill_string(layer)}" "{escape_skill_string(purpose)}")'
+
+
+def _bbox_expr(x0: float, y0: float, x1: float, y1: float) -> str:
+    """Render a bounding box as a nested SKILL list."""
+    return f"list(list({x0:g} {y0:g}) list({x1:g} {y1:g}))"
+
+
+def _string_list_expr(values: Iterable[str]) -> str:
+    """Render a list of SKILL string literals."""
+    rendered = " ".join(f'"{escape_skill_string(value)}"' for value in values)
+    return f"list({rendered})"
+
+
+def symbol_create_line(
+    layer: str,
+    purpose: str,
+    points: Iterable[tuple[float, float]],
+    *,
+    cv_expr: str = "cv",
+) -> str:
+    """Build SKILL to create a symbol line."""
+    return f"dbCreateLine({cv_expr} {_lpp_expr(layer, purpose)} {skill_point_list(points)})"
+
+
+def symbol_create_rect(
+    layer: str,
+    purpose: str,
+    x0: float,
+    y0: float,
+    x1: float,
+    y1: float,
+    *,
+    cv_expr: str = "cv",
+) -> str:
+    """Build SKILL to create a symbol rectangle."""
+    return f"dbCreateRect({cv_expr} {_lpp_expr(layer, purpose)} {_bbox_expr(x0, y0, x1, y1)})"
+
+
+def symbol_create_polygon(
+    layer: str,
+    purpose: str,
+    points: Iterable[tuple[float, float]],
+    *,
+    cv_expr: str = "cv",
+) -> str:
+    """Build SKILL to create a symbol polygon."""
+    return f"dbCreatePolygon({cv_expr} {_lpp_expr(layer, purpose)} {skill_point_list(points)})"
+
+
+def symbol_create_ellipse(
+    layer: str,
+    purpose: str,
+    x0: float,
+    y0: float,
+    x1: float,
+    y1: float,
+    *,
+    cv_expr: str = "cv",
+) -> str:
+    """Build SKILL to create a symbol ellipse."""
+    return f"dbCreateEllipse({cv_expr} {_lpp_expr(layer, purpose)} {_bbox_expr(x0, y0, x1, y1)})"
+
+
+def symbol_create_label(
+    layer: str,
+    purpose: str,
+    x: float,
+    y: float,
+    text: str,
+    justification: str,
+    rotation: str,
+    font: str,
+    height: float,
+    *,
+    cv_expr: str = "cv",
+    label_type: str | None = None,
+) -> str:
+    """Build SKILL to create a symbol label."""
+    create_label = (
+        f"dbCreateLabel({cv_expr} {_lpp_expr(layer, purpose)} {skill_point(x, y)} "
+        f'"{escape_skill_string(text)}" '
+        f'"{escape_skill_string(justification)}" '
+        f'"{escape_skill_string(rotation)}" '
+        f'"{escape_skill_string(font)}" {height:g})'
+    )
+    if label_type is None:
+        return create_label
+    return (
+        "let((rbLabel) "
+        f"rbLabel = {create_label} "
+        f'when(rbLabel rbLabel~>labelType = "{escape_skill_string(label_type)}") '
+        "rbLabel)"
+    )
+
+
+def symbol_create_pin(
+    pin_name: str,
+    x: float,
+    y: float,
+    *,
+    direction: str = "inputOutput",
+    half_size: float = 0.0625,
+    cv_expr: str = "cv",
+    label: bool = True,
+    label_x: float | None = None,
+    label_y: float | None = None,
+    label_justification: str = "centerLeft",
+    label_rotation: str = "R0",
+    label_font: str = "stick",
+    label_height: float = 0.0625,
+) -> str:
+    """Build SKILL to create a symbol terminal pin.
+
+    The pin is represented as a terminal/net pair plus a small rectangle on
+    ``pin/drawing``. An optional text label is placed on the same layer.
+    """
+    escaped_pin = escape_skill_string(pin_name)
+    escaped_direction = escape_skill_string(direction)
+    x0 = x - half_size
+    y0 = y - half_size
+    x1 = x + half_size
+    y1 = y + half_size
+    effective_label_x = x if label_x is None else label_x
+    effective_label_y = y if label_y is None else label_y
+
+    label_expr = ""
+    label_decl = ""
+    if label:
+        label_decl = " rbLabel"
+        label_expr = (
+            f"rbLabel = dbCreateLabel({cv_expr} {_lpp_expr('pin', 'drawing')} "
+            f"{skill_point(effective_label_x, effective_label_y)} "
+            f'"{escaped_pin}" '
+            f'"{escape_skill_string(label_justification)}" '
+            f'"{escape_skill_string(label_rotation)}" '
+            f'"{escape_skill_string(label_font)}" {label_height:g}) '
+            'unless(rbLabel error("pin label not created")) '
+        )
+
+    return (
+        f"let((rbExistingTerm rbNet rbTerm rbRect rbPin{label_decl}) "
+        f'rbExistingTerm = car(setof(x {cv_expr}~>terminals x~>name == "{escaped_pin}")) '
+        'when(rbExistingTerm error("terminal already exists")) '
+        f'rbNet = car(setof(x {cv_expr}~>nets x~>name == "{escaped_pin}")) '
+        f'unless(rbNet rbNet = dbCreateNet({cv_expr} "{escaped_pin}")) '
+        'unless(rbNet error("net not found")) '
+        f'rbTerm = dbCreateTerm(rbNet "{escaped_pin}" "{escaped_direction}") '
+        'unless(rbTerm error("term not created")) '
+        f"rbRect = dbCreateRect({cv_expr} {_lpp_expr('pin', 'drawing')} {_bbox_expr(x0, y0, x1, y1)}) "
+        'unless(rbRect error("pin rectangle not created")) '
+        f'rbPin = dbCreatePin(rbNet rbRect "{escaped_pin}" rbTerm) '
+        'unless(rbPin error("pin not created")) '
+        f"{label_expr}"
+        "rbPin)"
+    )
+
+
+def symbol_set_term_order(term_names: Iterable[str], *, cv_expr: str = "cv") -> str:
+    """Build SKILL to set the symbol terminal order."""
+    return f"{cv_expr}~>termOrder = {_string_list_expr(term_names)}"
+
+
+def symbol_check(*, cv_expr: str = "cv") -> str:
+    """Build SKILL to run symbol/schematic checking."""
+    return f"schCheck({cv_expr})"

--- a/src/virtuoso_bridge/virtuoso/symbol/reader.py
+++ b/src/virtuoso_bridge/virtuoso/symbol/reader.py
@@ -1,0 +1,186 @@
+"""Read-only helpers for symbol cellviews."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from virtuoso_bridge.virtuoso.ops import open_cell_view
+from virtuoso_bridge.virtuoso.skill_output import parse_sexpr
+
+
+def symbol_read_ports_skill(
+    lib: str,
+    cell: str,
+    *,
+    view: str = "symbol",
+    view_type: str = "schematicSymbol",
+) -> str:
+    """Build SKILL to report symbol terminals, labels, and term order."""
+    open_expr = open_cell_view(lib, cell, view=view, view_type=view_type, mode="r")
+    return (
+        "let((cv term pin fig label bbox xy result) "
+        f"{open_expr} "
+        'unless(cv error("open symbol failed")) '
+        "result = nil "
+        "foreach(term cv~>terminals "
+        "pin = car(term~>pins) "
+        "fig = nil "
+        "when(pin "
+        "fig = car(errset(pin~>fig nil)) "
+        "unless(fig fig = car(errset(car(pin~>figs) nil)))) "
+        "bbox = nil "
+        "when(fig && fig~>bBox "
+        "bbox = list(list(xCoord(car(fig~>bBox)) yCoord(car(fig~>bBox))) "
+        "list(xCoord(cadr(fig~>bBox)) yCoord(cadr(fig~>bBox))))) "
+        'result = cons(list("term" term~>name if(term~>direction term~>direction "") '
+        "if(term~>numBits term~>numBits 1) bbox) result)) "
+        "foreach(label cv~>shapes "
+        'when(label~>objType == "label" '
+        "xy = nil "
+        "when(label~>xy xy = list(xCoord(label~>xy) yCoord(label~>xy))) "
+        'result = cons(list("label" if(label~>theLabel label~>theLabel "") '
+        'if(label~>labelType label~>labelType "") xy) result))) '
+        'result = cons(list("termOrder" cv~>termOrder) result) '
+        "dbClose(cv) "
+        "reverse(result))"
+    )
+
+
+def parse_symbol_ports_output(output: str) -> dict[str, Any]:
+    """Parse ``symbol_read_ports_skill`` text output."""
+    text = (output or "").strip()
+    if not text.startswith("("):
+        raise ValueError("symbol readback output must be a structured SKILL list")
+    return _parse_symbol_ports_records(text)
+
+
+def _parse_symbol_ports_records(output: str) -> dict[str, Any]:
+    result: dict[str, Any] = {"terms": [], "labels": [], "termOrder": []}
+    parsed = parse_sexpr(output)
+    if not isinstance(parsed, list):
+        return result
+
+    for record in parsed:
+        if not isinstance(record, list) or not record:
+            continue
+        kind = _string_value(record[0])
+        if kind == "term" and len(record) >= 5:
+            result["terms"].append(
+                {
+                    "name": _string_value(record[1]),
+                    "direction": _string_value(record[2]),
+                    "numBits": _int_value(record[3], default=1),
+                    "bbox": _bbox_value(record[4]),
+                }
+            )
+        elif kind == "label" and len(record) >= 4:
+            result["labels"].append(
+                {
+                    "text": _string_value(record[1]),
+                    "labelType": _string_value(record[2]),
+                    "xy": _point_value(record[3]),
+                }
+            )
+        elif kind == "termOrder" and len(record) >= 2:
+            order = record[1] if isinstance(record[1], list) else []
+            result["termOrder"] = [_string_value(item) for item in order]
+    return result
+
+
+def read_symbol_ports(
+    client: Any,
+    lib: str,
+    cell: str,
+    *,
+    view: str = "symbol",
+    view_type: str = "schematicSymbol",
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """Read symbol terminals, labels, and term order."""
+    response = client.execute_skill(
+        symbol_read_ports_skill(lib, cell, view=view, view_type=view_type),
+        timeout=timeout,
+    )
+    errors, status, output = _response_fields(response)
+    _raise_for_symbol_read_error(errors, status, output, lib=lib, cell=cell)
+    raw = (output or "").strip()
+    if raw.strip() == "ERROR":
+        raise RuntimeError(f"read_symbol_ports could not open symbol {lib}/{cell}")
+    if not raw.strip():
+        raise RuntimeError(f"read_symbol_ports returned empty output for {lib}/{cell}")
+    return parse_symbol_ports_output(raw)
+
+
+def _string_value(value: Any) -> str:
+    if value is None:
+        return ""
+    if value is True:
+        return "t"
+    return str(value)
+
+
+def _int_value(value: Any, *, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _float_value(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _point_value(value: Any) -> list[float] | None:
+    if value is None:
+        return None
+    if isinstance(value, list):
+        return [_float_value(item) for item in value[:2]] if len(value) >= 2 else None
+    return None
+
+
+def _bbox_value(value: Any) -> list[list[float]] | None:
+    if not isinstance(value, list) or len(value) < 2:
+        return None
+    points = [_point_value(point) for point in value[:2]]
+    if any(point is None for point in points):
+        return None
+    return [point for point in points if point is not None]
+
+
+def _response_fields(response: Any) -> tuple[Any, Any, str]:
+    if isinstance(response, dict):
+        result = response.get("result") if isinstance(response.get("result"), dict) else {}
+        errors = response.get("errors") or result.get("errors")
+        status = response.get("status") or result.get("status")
+        output = response.get("output")
+        if output is None:
+            output = result.get("output", "")
+        if response.get("ok") is False and not errors:
+            errors = [response.get("error") or result.get("error") or "request failed"]
+        return errors, status, output or ""
+
+    return (
+        getattr(response, "errors", None),
+        getattr(response, "status", None),
+        getattr(response, "output", "") or "",
+    )
+
+
+def _raise_for_symbol_read_error(
+    errors: Any,
+    status: Any,
+    output: Any,
+    *,
+    lib: str,
+    cell: str,
+) -> None:
+    if errors:
+        raise RuntimeError(f"read_symbol_ports SKILL error: {errors[0]}")
+
+    status_value = getattr(status, "value", status)
+    if status_value is not None and str(status_value).lower() not in {"success", "ok"}:
+        detail = output or f"status={status_value}"
+        raise RuntimeError(f"read_symbol_ports SKILL error for {lib}/{cell}: {detail}")

--- a/tests/test_skill_output.py
+++ b/tests/test_skill_output.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from virtuoso_bridge.virtuoso.maestro.reader._parse_skill import (
+    _parse_skill_str_list as maestro_parse_skill_str_list,
+)
+from virtuoso_bridge.virtuoso.maestro.reader.bundle import _unwrap_errset
+from virtuoso_bridge.virtuoso.skill_output import (
+    parse_sexpr,
+    parse_skill_str_list,
+    tokenize_top_level,
+)
+
+
+def test_parse_skill_str_list_handles_escaped_string_values() -> None:
+    assert parse_skill_str_list('("A\\"\\\\B" "Y")') == ['A"\\B', "Y"]
+
+
+def test_parse_skill_str_list_handles_bare_quoted_tokens() -> None:
+    assert parse_skill_str_list('"test"') == ["test"]
+    assert parse_skill_str_list('"dc" "tran"') == ["dc", "tran"]
+
+
+def test_maestro_parse_skill_str_list_preserves_unwrapped_errset_behavior() -> None:
+    assert maestro_parse_skill_str_list(_unwrap_errset('("test")')) == ["test"]
+    assert maestro_parse_skill_str_list(_unwrap_errset('("dc" "tran")')) == ["dc", "tran"]
+    assert maestro_parse_skill_str_list(_unwrap_errset('("A\\"\\\\B" "Y")')) == ['A"\\B', "Y"]
+
+
+def test_tokenize_top_level_handles_nested_groups_and_escaped_strings() -> None:
+    assert tokenize_top_level(
+        r'("a b" (nested "c\"d") nil) "tail" atom',
+        include_groups=True,
+        include_strings=True,
+        include_atoms=True,
+    ) == [r'("a b" (nested "c\"d") nil)', '"tail"', "atom"]
+
+
+def test_parse_sexpr_decodes_common_skill_string_escapes() -> None:
+    assert parse_sexpr(r'("label" "foo\tbar\nbaz\"\\end")') == [
+        "label",
+        'foo\tbar\nbaz"\\end',
+    ]

--- a/tests/test_symbol_ops.py
+++ b/tests/test_symbol_ops.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import pytest
+
+from virtuoso_bridge.models import ExecutionStatus, VirtuosoResult
+from virtuoso_bridge.virtuoso.basic.bridge import VirtuosoClient
+from virtuoso_bridge.virtuoso.symbol import SymbolOps
+from virtuoso_bridge.virtuoso.symbol.editor import SymbolEditor
+from virtuoso_bridge.virtuoso.symbol.ops import (
+    symbol_check,
+    symbol_create_ellipse,
+    symbol_create_label,
+    symbol_create_line,
+    symbol_create_pin,
+    symbol_create_polygon,
+    symbol_create_rect,
+    symbol_set_term_order,
+)
+
+
+def test_symbol_create_basic_shapes() -> None:
+    assert (
+        symbol_create_line("device", "drawing", [(0, 0), (1.5, 0)])
+        == 'dbCreateLine(cv list("device" "drawing") \'((0.000 0.000) (1.500 0.000)))'
+    )
+    assert (
+        symbol_create_rect("device", "drawing", -0.5, -0.25, 0.5, 0.25)
+        == 'dbCreateRect(cv list("device" "drawing") list(list(-0.5 -0.25) list(0.5 0.25)))'
+    )
+    assert (
+        symbol_create_polygon("device", "drawing", [(-1, 0), (0, 1), (1, 0)])
+        == 'dbCreatePolygon(cv list("device" "drawing") \'((-1.000 0.000) (0.000 1.000) (1.000 0.000)))'
+    )
+    assert (
+        symbol_create_ellipse("device", "drawing", -0.5, -0.5, 0.5, 0.5)
+        == 'dbCreateEllipse(cv list("device" "drawing") list(list(-0.5 -0.5) list(0.5 0.5)))'
+    )
+
+
+def test_symbol_create_label_sets_optional_label_type_and_escapes_text() -> None:
+    skill = symbol_create_label(
+        "annotate",
+        "drawing",
+        1,
+        2,
+        '[@model:"x"]',
+        "centerCenter",
+        "R0",
+        "stick",
+        0.125,
+        label_type="ILLabel",
+    )
+
+    assert (
+        'rbLabel = dbCreateLabel(cv list("annotate" "drawing") \'(1.000 2.000) '
+        '"[@model:\\"x\\"]" "centerCenter" "R0" "stick" 0.125)'
+    ) in skill
+    assert 'rbLabel~>labelType = "ILLabel"' in skill
+    assert skill.endswith("rbLabel)")
+
+
+def test_symbol_create_pin_creates_net_term_pin_rect_and_label() -> None:
+    skill = symbol_create_pin(
+        "A",
+        1,
+        2,
+        direction="input",
+        half_size=0.05,
+        label=True,
+        label_x=1.25,
+        label_y=2,
+    )
+
+    assert 'rbExistingTerm = car(setof(x cv~>terminals x~>name == "A"))' in skill
+    assert 'when(rbExistingTerm error("terminal already exists"))' in skill
+    assert 'rbNet = car(setof(x cv~>nets x~>name == "A"))' in skill
+    assert 'unless(rbNet rbNet = dbCreateNet(cv "A"))' in skill
+    assert 'rbTerm = dbCreateTerm(rbNet "A" "input")' in skill
+    assert (
+        'rbRect = dbCreateRect(cv list("pin" "drawing") '
+        "list(list(0.95 1.95) list(1.05 2.05)))"
+    ) in skill
+    assert 'rbPin = dbCreatePin(rbNet rbRect "A" rbTerm)' in skill
+    assert (
+        'rbLabel = dbCreateLabel(cv list("pin" "drawing") \'(1.250 2.000) '
+        '"A" "centerLeft" "R0" "stick" 0.0625)'
+    ) in skill
+    assert skill.endswith("rbPin)")
+
+
+def test_symbol_create_pin_without_label_still_creates_terminal_and_pin() -> None:
+    skill = symbol_create_pin("A", 0, 0, label=False)
+
+    assert "rbLabel" not in skill
+    assert 'rbTerm = dbCreateTerm(rbNet "A" "inputOutput")' in skill
+    assert (
+        'rbRect = dbCreateRect(cv list("pin" "drawing") '
+        "list(list(-0.0625 -0.0625) list(0.0625 0.0625)))"
+    ) in skill
+    assert 'rbPin = dbCreatePin(rbNet rbRect "A" rbTerm)' in skill
+
+
+def test_symbol_create_pin_escapes_repeated_pin_name_and_direction() -> None:
+    skill = symbol_create_pin(
+        'A"\\B',
+        0,
+        0,
+        direction='input"\\Output',
+    )
+
+    assert 'x~>name == "A\\"\\\\B"' in skill
+    assert 'dbCreateNet(cv "A\\"\\\\B")' in skill
+    assert 'dbCreateTerm(rbNet "A\\"\\\\B" "input\\"\\\\Output")' in skill
+    assert 'dbCreatePin(rbNet rbRect "A\\"\\\\B" rbTerm)' in skill
+    assert '"A\\"\\\\B" "centerLeft"' in skill
+
+
+def test_symbol_set_term_order_and_check() -> None:
+    assert symbol_set_term_order(["A", "Y", "VDD", "VSS"]) == 'cv~>termOrder = list("A" "Y" "VDD" "VSS")'
+    assert symbol_set_term_order(['A"\\B', "Y"]) == 'cv~>termOrder = list("A\\"\\\\B" "Y")'
+    assert symbol_check() == "schCheck(cv)"
+
+
+def test_symbol_editor_opens_symbol_view_and_saves() -> None:
+    class Client:
+        commands: list[str] | None = None
+        timeout: int | None = None
+
+        def execute_operations(self, commands: list[str], *, timeout: int):
+            self.commands = commands
+            self.timeout = timeout
+            return {"ok": True, "result": {"status": "success"}}
+
+    client = Client()
+    with SymbolEditor(client, "demoLib", "nand2", timeout=7) as symbol:
+        symbol.add(symbol_create_rect("device", "drawing", -1, -1, 1, 1))
+
+    assert client.timeout == 7
+    assert client.commands is not None
+    assert client.commands[0] == 'cv = dbOpenCellViewByType("demoLib" "nand2" "symbol" "schematicSymbol" "w")'
+    assert client.commands[1] == 'dbCreateRect(cv list("device" "drawing") list(list(-1 -1) list(1 1)))'
+    assert client.commands[2] == "schCheck(cv)"
+    assert "dbSave(rbCv)" in client.commands[3]
+
+
+def test_symbol_editor_forwards_custom_view_type() -> None:
+    class Client:
+        commands: list[str] | None = None
+
+        def execute_operations(self, commands: list[str], *, timeout: int):
+            self.commands = commands
+            return {"ok": True, "result": {"status": "success"}}
+
+    client = Client()
+    with SymbolEditor(client, "demoLib", "nand2", view_type="symbol") as symbol:
+        symbol.add(symbol_create_rect("device", "drawing", -1, -1, 1, 1))
+
+    assert client.commands is not None
+    assert client.commands[0] == 'cv = dbOpenCellViewByType("demoLib" "nand2" "symbol" "symbol" "w")'
+
+
+def test_symbol_editor_raises_for_failed_virtuoso_result() -> None:
+    class Client:
+        def execute_operations(self, commands: list[str], *, timeout: int):
+            return VirtuosoResult(
+                status=ExecutionStatus.ERROR,
+                errors=["symbol check failed"],
+            )
+
+    with pytest.raises(RuntimeError, match="symbol edit failed: symbol check failed"):
+        with SymbolEditor(Client(), "demoLib", "nand2") as symbol:
+            symbol.add(symbol_create_rect("device", "drawing", -1, -1, 1, 1))
+
+
+def test_symbol_editor_raises_for_failed_dict_result_status() -> None:
+    class Client:
+        def execute_operations(self, commands: list[str], *, timeout: int):
+            return {"ok": True, "result": {"status": "error", "errors": ["bad pin"]}}
+
+    with pytest.raises(RuntimeError, match="symbol edit failed: bad pin"):
+        with SymbolEditor(Client(), "demoLib", "nand2") as symbol:
+            symbol.add(symbol_create_pin("A", 0, 0))
+
+
+def test_virtuoso_client_exposes_symbol_ops() -> None:
+    client = VirtuosoClient.local()
+
+    assert isinstance(client.symbol, SymbolOps)

--- a/tests/test_symbol_reader.py
+++ b/tests/test_symbol_reader.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import pytest
+
+from virtuoso_bridge.models import ExecutionStatus, VirtuosoResult
+from virtuoso_bridge.virtuoso.symbol import SymbolOps
+from virtuoso_bridge.virtuoso.symbol.reader import (
+    parse_symbol_ports_output,
+    read_symbol_ports,
+    symbol_read_ports_skill,
+)
+
+
+def test_symbol_read_ports_skill_opens_symbol_and_reports_terms_labels_and_order() -> None:
+    skill = symbol_read_ports_skill("demoLib", "nand2")
+
+    assert 'dbOpenCellViewByType("demoLib" "nand2" "symbol" "schematicSymbol" "r")' in skill
+    assert 'result = cons(list("term"' in skill
+    assert "fig = car(errset(pin~>fig nil))" in skill
+    assert "unless(fig fig = car(errset(car(pin~>figs) nil)))" in skill
+    assert "bbox = list(list(xCoord(car(fig~>bBox)) yCoord(car(fig~>bBox)))" in skill
+    assert "list(xCoord(cadr(fig~>bBox)) yCoord(cadr(fig~>bBox))))" in skill
+    assert 'result = cons(list("label"' in skill
+    assert "xy = list(xCoord(label~>xy) yCoord(label~>xy))" in skill
+    assert 'result = cons(list("termOrder" cv~>termOrder) result)' in skill
+    assert "dbClose(cv)" in skill
+    assert skill.endswith("reverse(result))")
+
+
+def test_parse_symbol_ports_output_rejects_legacy_tsv() -> None:
+    output = "term\tname=A\tdirection=input\tnumBits=1\tbbox=nil\ntermOrder\t(\"A\")"
+
+    with pytest.raises(ValueError, match="structured SKILL list"):
+        parse_symbol_ports_output(output)
+
+
+def test_parse_symbol_ports_output_preserves_label_delimiters_from_sexpr() -> None:
+    parsed = parse_symbol_ports_output(
+        r'(("label" "foo\tbar\nbaz\"\\end" "normalLabel" (0.2 0.0))'
+        r' ("term" "A" "input" 1 ((0 0) (0.1 0.1)))'
+        r' ("termOrder" ("A")))'
+    )
+
+    assert parsed["labels"] == [
+        {"text": 'foo\tbar\nbaz"\\end', "labelType": "normalLabel", "xy": [0.2, 0.0]}
+    ]
+    assert parsed["terms"] == [
+        {"name": "A", "direction": "input", "numBits": 1, "bbox": [[0.0, 0.0], [0.1, 0.1]]}
+    ]
+    assert parsed["termOrder"] == ["A"]
+
+
+def test_read_symbol_ports_executes_skill() -> None:
+    class Client:
+        skill: str | None = None
+        timeout: int | None = None
+
+        def execute_skill(self, skill: str, *, timeout: int):
+            self.skill = skill
+            self.timeout = timeout
+            return type("Result", (), {"output": '(("term" "A" "input" 1 nil) ("termOrder" ("A")))'})()
+
+    client = Client()
+    parsed = read_symbol_ports(client, "demoLib", "nand2", timeout=17)
+
+    assert parsed["terms"][0]["name"] == "A"
+    assert parsed["termOrder"] == ["A"]
+    assert client.timeout == 17
+    assert client.skill is not None
+    assert 'dbOpenCellViewByType("demoLib" "nand2" "symbol" "schematicSymbol" "r")' in client.skill
+
+
+def test_read_symbol_ports_forwards_custom_view_type() -> None:
+    class Client:
+        skill: str | None = None
+
+        def execute_skill(self, skill: str, *, timeout: int):
+            self.skill = skill
+            return type("Result", (), {"output": '(("termOrder" ("A")))'})()
+
+    client = Client()
+    read_symbol_ports(client, "demoLib", "nand2", view_type="symbol")
+
+    assert client.skill is not None
+    assert 'dbOpenCellViewByType("demoLib" "nand2" "symbol" "symbol" "r")' in client.skill
+
+
+def test_read_symbol_ports_raises_on_skill_error() -> None:
+    class Client:
+        def execute_skill(self, skill: str, *, timeout: int):
+            return VirtuosoResult(
+                status=ExecutionStatus.ERROR,
+                errors=["open symbol failed"],
+            )
+
+    with pytest.raises(RuntimeError, match="read_symbol_ports SKILL error: open symbol failed"):
+        read_symbol_ports(Client(), "demoLib", "missing")
+
+
+def test_read_symbol_ports_raises_on_empty_output() -> None:
+    class Client:
+        def execute_skill(self, skill: str, *, timeout: int):
+            return VirtuosoResult(status=ExecutionStatus.SUCCESS, output="")
+
+    with pytest.raises(RuntimeError, match="read_symbol_ports returned empty output"):
+        read_symbol_ports(Client(), "demoLib", "missing")
+
+
+def test_read_symbol_ports_raises_on_dict_transport_error() -> None:
+    class Client:
+        def execute_skill(self, skill: str, *, timeout: int):
+            return {"ok": False, "error": "transport failed"}
+
+    with pytest.raises(RuntimeError, match="read_symbol_ports SKILL error: transport failed"):
+        read_symbol_ports(Client(), "demoLib", "missing")
+
+
+def test_read_symbol_ports_parses_structured_skill_output() -> None:
+    class Client:
+        def execute_skill(self, skill: str, *, timeout: int):
+            return type(
+                "Result",
+                (),
+                {
+                    "output": (
+                        '((\"term\" \"A\" \"input\" 1 nil) '
+                        '(\"label\" \"A\" \"\" (0.0 0.0)) '
+                        '(\"termOrder\" (\"A\")))'
+                    )
+                },
+            )()
+
+    parsed = read_symbol_ports(Client(), "demoLib", "nand2")
+
+    assert parsed["terms"][0]["name"] == "A"
+    assert parsed["labels"][0]["text"] == "A"
+    assert parsed["termOrder"] == ["A"]
+
+
+def test_symbol_ops_exposes_read_ports() -> None:
+    class Client:
+        def execute_skill(self, skill: str, *, timeout: int):
+            return {"output": '(("term" "A" "input" 1 nil) ("termOrder" ("A")))'}
+
+    ops = SymbolOps(Client())
+
+    assert ops.read_ports("demoLib", "nand2")["termOrder"] == ["A"]
+
+
+def test_read_symbol_ports_accepts_nested_dict_output() -> None:
+    class Client:
+        def execute_skill(self, skill: str, *, timeout: int):
+            return {
+                "ok": True,
+                "result": {
+                    "status": "success",
+                    "output": '(("term" "A" "input" 1 nil) ("termOrder" ("A")))',
+                },
+            }
+
+    parsed = read_symbol_ports(Client(), "demoLib", "nand2")
+
+    assert parsed["terms"][0]["name"] == "A"
+    assert parsed["termOrder"] == ["A"]


### PR DESCRIPTION
Summary:
- Add `client.symbol` with a `SymbolEditor` context manager for editing Virtuoso symbol views.
- Default symbol editing and readback to `view_type="schematicSymbol"`.
- Add SKILL builders for symbol shapes, labels, pins, terminal order, and symbol checks.
- Add `client.symbol.read_ports(...)` to read symbol terminals, labels, pin geometry, and term order back into Python.
- Return symbol readback as structured SKILL data and decode it with shared SKILL s-expression parsing helpers.

Validation:
```bash
python -m pytest tests/test_skill_output.py tests/test_symbol_ops.py tests/test_symbol_reader.py -q
python -m pytest -q
python -m compileall -q src/virtuoso_bridge/virtuoso/skill_output.py src/virtuoso_bridge/virtuoso/maestro/reader/_parse_skill.py src/virtuoso_bridge/virtuoso/symbol/__init__.py src/virtuoso_bridge/virtuoso/symbol/editor.py src/virtuoso_bridge/virtuoso/symbol/ops.py src/virtuoso_bridge/virtuoso/symbol/reader.py src/virtuoso_bridge/virtuoso/basic/bridge.py tests/test_skill_output.py tests/test_symbol_ops.py tests/test_symbol_reader.py
git diff --check origin/main..HEAD
```

Manual local Virtuoso check:
- Created a temporary symbol cell in the `sinomos` library.
- Added rect, label, two database-backed pins, and terminal order through `client.symbol.edit(...)`.
- Read the same symbol back with `client.symbol.read_ports(...)`.
- Confirmed `termOrder` was `[A, Y]`, terms were `A/input` and `Y/output`, `numBits` was returned as integers, and pin bboxes / label xy were returned as numeric coordinate lists.
- Repeated readback with a label containing tab, newline, quote, and backslash; confirmed tab, quote, and backslash read back correctly, with newline matching the value stored by Virtuoso.
- Removed temporary symbol cells after validation.