### PR TITLE
Add schematic netlist import helper

### DIFF
--- a/src/virtuoso_bridge/virtuoso/schematic/__init__.py
+++ b/src/virtuoso_bridge/virtuoso/schematic/__init__.py
@@ -76,6 +76,43 @@ class SchematicOps:
             timeout=timeout,
         )
 
+    def import_netlist(
+        self,
+        lib: str,
+        cell: str,
+        netlist_file: str | Path,
+        *,
+        language: str = "Spectre",
+        sim_name: str = "spectre",
+        output_sim_name: str = "spectre",
+        ref_libs: list[str] | tuple[str, ...] = ("analogLib", "basic"),
+        netlist_view: str = "netlist",
+        schematic_view: str = "schematic",
+        overwrite: bool = False,
+        dev_map_file: str | Path | None = None,
+        run_dir: str | Path = "/tmp/virtuoso_bridge_netlist_import",
+        timeout: int = 300,
+    ) -> Any:
+        """Import a netlist package through ``spiceIn`` and convert to schematic."""
+        from virtuoso_bridge.virtuoso.schematic import netlist as schematic_netlist_module
+
+        return schematic_netlist_module.import_netlist_schematic(
+            self._owner,
+            lib,
+            cell,
+            netlist_file,
+            language=language,
+            sim_name=sim_name,
+            output_sim_name=output_sim_name,
+            ref_libs=ref_libs,
+            netlist_view=netlist_view,
+            schematic_view=schematic_view,
+            overwrite=overwrite,
+            dev_map_file=dev_map_file,
+            run_dir=run_dir,
+            timeout=timeout,
+        )
+
 
 __all__ = [
     "SchematicOps",

--- a/src/virtuoso_bridge/virtuoso/schematic/__init__.py
+++ b/src/virtuoso_bridge/virtuoso/schematic/__init__.py
@@ -90,7 +90,7 @@ class SchematicOps:
         schematic_view: str = "schematic",
         overwrite: bool = False,
         dev_map_file: str | Path | None = None,
-        run_dir: str | Path = "/tmp/virtuoso_bridge_netlist_import",
+        run_dir: str | Path | None = None,
         timeout: int = 300,
     ) -> Any:
         """Import a netlist package through ``spiceIn`` and convert to schematic."""

--- a/src/virtuoso_bridge/virtuoso/schematic/__init__.py
+++ b/src/virtuoso_bridge/virtuoso/schematic/__init__.py
@@ -22,9 +22,12 @@ from virtuoso_bridge.virtuoso.schematic.ops import (
     schematic_set_netset_property,
 )
 from virtuoso_bridge.virtuoso.schematic.netlist import (
+    NetlistImportResult,
     SchematicNetlistExportResult,
+    classify_netlist_import_log,
     export_schematic_netlist,
     import_netlist_schematic,
+    parse_netlist_import_output,
     schematic_export_netlist_skill,
     schematic_import_netlist_skill,
 )
@@ -95,4 +98,7 @@ __all__ = [
     "export_schematic_netlist",
     "schematic_import_netlist_skill",
     "import_netlist_schematic",
+    "NetlistImportResult",
+    "parse_netlist_import_output",
+    "classify_netlist_import_log",
 ]

--- a/src/virtuoso_bridge/virtuoso/schematic/__init__.py
+++ b/src/virtuoso_bridge/virtuoso/schematic/__init__.py
@@ -24,7 +24,9 @@ from virtuoso_bridge.virtuoso.schematic.ops import (
 from virtuoso_bridge.virtuoso.schematic.netlist import (
     SchematicNetlistExportResult,
     export_schematic_netlist,
+    import_netlist_schematic,
     schematic_export_netlist_skill,
+    schematic_import_netlist_skill,
 )
 
 if TYPE_CHECKING:
@@ -91,4 +93,6 @@ __all__ = [
     "SchematicNetlistExportResult",
     "schematic_export_netlist_skill",
     "export_schematic_netlist",
+    "schematic_import_netlist_skill",
+    "import_netlist_schematic",
 ]

--- a/src/virtuoso_bridge/virtuoso/schematic/netlist.py
+++ b/src/virtuoso_bridge/virtuoso/schematic/netlist.py
@@ -267,34 +267,55 @@ def schematic_import_netlist_skill(
     temp_schematic_view = f"__vb_import_{uuid.uuid4().hex}" if overwrite else schematic_view
     escaped_temp_schematic_view = escape_skill_string(temp_schematic_view)
 
+    if not overwrite:
+        return (
+            "let((vbSchematicObj vbNetlistObj vbConnOk vbDestViewName) "
+            f'when("{escaped_netlist_view}" == "{escaped_schematic_view}" '
+            'error("netlist and schematic views must differ")) '
+            f'vbSchematicObj = ddGetObj("{escaped_lib}" "{escaped_cell}" "{escaped_schematic_view}") '
+            "when(vbSchematicObj "
+            'ddReleaseObj(vbSchematicObj) error("target schematic exists")) '
+            f'vbDestViewName = "{escaped_temp_schematic_view}" '
+            f'vbNetlistObj = ddGetObj("{escaped_lib}" "{escaped_cell}" "{escaped_netlist_view}") '
+            'unless(vbNetlistObj error("source netlist view not found")) '
+            "unless(isCallable('conn2Sch) error(\"conn2Sch API unavailable\")) "
+            f'vbConnOk = errset(conn2Sch("{escaped_lib}" "{escaped_cell}" "{escaped_netlist_view}" '
+            f'?destLibName "{escaped_lib}" ?destCellName "{escaped_cell}" '
+            '?destViewName vbDestViewName ?block t) nil) '
+            'unless(vbConnOk && car(vbConnOk) error("conn2Sch failed")) '
+            f'list("imported" "{escaped_lib}" "{escaped_cell}" "{escaped_param_file}" '
+            f'"{escaped_spicein_log}"))'
+        )
+
     return (
         "let((vbSchematicObj vbNetlistObj vbTempObj vbTempCv vbConnOk vbCopyOk vbDestViewName) "
         f'when("{escaped_netlist_view}" == "{escaped_schematic_view}" '
         'error("netlist and schematic views must differ")) '
         f'vbSchematicObj = ddGetObj("{escaped_lib}" "{escaped_cell}" "{escaped_schematic_view}") '
         "when(vbSchematicObj "
-        f'if({_skill_bool(overwrite)} then ddReleaseObj(vbSchematicObj) '
-        'else ddReleaseObj(vbSchematicObj) error("target schematic exists"))) '
+        "ddReleaseObj(vbSchematicObj)) "
         f'vbDestViewName = "{escaped_temp_schematic_view}" '
-        f'when({_skill_bool(overwrite)} '
         f'vbTempObj = ddGetObj("{escaped_lib}" "{escaped_cell}" vbDestViewName) '
-        'when(vbTempObj unless(ddDeleteObj(vbTempObj) error("temporary schematic delete failed")))) '
+        'when(vbTempObj unless(ddDeleteObj(vbTempObj) error("temporary schematic delete failed"))) '
         f'vbNetlistObj = ddGetObj("{escaped_lib}" "{escaped_cell}" "{escaped_netlist_view}") '
         'unless(vbNetlistObj error("source netlist view not found")) '
         "unless(isCallable('conn2Sch) error(\"conn2Sch API unavailable\")) "
+        "unwindProtect("
+        "progn("
         f'vbConnOk = errset(conn2Sch("{escaped_lib}" "{escaped_cell}" "{escaped_netlist_view}" '
         f'?destLibName "{escaped_lib}" ?destCellName "{escaped_cell}" '
         '?destViewName vbDestViewName ?block t) nil) '
         'unless(vbConnOk && car(vbConnOk) error("conn2Sch failed")) '
-        f'when({_skill_bool(overwrite)} '
         "unless(isCallable('dbCopyCellView) error(\"dbCopyCellView API unavailable\")) "
         f'vbTempCv = dbOpenCellViewByType("{escaped_lib}" "{escaped_cell}" vbDestViewName "schematic" "r") '
         'unless(vbTempCv error("temporary schematic open failed")) '
         f'vbCopyOk = dbCopyCellView(vbTempCv "{escaped_lib}" "{escaped_cell}" "{escaped_schematic_view}" nil nil t) '
-        "when(isCallable('dbClose) dbClose(vbTempCv)) "
         'unless(vbCopyOk error("target schematic copy failed")) '
+        ") "
+        "progn("
+        "when(vbTempCv when(isCallable('dbClose) dbClose(vbTempCv)) vbTempCv = nil) "
         f'vbTempObj = ddGetObj("{escaped_lib}" "{escaped_cell}" vbDestViewName) '
-        'when(vbTempObj unless(ddDeleteObj(vbTempObj) error("temporary schematic cleanup failed")))) '
+        "when(vbTempObj errset(ddDeleteObj(vbTempObj) nil)))) "
         f'list("imported" "{escaped_lib}" "{escaped_cell}" "{escaped_param_file}" '
         f'"{escaped_spicein_log}"))'
     )
@@ -383,7 +404,9 @@ def import_netlist_schematic(
         param_file=paths["param_file"],
         spicein_log_file=paths["spicein_log_file"],
     )
-    return client.execute_skill(skill, timeout=timeout)
+    result = client.execute_skill(skill, timeout=timeout)
+    _require_result_ok(result, "netlist import conversion failed")
+    return result
 
 
 @dataclass(frozen=True)
@@ -527,8 +550,8 @@ def _run_spicein_local(
 ) -> dict[str, str]:
     run_path = Path(run_dir).expanduser().resolve()
     run_path.mkdir(parents=True, exist_ok=True)
-    netlist_path = _local_input_path(netlist_file)
-    dev_map_path = "" if dev_map_file is None else _local_input_path(dev_map_file)
+    netlist_path = _local_input_path(netlist_file, run_path)
+    dev_map_path = "" if dev_map_file is None else _local_input_path(dev_map_file, run_path)
     paths = _import_paths(str(run_path))
     _write_spicein_stage(
         run_path / "spiceIn.il",
@@ -584,9 +607,28 @@ def _run_spicein_remote(
     mkdir_result = runner.run_command(f"mkdir -p {shlex.quote(run_dir_text)}", timeout=timeout)
     _require_command_ok(mkdir_result, "cannot create netlist import run directory")
     paths = _import_paths(run_dir_text)
-    remote_netlist_file = _stage_remote_input(client, runner, netlist_file, run_dir_text, timeout=timeout)
+    inputs_dir = _input_stage_dir(run_dir_text)
+    mkdir_inputs_result = runner.run_command(f"mkdir -p {shlex.quote(inputs_dir)}", timeout=timeout)
+    _require_command_ok(mkdir_inputs_result, "cannot create netlist import input directory")
+    remote_netlist_file = _stage_remote_input(
+        client,
+        runner,
+        netlist_file,
+        inputs_dir,
+        role="netlist",
+        timeout=timeout,
+    )
     remote_dev_map_file = (
-        "" if dev_map_file is None else _stage_remote_input(client, runner, dev_map_file, run_dir_text, timeout=timeout)
+        ""
+        if dev_map_file is None
+        else _stage_remote_input(
+            client,
+            runner,
+            dev_map_file,
+            inputs_dir,
+            role="devmap",
+            timeout=timeout,
+        )
     )
     with tempfile.TemporaryDirectory(prefix="vb-netlist-import-") as stage:
         stage_path = Path(stage)
@@ -623,6 +665,10 @@ def _import_paths(run_dir: str) -> dict[str, str]:
         "spicein_log_file": f"{base}/spiceIn.log",
         "spicein_stdout_file": f"{base}/spiceIn.stdout",
     }
+
+
+def _input_stage_dir(run_dir: str) -> str:
+    return f"{run_dir.rstrip('/')}/inputs"
 
 
 def _resolve_import_run_dir(run_dir: str | Path | None, lib: str, cell: str) -> str:
@@ -716,24 +762,50 @@ def _staged_cds_lib_text(context: dict[str, str]) -> str:
     return f"INCLUDE {work_dir}/cds.lib\n" if work_dir else ""
 
 
-def _local_input_path(path: str | Path) -> str:
+def _local_input_path(path: str | Path, run_path: Path) -> str:
     candidate = Path(path).expanduser()
-    if candidate.exists():
-        return str(candidate.resolve())
-    return str(path)
+    if not candidate.is_file():
+        raise RuntimeError(f"local input file not found: {path}")
+    resolved = candidate.resolve()
+    if resolved in _local_control_paths(run_path):
+        raise RuntimeError(f"local input file conflicts with netlist import control file: {path}")
+    return str(resolved)
 
 
-def _stage_remote_input(client: Any, runner: Any, path: str | Path, run_dir: str, *, timeout: int) -> str:
+def _local_control_paths(run_path: Path) -> set[Path]:
+    return {
+        (run_path / "spiceIn.il").resolve(),
+        (run_path / "cds.lib").resolve(),
+        (run_path / "spiceIn.log").resolve(),
+        (run_path / "spiceIn.stdout").resolve(),
+    }
+
+
+def _stage_remote_input(
+    client: Any,
+    runner: Any,
+    path: str | Path,
+    inputs_dir: str,
+    *,
+    role: str,
+    timeout: int,
+) -> str:
     candidate = Path(path).expanduser()
     if not candidate.is_file():
         remote_path = str(path)
+        if not PurePosixPath(remote_path).is_absolute():
+            raise RuntimeError(f"remote input file must be absolute: {remote_path}")
         result = runner.run_command(f"test -f {shlex.quote(remote_path)}", timeout=timeout)
         if getattr(result, "returncode", 1) != 0:
             raise RuntimeError(f"remote input file not found: {remote_path}")
         return remote_path
-    remote_path = f"{run_dir.rstrip('/')}/{candidate.name}"
+    remote_path = f"{inputs_dir.rstrip('/')}/{_staged_input_name(role, candidate.name)}"
     _upload_required(client, candidate, remote_path, timeout=timeout)
     return remote_path
+
+
+def _staged_input_name(role: str, source_name: str) -> str:
+    return f"{_safe_path_segment(role)}_{_safe_path_segment(source_name)}"
 
 
 def _upload_required(client: Any, local_path: Path, remote_path: str, *, timeout: int) -> None:

--- a/src/virtuoso_bridge/virtuoso/schematic/netlist.py
+++ b/src/virtuoso_bridge/virtuoso/schematic/netlist.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import json
 import re
 import shutil
 import uuid
+from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any, TypedDict
 
@@ -353,3 +355,80 @@ def import_netlist_schematic(
         run_dir=run_dir,
     )
     return client.execute_skill(skill, timeout=timeout)
+
+
+@dataclass(frozen=True)
+class NetlistImportResult:
+    """Structured summary of a netlist-to-schematic import attempt."""
+
+    status: str
+    lib: str | None = None
+    cell: str | None = None
+    param_file: str | None = None
+    spicein_log_file: str | None = None
+    conn2sch_log_file: str | None = None
+    reason: str | None = None
+    netlist_file: str | None = None
+    netlist_view: str | None = None
+    schematic_view: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        """Whether the import completed successfully."""
+        return self.status == "imported"
+
+
+def parse_netlist_import_output(output: str) -> NetlistImportResult:
+    """Parse common netlist import return payloads into a structured result."""
+    stripped = output.strip()
+    if not stripped:
+        return NetlistImportResult(status="unknown", reason="empty output")
+
+    if stripped.startswith("{"):
+        try:
+            payload = json.loads(stripped)
+        except json.JSONDecodeError as exc:
+            return NetlistImportResult(status="unknown", reason=f"invalid json: {exc}")
+        return NetlistImportResult(
+            status=str(payload.get("status", "unknown")),
+            lib=payload.get("libName"),
+            cell=payload.get("cellName"),
+            param_file=payload.get("paramFile"),
+            spicein_log_file=payload.get("spiceInLogFile"),
+            conn2sch_log_file=payload.get("conn2schLogFile"),
+            reason=payload.get("reason"),
+            netlist_file=payload.get("netlistFile"),
+            netlist_view=payload.get("netlistView"),
+            schematic_view=payload.get("schematicView"),
+        )
+
+    values = [_unescape_skill_string(value) for value in re.findall(r'"((?:[^"\\]|\\.)*)"', stripped)]
+    if values and values[0] == "imported":
+        return NetlistImportResult(
+            status="imported",
+            lib=values[1] if len(values) > 1 else None,
+            cell=values[2] if len(values) > 2 else None,
+            param_file=values[3] if len(values) > 3 else None,
+            spicein_log_file=values[4] if len(values) > 4 else None,
+            conn2sch_log_file=values[5] if len(values) > 5 else None,
+        )
+    return NetlistImportResult(status="unknown", reason=stripped)
+
+
+def classify_netlist_import_log(text: str) -> list[str]:
+    """Classify common Spice In / conn2sch log failures."""
+    lowered = text.lower()
+    reasons: list[str] = []
+    if any(marker in lowered for marker in ("unable to find master", "master cell", "devmap", "device mapping")):
+        reasons.append("missing master or device mapping")
+    if any(marker in lowered for marker in ("cannot open include", "can't open include", "no such file", "source netlist")):
+        reasons.append("missing include or source netlist")
+    if any(marker in lowered for marker in ("pin count", "terminal count", "pin mismatch")):
+        reasons.append("pin mismatch")
+    if "syntax error" in lowered or "parse error" in lowered:
+        reasons.append("netlist syntax error")
+    return reasons
+
+
+def _unescape_skill_string(value: str) -> str:
+    return value.replace(r"\"", '"').replace(r"\\", "\\")

--- a/src/virtuoso_bridge/virtuoso/schematic/netlist.py
+++ b/src/virtuoso_bridge/virtuoso/schematic/netlist.py
@@ -265,13 +265,15 @@ def schematic_import_netlist_skill(
     overwrite_cells = "all" if overwrite else "none"
 
     return (
-        "let((vbRunDir vbParamFile vbSpiceInLog vbSpiceInStdout vbConn2SchLog "
+        "let((vbRunDir vbParamFile vbRunCdsLib vbWorkCdsLib vbSpiceInLog vbSpiceInStdout vbConn2SchLog "
         "vbOut vbSchematicObj vbNetlistObj vbSpiceOk vbConnOk) "
         f'when("{escaped_netlist_view}" == "{escaped_schematic_view}" '
         'error("netlist and schematic views must differ")) '
         f'vbRunDir = "{escaped_run_dir}" '
         "unless(isDir(vbRunDir) || createDirHier(vbRunDir) error(\"cannot create run directory\")) "
         f'vbParamFile = strcat("{escaped_run_dir}" "/spiceIn.il") '
+        f'vbRunCdsLib = strcat("{escaped_run_dir}" "/cds.lib") '
+        'vbWorkCdsLib = strcat(getWorkingDir() "/cds.lib") '
         f'vbSpiceInLog = strcat("{escaped_run_dir}" "/spiceIn.log") '
         f'vbSpiceInStdout = strcat("{escaped_run_dir}" "/spiceIn.stdout") '
         f'vbConn2SchLog = strcat("{escaped_run_dir}" "/conn2sch.stdout") '
@@ -303,6 +305,11 @@ def schematic_import_netlist_skill(
         "fprintf(vbOut \"  'logFile %L\\n\" vbSpiceInLog) "
         'fprintf(vbOut ")\\n") '
         "close(vbOut) "
+        "when(isFile(vbWorkCdsLib) "
+        "vbOut = outfile(vbRunCdsLib \"w\") "
+        'unless(vbOut error("cannot open run-dir cds.lib")) '
+        'fprintf(vbOut "INCLUDE %s\\n" vbWorkCdsLib) '
+        "close(vbOut)) "
         "unless(isCallable('system) error(\"system API unavailable\")) "
         "vbSpiceOk = system(strcat(\"cd \" vbRunDir \" && spiceIn -param \" vbParamFile "
         "\" > \" vbSpiceInStdout \" 2>&1\")) "

--- a/src/virtuoso_bridge/virtuoso/schematic/netlist.py
+++ b/src/virtuoso_bridge/virtuoso/schematic/netlist.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 import json
+import os
 import re
+import shlex
 import shutil
+import subprocess
+import tempfile
 import uuid
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
@@ -12,6 +16,7 @@ from typing import Any, TypedDict
 
 from virtuoso_bridge.models import ExecutionStatus
 from virtuoso_bridge.virtuoso.ops import escape_skill_string
+from virtuoso_bridge.virtuoso.skill_output import parse_sexpr
 
 _SKILL_SYMBOL_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
@@ -69,6 +74,13 @@ def _set_result_output(result: Any, output: str) -> Any:
     except Exception:
         pass
     return result
+
+
+def _require_result_ok(result: Any, default_error: str) -> None:
+    if _result_ok(result):
+        return
+    errors = "; ".join(_result_errors(result)) or default_error
+    raise RuntimeError(errors)
 
 
 def _decode_skill_string(raw: str) -> str:
@@ -233,99 +245,46 @@ def export_schematic_netlist(
 def schematic_import_netlist_skill(
     lib: str,
     cell: str,
-    netlist_file: str | Path,
     *,
-    language: str = "Spectre",
-    sim_name: str = "spectre",
-    output_sim_name: str = "spectre",
-    ref_libs: list[str] | tuple[str, ...] = ("analogLib", "basic"),
     netlist_view: str = "netlist",
     schematic_view: str = "schematic",
     overwrite: bool = False,
-    dev_map_file: str | Path | None = None,
-    run_dir: str | Path = "/tmp/virtuoso_bridge_netlist_import",
+    param_file: str | Path = "",
+    spicein_log_file: str | Path = "",
+    conn2sch_log_file: str | Path = "",
 ) -> str:
-    """Build SKILL to import a netlist and convert it to a schematic view.
+    """Build SKILL to convert an imported netlist view into a schematic view.
 
-    The generated flow uses Cadence Spice In to create an intermediate
-    netlist view, then converts that connectivity view into a schematic using
-    ``conn2Sch`` when available, with the ``conn2sch`` command as fallback.
+    External tools such as ``spiceIn`` are intentionally not invoked here:
+    they can start their own Virtuoso process and should be run from the
+    Python/shell side.  This SKILL only touches the live DFII database.
     """
     escaped_lib = escape_skill_string(lib)
     escaped_cell = escape_skill_string(cell)
-    escaped_netlist_file = escape_skill_string(str(netlist_file))
-    escaped_language = escape_skill_string(language)
-    escaped_sim_name = escape_skill_string(sim_name)
-    escaped_output_sim_name = escape_skill_string(output_sim_name)
-    escaped_ref_libs = escape_skill_string(" ".join(ref_libs))
     escaped_netlist_view = escape_skill_string(netlist_view)
     escaped_schematic_view = escape_skill_string(schematic_view)
-    escaped_dev_map = escape_skill_string("" if dev_map_file is None else str(dev_map_file))
-    escaped_run_dir = escape_skill_string(str(run_dir))
-    overwrite_cells = "all" if overwrite else "none"
+    escaped_param_file = escape_skill_string(str(param_file))
+    escaped_spicein_log = escape_skill_string(str(spicein_log_file))
+    escaped_conn2sch_log = escape_skill_string(str(conn2sch_log_file))
 
     return (
-        "let((vbRunDir vbParamFile vbRunCdsLib vbWorkCdsLib vbSpiceInLog vbSpiceInStdout vbConn2SchLog "
-        "vbOut vbSchematicObj vbNetlistObj vbSpiceOk vbConnOk) "
+        "let((vbSchematicObj vbNetlistObj vbConnOk) "
         f'when("{escaped_netlist_view}" == "{escaped_schematic_view}" '
         'error("netlist and schematic views must differ")) '
-        f'vbRunDir = "{escaped_run_dir}" '
-        "unless(isDir(vbRunDir) || createDirHier(vbRunDir) error(\"cannot create run directory\")) "
-        f'vbParamFile = strcat("{escaped_run_dir}" "/spiceIn.il") '
-        f'vbRunCdsLib = strcat("{escaped_run_dir}" "/cds.lib") '
-        'vbWorkCdsLib = strcat(getWorkingDir() "/cds.lib") '
-        f'vbSpiceInLog = strcat("{escaped_run_dir}" "/spiceIn.log") '
-        f'vbSpiceInStdout = strcat("{escaped_run_dir}" "/spiceIn.stdout") '
-        f'vbConn2SchLog = strcat("{escaped_run_dir}" "/conn2sch.stdout") '
         f'vbSchematicObj = ddGetObj("{escaped_lib}" "{escaped_cell}" "{escaped_schematic_view}") '
         "when(vbSchematicObj "
         f'if({_skill_bool(overwrite)} then '
         'unless(ddDeleteObj(vbSchematicObj) error("target schematic delete failed")) '
         'else ddReleaseObj(vbSchematicObj) error("target schematic exists"))) '
         f'vbNetlistObj = ddGetObj("{escaped_lib}" "{escaped_cell}" "{escaped_netlist_view}") '
-        "when(vbNetlistObj "
-        f'if({_skill_bool(overwrite)} then '
-        'unless(ddDeleteObj(vbNetlistObj) error("target netlist delete failed")) '
-        'else ddReleaseObj(vbNetlistObj) error("target netlist exists"))) '
-        "vbOut = outfile(vbParamFile \"w\") "
-        'unless(vbOut error("cannot open spiceIn parameter file")) '
-        'fprintf(vbOut "spiceInParams = list(nil\\n") '
-        f"fprintf(vbOut \"  'language %L\\n\" \"{escaped_language}\") "
-        f"fprintf(vbOut \"  'netlistFile %L\\n\" \"{escaped_netlist_file}\") "
-        f"fprintf(vbOut \"  'importSubList %L\\n\" \"{escaped_cell}\") "
-        f"fprintf(vbOut \"  'outputLib %L\\n\" \"{escaped_lib}\") "
-        f"fprintf(vbOut \"  'refLibList %L\\n\" \"{escaped_ref_libs}\") "
-        f"fprintf(vbOut \"  'outputViewName %L\\n\" \"{escaped_netlist_view}\") "
-        "fprintf(vbOut \"  'outputViewType %L\\n\" \"netlist\") "
-        f"fprintf(vbOut \"  'simName %L\\n\" \"{escaped_sim_name}\") "
-        f"fprintf(vbOut \"  'outputSimName %L\\n\" \"{escaped_output_sim_name}\") "
-        f"fprintf(vbOut \"  'overwriteCells %L\\n\" \"{overwrite_cells}\") "
-        f"fprintf(vbOut \"  'devMapFile %L\\n\" \"{escaped_dev_map}\") "
-        "fprintf(vbOut \"  'masterCellForGnd %L\\n\" \"gnd\") "
-        "fprintf(vbOut \"  'logFile %L\\n\" vbSpiceInLog) "
-        'fprintf(vbOut ")\\n") '
-        "close(vbOut) "
-        "when(isFile(vbWorkCdsLib) "
-        "vbOut = outfile(vbRunCdsLib \"w\") "
-        'unless(vbOut error("cannot open run-dir cds.lib")) '
-        'fprintf(vbOut "INCLUDE %s\\n" vbWorkCdsLib) '
-        "close(vbOut)) "
-        "unless(isCallable('system) error(\"system API unavailable\")) "
-        "vbSpiceOk = system(strcat(\"cd \" vbRunDir \" && spiceIn -param \" vbParamFile "
-        "\" > \" vbSpiceInStdout \" 2>&1\")) "
-        "unless(or(vbSpiceOk == 0 vbSpiceOk == t) error(\"spiceIn failed\")) "
-        "vbConnOk = nil "
-        "when(isCallable('conn2Sch) "
+        'unless(vbNetlistObj error("source netlist view not found")) '
+        "unless(isCallable('conn2Sch) error(\"conn2Sch API unavailable\")) "
         f'vbConnOk = errset(conn2Sch("{escaped_lib}" "{escaped_cell}" "{escaped_netlist_view}" '
         f'?destLibName "{escaped_lib}" ?destCellName "{escaped_cell}" '
-        f'?destViewName "{escaped_schematic_view}" ?block t) nil)) '
-        "unless(vbConnOk && car(vbConnOk) "
-        "vbConnOk = system(strcat(\"cd \" vbRunDir "
-        f'" && conn2sch -lib {escaped_lib} -cell {escaped_cell} -view {escaped_netlist_view} '
-        f'-destlib {escaped_lib} -destview {escaped_schematic_view}" '
-        '" > " vbConn2SchLog " 2>&1")) '
-        'unless(or(vbConnOk == 0 vbConnOk == t) error("conn2sch failed"))) '
-        f'list("imported" "{escaped_lib}" "{escaped_cell}" vbParamFile vbSpiceInLog vbConn2SchLog))'
+        f'?destViewName "{escaped_schematic_view}" ?block t) nil) '
+        'unless(vbConnOk && car(vbConnOk) error("conn2Sch failed")) '
+        f'list("imported" "{escaped_lib}" "{escaped_cell}" "{escaped_param_file}" '
+        f'"{escaped_spicein_log}" "{escaped_conn2sch_log}"))'
     )
 
 
@@ -346,20 +305,71 @@ def import_netlist_schematic(
     run_dir: str | Path = "/tmp/virtuoso_bridge_netlist_import",
     timeout: int = 300,
 ) -> Any:
-    """Import a netlist into a schematic view by executing generated SKILL."""
+    """Import a netlist into a schematic view through shell ``spiceIn`` + SKILL.
+
+    ``spiceIn`` is run outside the CIW SKILL channel, matching the project
+    guidance for Cadence tools that may launch their own Virtuoso process.
+    The live SKILL bridge is used for environment discovery, preflight checks,
+    and the final ``conn2Sch`` database conversion.
+    """
+    context = _netlist_import_context(client, timeout=timeout)
+    preflight = client.execute_skill(
+        _schematic_import_preflight_skill(
+            lib,
+            cell,
+            netlist_view=netlist_view,
+            schematic_view=schematic_view,
+            overwrite=overwrite,
+        ),
+        timeout=timeout,
+    )
+    _require_result_ok(preflight, "netlist import preflight failed")
+
+    runner = getattr(client, "ssh_runner", None)
+    if runner is None:
+        paths = _run_spicein_local(
+            context,
+            lib,
+            cell,
+            netlist_file,
+            language=language,
+            sim_name=sim_name,
+            output_sim_name=output_sim_name,
+            ref_libs=ref_libs,
+            netlist_view=netlist_view,
+            overwrite=overwrite,
+            dev_map_file=dev_map_file,
+            run_dir=run_dir,
+            timeout=timeout,
+        )
+    else:
+        paths = _run_spicein_remote(
+            client,
+            runner,
+            context,
+            lib,
+            cell,
+            netlist_file,
+            language=language,
+            sim_name=sim_name,
+            output_sim_name=output_sim_name,
+            ref_libs=ref_libs,
+            netlist_view=netlist_view,
+            overwrite=overwrite,
+            dev_map_file=dev_map_file,
+            run_dir=run_dir,
+            timeout=timeout,
+        )
+
     skill = schematic_import_netlist_skill(
         lib,
         cell,
-        netlist_file,
-        language=language,
-        sim_name=sim_name,
-        output_sim_name=output_sim_name,
-        ref_libs=ref_libs,
         netlist_view=netlist_view,
         schematic_view=schematic_view,
         overwrite=overwrite,
-        dev_map_file=dev_map_file,
-        run_dir=run_dir,
+        param_file=paths["param_file"],
+        spicein_log_file=paths["spicein_log_file"],
+        conn2sch_log_file=paths["conn2sch_log_file"],
     )
     return client.execute_skill(skill, timeout=timeout)
 
@@ -409,8 +419,9 @@ def parse_netlist_import_output(output: str) -> NetlistImportResult:
             schematic_view=payload.get("schematicView"),
         )
 
-    values = [_unescape_skill_string(value) for value in re.findall(r'"((?:[^"\\]|\\.)*)"', stripped)]
-    if values and values[0] == "imported":
+    parsed = parse_sexpr(stripped)
+    if isinstance(parsed, list) and parsed and parsed[0] == "imported":
+        values = ["" if value is None else str(value) for value in parsed]
         return NetlistImportResult(
             status="imported",
             lib=values[1] if len(values) > 1 else None,
@@ -437,5 +448,337 @@ def classify_netlist_import_log(text: str) -> list[str]:
     return reasons
 
 
-def _unescape_skill_string(value: str) -> str:
-    return value.replace(r"\"", '"').replace(r"\\", "\\")
+def _schematic_import_preflight_skill(
+    lib: str,
+    cell: str,
+    *,
+    netlist_view: str,
+    schematic_view: str,
+    overwrite: bool,
+) -> str:
+    escaped_lib = escape_skill_string(lib)
+    escaped_cell = escape_skill_string(cell)
+    escaped_netlist_view = escape_skill_string(netlist_view)
+    escaped_schematic_view = escape_skill_string(schematic_view)
+    return (
+        "let((vbSchematicObj vbNetlistObj) "
+        f'when("{escaped_netlist_view}" == "{escaped_schematic_view}" '
+        'error("netlist and schematic views must differ")) '
+        f'vbSchematicObj = ddGetObj("{escaped_lib}" "{escaped_cell}" "{escaped_schematic_view}") '
+        "when(vbSchematicObj "
+        f'if({_skill_bool(overwrite)} then ddReleaseObj(vbSchematicObj) '
+        'else ddReleaseObj(vbSchematicObj) error("target schematic exists"))) '
+        f'vbNetlistObj = ddGetObj("{escaped_lib}" "{escaped_cell}" "{escaped_netlist_view}") '
+        "when(vbNetlistObj "
+        f'if({_skill_bool(overwrite)} then ddReleaseObj(vbNetlistObj) '
+        'else ddReleaseObj(vbNetlistObj) error("target netlist exists"))) '
+        "t)"
+    )
+
+
+def _netlist_import_context_skill() -> str:
+    return (
+        'list(getWorkingDir() getShellEnvVar("PATH") getShellEnvVar("LD_LIBRARY_PATH") '
+        'getShellEnvVar("LM_LICENSE_FILE") getShellEnvVar("CDS_LIC_FILE") cdsGetInstPath())'
+    )
+
+
+def _netlist_import_context(client: Any, *, timeout: int) -> dict[str, str]:
+    result = client.execute_skill(_netlist_import_context_skill(), timeout=timeout)
+    _require_result_ok(result, "netlist import environment discovery failed")
+    parsed = parse_sexpr(_result_output(result))
+    if not isinstance(parsed, list) or len(parsed) < 6:
+        raise RuntimeError(f"unexpected netlist import context: {_result_output(result)}")
+    keys = ["work_dir", "path", "ld_library_path", "lm_license_file", "cds_lic_file", "cds_inst_dir"]
+    return {key: _context_value(value) for key, value in zip(keys, parsed)}
+
+
+def _context_value(value: Any) -> str:
+    return "" if value is None else str(value)
+
+
+def _run_spicein_local(
+    context: dict[str, str],
+    lib: str,
+    cell: str,
+    netlist_file: str | Path,
+    *,
+    language: str,
+    sim_name: str,
+    output_sim_name: str,
+    ref_libs: list[str] | tuple[str, ...],
+    netlist_view: str,
+    overwrite: bool,
+    dev_map_file: str | Path | None,
+    run_dir: str | Path,
+    timeout: int,
+) -> dict[str, str]:
+    run_path = Path(run_dir).expanduser().resolve()
+    run_path.mkdir(parents=True, exist_ok=True)
+    netlist_path = _local_input_path(netlist_file)
+    dev_map_path = "" if dev_map_file is None else _local_input_path(dev_map_file)
+    paths = _import_paths(str(run_path))
+    _write_spicein_stage(
+        run_path / "spiceIn.il",
+        run_path / "cds.lib",
+        context,
+        lib,
+        cell,
+        netlist_path,
+        language=language,
+        sim_name=sim_name,
+        output_sim_name=output_sim_name,
+        ref_libs=ref_libs,
+        netlist_view=netlist_view,
+        overwrite=overwrite,
+        dev_map_file=dev_map_path,
+        spicein_log_file=paths["spicein_log_file"],
+    )
+    command = [_spicein_executable(context), "-param", paths["param_file"]]
+    result = subprocess.run(
+        command,
+        cwd=run_path,
+        env=_local_spicein_env(context),
+        timeout=timeout,
+        capture_output=True,
+        text=True,
+    )
+    stdout_file = run_path / "spiceIn.stdout"
+    stdout_file.write_text((result.stdout or "") + (result.stderr or ""), encoding="utf-8")
+    if result.returncode != 0:
+        raise RuntimeError(_spicein_failure_message(result.returncode, result.stdout, result.stderr))
+    return paths
+
+
+def _run_spicein_remote(
+    client: Any,
+    runner: Any,
+    context: dict[str, str],
+    lib: str,
+    cell: str,
+    netlist_file: str | Path,
+    *,
+    language: str,
+    sim_name: str,
+    output_sim_name: str,
+    ref_libs: list[str] | tuple[str, ...],
+    netlist_view: str,
+    overwrite: bool,
+    dev_map_file: str | Path | None,
+    run_dir: str | Path,
+    timeout: int,
+) -> dict[str, str]:
+    run_dir_text = str(run_dir)
+    mkdir_result = runner.run_command(f"mkdir -p {shlex.quote(run_dir_text)}", timeout=timeout)
+    _require_command_ok(mkdir_result, "cannot create netlist import run directory")
+    paths = _import_paths(run_dir_text)
+    remote_netlist_file = _stage_remote_input(client, netlist_file, run_dir_text, timeout=timeout)
+    remote_dev_map_file = (
+        "" if dev_map_file is None else _stage_remote_input(client, dev_map_file, run_dir_text, timeout=timeout)
+    )
+    with tempfile.TemporaryDirectory(prefix="vb-netlist-import-") as stage:
+        stage_path = Path(stage)
+        param_file = stage_path / "spiceIn.il"
+        cds_lib = stage_path / "cds.lib"
+        _write_spicein_stage(
+            param_file,
+            cds_lib,
+            context,
+            lib,
+            cell,
+            remote_netlist_file,
+            language=language,
+            sim_name=sim_name,
+            output_sim_name=output_sim_name,
+            ref_libs=ref_libs,
+            netlist_view=netlist_view,
+            overwrite=overwrite,
+            dev_map_file=remote_dev_map_file,
+            spicein_log_file=paths["spicein_log_file"],
+        )
+        _upload_required(client, param_file, paths["param_file"], timeout=timeout)
+        _upload_required(client, cds_lib, f"{run_dir_text.rstrip('/')}/cds.lib", timeout=timeout)
+    script = _remote_spicein_script(context, run_dir_text, paths["param_file"], paths["spicein_stdout_file"])
+    result = runner.run_command(f"bash -lc {shlex.quote(script)}", timeout=timeout)
+    _require_command_ok(result, "spiceIn failed")
+    return paths
+
+
+def _import_paths(run_dir: str) -> dict[str, str]:
+    base = run_dir.rstrip("/")
+    return {
+        "param_file": f"{base}/spiceIn.il",
+        "spicein_log_file": f"{base}/spiceIn.log",
+        "spicein_stdout_file": f"{base}/spiceIn.stdout",
+        "conn2sch_log_file": f"{base}/conn2sch.stdout",
+    }
+
+
+def _write_spicein_stage(
+    param_file: Path,
+    cds_lib_file: Path,
+    context: dict[str, str],
+    lib: str,
+    cell: str,
+    netlist_file: str,
+    *,
+    language: str,
+    sim_name: str,
+    output_sim_name: str,
+    ref_libs: list[str] | tuple[str, ...],
+    netlist_view: str,
+    overwrite: bool,
+    dev_map_file: str,
+    spicein_log_file: str,
+) -> None:
+    param_file.write_text(
+        _spicein_param_text(
+            lib,
+            cell,
+            netlist_file,
+            language=language,
+            sim_name=sim_name,
+            output_sim_name=output_sim_name,
+            ref_libs=ref_libs,
+            netlist_view=netlist_view,
+            overwrite=overwrite,
+            dev_map_file=dev_map_file,
+            spicein_log_file=spicein_log_file,
+        ),
+        encoding="utf-8",
+    )
+    cds_lib_file.write_text(_staged_cds_lib_text(context), encoding="utf-8")
+
+
+def _spicein_param_text(
+    lib: str,
+    cell: str,
+    netlist_file: str,
+    *,
+    language: str,
+    sim_name: str,
+    output_sim_name: str,
+    ref_libs: list[str] | tuple[str, ...],
+    netlist_view: str,
+    overwrite: bool,
+    dev_map_file: str,
+    spicein_log_file: str,
+) -> str:
+    overwrite_cells = "all" if overwrite else "none"
+    rows = [
+        "spiceInParams = list(nil",
+        f'  \'language "{escape_skill_string(language)}"',
+        f'  \'netlistFile "{escape_skill_string(netlist_file)}"',
+        f'  \'importSubList "{escape_skill_string(cell)}"',
+        f'  \'outputLib "{escape_skill_string(lib)}"',
+        f'  \'refLibList "{escape_skill_string(" ".join(ref_libs))}"',
+        f'  \'outputViewName "{escape_skill_string(netlist_view)}"',
+        '  \'outputViewType "netlist"',
+        f'  \'simName "{escape_skill_string(sim_name)}"',
+        f'  \'outputSimName "{escape_skill_string(output_sim_name)}"',
+        f'  \'overwriteCells "{overwrite_cells}"',
+        f'  \'devMapFile "{escape_skill_string(dev_map_file)}"',
+        '  \'masterCellForGnd "gnd"',
+        f'  \'logFile "{escape_skill_string(spicein_log_file)}"',
+        ")",
+        "",
+    ]
+    return "\n".join(rows)
+
+
+def _staged_cds_lib_text(context: dict[str, str]) -> str:
+    work_dir = context.get("work_dir", "").rstrip("/")
+    return f"INCLUDE {work_dir}/cds.lib\n" if work_dir else ""
+
+
+def _local_input_path(path: str | Path) -> str:
+    candidate = Path(path).expanduser()
+    if candidate.exists():
+        return str(candidate.resolve())
+    return str(path)
+
+
+def _stage_remote_input(client: Any, path: str | Path, run_dir: str, *, timeout: int) -> str:
+    candidate = Path(path).expanduser()
+    if not candidate.is_file():
+        return str(path)
+    remote_path = f"{run_dir.rstrip('/')}/{candidate.name}"
+    _upload_required(client, candidate, remote_path, timeout=timeout)
+    return remote_path
+
+
+def _upload_required(client: Any, local_path: Path, remote_path: str, *, timeout: int) -> None:
+    result = client.upload_file(local_path, remote_path, timeout=timeout)
+    _require_result_ok(result, f"failed to upload {local_path} to {remote_path}")
+
+
+def _spicein_executable(context: dict[str, str]) -> str:
+    cds_inst = context.get("cds_inst_dir", "").rstrip("/")
+    return f"{cds_inst}/bin/spiceIn" if cds_inst else "spiceIn"
+
+
+def _local_spicein_env(context: dict[str, str]) -> dict[str, str]:
+    env = os.environ.copy()
+    env.update(_spicein_env_values(context))
+    return env
+
+
+def _spicein_env_values(context: dict[str, str]) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for key, context_key in (
+        ("PATH", "path"),
+        ("LD_LIBRARY_PATH", "ld_library_path"),
+        ("LM_LICENSE_FILE", "lm_license_file"),
+        ("CDS_LIC_FILE", "cds_lic_file"),
+    ):
+        value = context.get(context_key, "")
+        if value:
+            values[key] = value
+    cds_inst = context.get("cds_inst_dir", "")
+    if cds_inst:
+        values["CDSHOME"] = cds_inst
+        values["CDS_INST_DIR"] = cds_inst
+        values["IC_HOME"] = cds_inst
+    return values
+
+
+def _remote_spicein_script(
+    context: dict[str, str],
+    run_dir: str,
+    param_file: str,
+    stdout_file: str,
+) -> str:
+    exports = []
+    env = _spicein_env_values(context)
+    for key in ("PATH", "LD_LIBRARY_PATH", "LM_LICENSE_FILE", "CDS_LIC_FILE", "CDSHOME", "CDS_INST_DIR", "IC_HOME"):
+        value = env.get(key, "")
+        if value:
+            exports.append(f"export {key}={shlex.quote(value)}")
+    spicein = shlex.quote(_spicein_executable(context))
+    stdout_q = shlex.quote(stdout_file)
+    return "\n".join(
+        [
+            *exports,
+            "export HOSTNAME=$(hostname 2>/dev/null || echo localhost)",
+            f"cd {shlex.quote(run_dir)}",
+            f"{spicein} -param {shlex.quote(param_file)} > {stdout_q} 2>&1",
+            "rc=$?",
+            f'if [ "$rc" -ne 0 ]; then tail -n 120 {stdout_q} >&2 2>/dev/null || true; fi',
+            'exit "$rc"',
+        ]
+    )
+
+
+def _require_command_ok(result: Any, default_error: str) -> None:
+    if getattr(result, "returncode", 1) == 0:
+        return
+    stdout = str(getattr(result, "stdout", "") or "")
+    stderr = str(getattr(result, "stderr", "") or "")
+    details = "\n".join(part.strip() for part in (stderr, stdout) if part and part.strip())
+    message = f"{default_error} with exit code {getattr(result, 'returncode', 1)}"
+    raise RuntimeError(message + (f": {details}" if details else ""))
+
+
+def _spicein_failure_message(returncode: int, stdout: str, stderr: str) -> str:
+    details = "\n".join(part.strip() for part in (stderr, stdout) if part and part.strip())
+    return f"spiceIn failed with exit code {returncode}" + (f": {details}" if details else "")

--- a/src/virtuoso_bridge/virtuoso/schematic/netlist.py
+++ b/src/virtuoso_bridge/virtuoso/schematic/netlist.py
@@ -251,7 +251,6 @@ def schematic_import_netlist_skill(
     overwrite: bool = False,
     param_file: str | Path = "",
     spicein_log_file: str | Path = "",
-    conn2sch_log_file: str | Path = "",
 ) -> str:
     """Build SKILL to convert an imported netlist view into a schematic view.
 
@@ -265,26 +264,39 @@ def schematic_import_netlist_skill(
     escaped_schematic_view = escape_skill_string(schematic_view)
     escaped_param_file = escape_skill_string(str(param_file))
     escaped_spicein_log = escape_skill_string(str(spicein_log_file))
-    escaped_conn2sch_log = escape_skill_string(str(conn2sch_log_file))
+    temp_schematic_view = f"__vb_import_{uuid.uuid4().hex}" if overwrite else schematic_view
+    escaped_temp_schematic_view = escape_skill_string(temp_schematic_view)
 
     return (
-        "let((vbSchematicObj vbNetlistObj vbConnOk) "
+        "let((vbSchematicObj vbNetlistObj vbTempObj vbTempCv vbConnOk vbCopyOk vbDestViewName) "
         f'when("{escaped_netlist_view}" == "{escaped_schematic_view}" '
         'error("netlist and schematic views must differ")) '
         f'vbSchematicObj = ddGetObj("{escaped_lib}" "{escaped_cell}" "{escaped_schematic_view}") '
         "when(vbSchematicObj "
-        f'if({_skill_bool(overwrite)} then '
-        'unless(ddDeleteObj(vbSchematicObj) error("target schematic delete failed")) '
+        f'if({_skill_bool(overwrite)} then ddReleaseObj(vbSchematicObj) '
         'else ddReleaseObj(vbSchematicObj) error("target schematic exists"))) '
+        f'vbDestViewName = "{escaped_temp_schematic_view}" '
+        f'when({_skill_bool(overwrite)} '
+        f'vbTempObj = ddGetObj("{escaped_lib}" "{escaped_cell}" vbDestViewName) '
+        'when(vbTempObj unless(ddDeleteObj(vbTempObj) error("temporary schematic delete failed")))) '
         f'vbNetlistObj = ddGetObj("{escaped_lib}" "{escaped_cell}" "{escaped_netlist_view}") '
         'unless(vbNetlistObj error("source netlist view not found")) '
         "unless(isCallable('conn2Sch) error(\"conn2Sch API unavailable\")) "
         f'vbConnOk = errset(conn2Sch("{escaped_lib}" "{escaped_cell}" "{escaped_netlist_view}" '
         f'?destLibName "{escaped_lib}" ?destCellName "{escaped_cell}" '
-        f'?destViewName "{escaped_schematic_view}" ?block t) nil) '
+        '?destViewName vbDestViewName ?block t) nil) '
         'unless(vbConnOk && car(vbConnOk) error("conn2Sch failed")) '
+        f'when({_skill_bool(overwrite)} '
+        "unless(isCallable('dbCopyCellView) error(\"dbCopyCellView API unavailable\")) "
+        f'vbTempCv = dbOpenCellViewByType("{escaped_lib}" "{escaped_cell}" vbDestViewName "schematic" "r") '
+        'unless(vbTempCv error("temporary schematic open failed")) '
+        f'vbCopyOk = dbCopyCellView(vbTempCv "{escaped_lib}" "{escaped_cell}" "{escaped_schematic_view}" nil nil t) '
+        "when(isCallable('dbClose) dbClose(vbTempCv)) "
+        'unless(vbCopyOk error("target schematic copy failed")) '
+        f'vbTempObj = ddGetObj("{escaped_lib}" "{escaped_cell}" vbDestViewName) '
+        'when(vbTempObj unless(ddDeleteObj(vbTempObj) error("temporary schematic cleanup failed")))) '
         f'list("imported" "{escaped_lib}" "{escaped_cell}" "{escaped_param_file}" '
-        f'"{escaped_spicein_log}" "{escaped_conn2sch_log}"))'
+        f'"{escaped_spicein_log}"))'
     )
 
 
@@ -302,7 +314,7 @@ def import_netlist_schematic(
     schematic_view: str = "schematic",
     overwrite: bool = False,
     dev_map_file: str | Path | None = None,
-    run_dir: str | Path = "/tmp/virtuoso_bridge_netlist_import",
+    run_dir: str | Path | None = None,
     timeout: int = 300,
 ) -> Any:
     """Import a netlist into a schematic view through shell ``spiceIn`` + SKILL.
@@ -313,6 +325,7 @@ def import_netlist_schematic(
     and the final ``conn2Sch`` database conversion.
     """
     context = _netlist_import_context(client, timeout=timeout)
+    resolved_run_dir = _resolve_import_run_dir(run_dir, lib, cell)
     preflight = client.execute_skill(
         _schematic_import_preflight_skill(
             lib,
@@ -339,7 +352,7 @@ def import_netlist_schematic(
             netlist_view=netlist_view,
             overwrite=overwrite,
             dev_map_file=dev_map_file,
-            run_dir=run_dir,
+            run_dir=resolved_run_dir,
             timeout=timeout,
         )
     else:
@@ -357,7 +370,7 @@ def import_netlist_schematic(
             netlist_view=netlist_view,
             overwrite=overwrite,
             dev_map_file=dev_map_file,
-            run_dir=run_dir,
+            run_dir=resolved_run_dir,
             timeout=timeout,
         )
 
@@ -369,7 +382,6 @@ def import_netlist_schematic(
         overwrite=overwrite,
         param_file=paths["param_file"],
         spicein_log_file=paths["spicein_log_file"],
-        conn2sch_log_file=paths["conn2sch_log_file"],
     )
     return client.execute_skill(skill, timeout=timeout)
 
@@ -572,9 +584,9 @@ def _run_spicein_remote(
     mkdir_result = runner.run_command(f"mkdir -p {shlex.quote(run_dir_text)}", timeout=timeout)
     _require_command_ok(mkdir_result, "cannot create netlist import run directory")
     paths = _import_paths(run_dir_text)
-    remote_netlist_file = _stage_remote_input(client, netlist_file, run_dir_text, timeout=timeout)
+    remote_netlist_file = _stage_remote_input(client, runner, netlist_file, run_dir_text, timeout=timeout)
     remote_dev_map_file = (
-        "" if dev_map_file is None else _stage_remote_input(client, dev_map_file, run_dir_text, timeout=timeout)
+        "" if dev_map_file is None else _stage_remote_input(client, runner, dev_map_file, run_dir_text, timeout=timeout)
     )
     with tempfile.TemporaryDirectory(prefix="vb-netlist-import-") as stage:
         stage_path = Path(stage)
@@ -610,8 +622,21 @@ def _import_paths(run_dir: str) -> dict[str, str]:
         "param_file": f"{base}/spiceIn.il",
         "spicein_log_file": f"{base}/spiceIn.log",
         "spicein_stdout_file": f"{base}/spiceIn.stdout",
-        "conn2sch_log_file": f"{base}/conn2sch.stdout",
     }
+
+
+def _resolve_import_run_dir(run_dir: str | Path | None, lib: str, cell: str) -> str:
+    if run_dir is not None:
+        return str(run_dir)
+    return (
+        f"/tmp/virtuoso_bridge_netlist_import_"
+        f"{_safe_path_segment(lib)}_{_safe_path_segment(cell)}_{uuid.uuid4().hex}"
+    )
+
+
+def _safe_path_segment(value: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9_.-]+", "_", value).strip("._")
+    return safe or "cell"
 
 
 def _write_spicein_stage(
@@ -698,10 +723,14 @@ def _local_input_path(path: str | Path) -> str:
     return str(path)
 
 
-def _stage_remote_input(client: Any, path: str | Path, run_dir: str, *, timeout: int) -> str:
+def _stage_remote_input(client: Any, runner: Any, path: str | Path, run_dir: str, *, timeout: int) -> str:
     candidate = Path(path).expanduser()
     if not candidate.is_file():
-        return str(path)
+        remote_path = str(path)
+        result = runner.run_command(f"test -f {shlex.quote(remote_path)}", timeout=timeout)
+        if getattr(result, "returncode", 1) != 0:
+            raise RuntimeError(f"remote input file not found: {remote_path}")
+        return remote_path
     remote_path = f"{run_dir.rstrip('/')}/{candidate.name}"
     _upload_required(client, candidate, remote_path, timeout=timeout)
     return remote_path

--- a/src/virtuoso_bridge/virtuoso/schematic/netlist.py
+++ b/src/virtuoso_bridge/virtuoso/schematic/netlist.py
@@ -226,3 +226,130 @@ def export_schematic_netlist(
         "skill_result": skill_result,
         "download_result": download_result,
     }
+
+
+def schematic_import_netlist_skill(
+    lib: str,
+    cell: str,
+    netlist_file: str | Path,
+    *,
+    language: str = "Spectre",
+    sim_name: str = "spectre",
+    output_sim_name: str = "spectre",
+    ref_libs: list[str] | tuple[str, ...] = ("analogLib", "basic"),
+    netlist_view: str = "netlist",
+    schematic_view: str = "schematic",
+    overwrite: bool = False,
+    dev_map_file: str | Path | None = None,
+    run_dir: str | Path = "/tmp/virtuoso_bridge_netlist_import",
+) -> str:
+    """Build SKILL to import a netlist and convert it to a schematic view.
+
+    The generated flow uses Cadence Spice In to create an intermediate
+    netlist view, then converts that connectivity view into a schematic using
+    ``conn2Sch`` when available, with the ``conn2sch`` command as fallback.
+    """
+    escaped_lib = escape_skill_string(lib)
+    escaped_cell = escape_skill_string(cell)
+    escaped_netlist_file = escape_skill_string(str(netlist_file))
+    escaped_language = escape_skill_string(language)
+    escaped_sim_name = escape_skill_string(sim_name)
+    escaped_output_sim_name = escape_skill_string(output_sim_name)
+    escaped_ref_libs = escape_skill_string(" ".join(ref_libs))
+    escaped_netlist_view = escape_skill_string(netlist_view)
+    escaped_schematic_view = escape_skill_string(schematic_view)
+    escaped_dev_map = escape_skill_string("" if dev_map_file is None else str(dev_map_file))
+    escaped_run_dir = escape_skill_string(str(run_dir))
+    overwrite_cells = "all" if overwrite else "none"
+
+    return (
+        "let((vbRunDir vbParamFile vbSpiceInLog vbSpiceInStdout vbConn2SchLog "
+        "vbOut vbSchematicObj vbNetlistObj vbSpiceOk vbConnOk) "
+        f'when("{escaped_netlist_view}" == "{escaped_schematic_view}" '
+        'error("netlist and schematic views must differ")) '
+        f'vbRunDir = "{escaped_run_dir}" '
+        "unless(isDir(vbRunDir) || createDirHier(vbRunDir) error(\"cannot create run directory\")) "
+        f'vbParamFile = strcat("{escaped_run_dir}" "/spiceIn.il") '
+        f'vbSpiceInLog = strcat("{escaped_run_dir}" "/spiceIn.log") '
+        f'vbSpiceInStdout = strcat("{escaped_run_dir}" "/spiceIn.stdout") '
+        f'vbConn2SchLog = strcat("{escaped_run_dir}" "/conn2sch.stdout") '
+        f'vbSchematicObj = ddGetObj("{escaped_lib}" "{escaped_cell}" "{escaped_schematic_view}") '
+        "when(vbSchematicObj "
+        f'if({_skill_bool(overwrite)} then '
+        'unless(ddDeleteObj(vbSchematicObj) error("target schematic delete failed")) '
+        'else ddReleaseObj(vbSchematicObj) error("target schematic exists"))) '
+        f'vbNetlistObj = ddGetObj("{escaped_lib}" "{escaped_cell}" "{escaped_netlist_view}") '
+        "when(vbNetlistObj "
+        f'if({_skill_bool(overwrite)} then '
+        'unless(ddDeleteObj(vbNetlistObj) error("target netlist delete failed")) '
+        'else ddReleaseObj(vbNetlistObj) error("target netlist exists"))) '
+        "vbOut = outfile(vbParamFile \"w\") "
+        'unless(vbOut error("cannot open spiceIn parameter file")) '
+        'fprintf(vbOut "spiceInParams = list(nil\\n") '
+        f"fprintf(vbOut \"  'language %L\\n\" \"{escaped_language}\") "
+        f"fprintf(vbOut \"  'netlistFile %L\\n\" \"{escaped_netlist_file}\") "
+        f"fprintf(vbOut \"  'importSubList %L\\n\" \"{escaped_cell}\") "
+        f"fprintf(vbOut \"  'outputLib %L\\n\" \"{escaped_lib}\") "
+        f"fprintf(vbOut \"  'refLibList %L\\n\" \"{escaped_ref_libs}\") "
+        f"fprintf(vbOut \"  'outputViewName %L\\n\" \"{escaped_netlist_view}\") "
+        "fprintf(vbOut \"  'outputViewType %L\\n\" \"netlist\") "
+        f"fprintf(vbOut \"  'simName %L\\n\" \"{escaped_sim_name}\") "
+        f"fprintf(vbOut \"  'outputSimName %L\\n\" \"{escaped_output_sim_name}\") "
+        f"fprintf(vbOut \"  'overwriteCells %L\\n\" \"{overwrite_cells}\") "
+        f"fprintf(vbOut \"  'devMapFile %L\\n\" \"{escaped_dev_map}\") "
+        "fprintf(vbOut \"  'masterCellForGnd %L\\n\" \"gnd\") "
+        "fprintf(vbOut \"  'logFile %L\\n\" vbSpiceInLog) "
+        'fprintf(vbOut ")\\n") '
+        "close(vbOut) "
+        "unless(isCallable('system) error(\"system API unavailable\")) "
+        "vbSpiceOk = system(strcat(\"cd \" vbRunDir \" && spiceIn -param \" vbParamFile "
+        "\" > \" vbSpiceInStdout \" 2>&1\")) "
+        "unless(or(vbSpiceOk == 0 vbSpiceOk == t) error(\"spiceIn failed\")) "
+        "vbConnOk = nil "
+        "when(isCallable('conn2Sch) "
+        f'vbConnOk = errset(conn2Sch("{escaped_lib}" "{escaped_cell}" "{escaped_netlist_view}" '
+        f'?destLibName "{escaped_lib}" ?destCellName "{escaped_cell}" '
+        f'?destViewName "{escaped_schematic_view}" ?block t) nil)) '
+        "unless(vbConnOk && car(vbConnOk) "
+        "vbConnOk = system(strcat(\"cd \" vbRunDir "
+        f'" && conn2sch -lib {escaped_lib} -cell {escaped_cell} -view {escaped_netlist_view} '
+        f'-destlib {escaped_lib} -destview {escaped_schematic_view}" '
+        '" > " vbConn2SchLog " 2>&1")) '
+        'unless(or(vbConnOk == 0 vbConnOk == t) error("conn2sch failed"))) '
+        f'list("imported" "{escaped_lib}" "{escaped_cell}" vbParamFile vbSpiceInLog vbConn2SchLog))'
+    )
+
+
+def import_netlist_schematic(
+    client: Any,
+    lib: str,
+    cell: str,
+    netlist_file: str | Path,
+    *,
+    language: str = "Spectre",
+    sim_name: str = "spectre",
+    output_sim_name: str = "spectre",
+    ref_libs: list[str] | tuple[str, ...] = ("analogLib", "basic"),
+    netlist_view: str = "netlist",
+    schematic_view: str = "schematic",
+    overwrite: bool = False,
+    dev_map_file: str | Path | None = None,
+    run_dir: str | Path = "/tmp/virtuoso_bridge_netlist_import",
+    timeout: int = 300,
+) -> Any:
+    """Import a netlist into a schematic view by executing generated SKILL."""
+    skill = schematic_import_netlist_skill(
+        lib,
+        cell,
+        netlist_file,
+        language=language,
+        sim_name=sim_name,
+        output_sim_name=output_sim_name,
+        ref_libs=ref_libs,
+        netlist_view=netlist_view,
+        schematic_view=schematic_view,
+        overwrite=overwrite,
+        dev_map_file=dev_map_file,
+        run_dir=run_dir,
+    )
+    return client.execute_skill(skill, timeout=timeout)

--- a/tests/test_netlist_import_result.py
+++ b/tests/test_netlist_import_result.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from virtuoso_bridge.virtuoso.schematic import (
+    NetlistImportResult,
+    classify_netlist_import_log,
+    parse_netlist_import_output,
+)
+
+
+def test_parse_netlist_import_output_from_skill_list() -> None:
+    result = parse_netlist_import_output(
+        '("imported" "demoLib" "nand2" "/run/spiceIn.il" "/run/spiceIn.log" "/run/conn2sch.stdout")'
+    )
+
+    assert result == NetlistImportResult(
+        status="imported",
+        lib="demoLib",
+        cell="nand2",
+        param_file="/run/spiceIn.il",
+        spicein_log_file="/run/spiceIn.log",
+        conn2sch_log_file="/run/conn2sch.stdout",
+        reason=None,
+    )
+    assert result.ok is True
+
+
+def test_parse_netlist_import_output_from_json_error() -> None:
+    result = parse_netlist_import_output(
+        '{"status":"error","reason":"spicein_failed","libName":"demoLib",'
+        '"cellName":"nand2","netlistFile":"/tmp/nand2.scs",'
+        '"netlistView":"netlist","schematicView":"schematic"}'
+    )
+
+    assert result.ok is False
+    assert result.status == "error"
+    assert result.reason == "spicein_failed"
+    assert result.lib == "demoLib"
+    assert result.cell == "nand2"
+
+
+def test_classify_netlist_import_log_detects_common_failures() -> None:
+    text = "\n".join(
+        [
+            "ERROR: Unable to find master cell for subckt sky130_fd_pr__nfet_01v8.",
+            "Cannot open include file models.scs.",
+            "WARNING: pin count mismatch for instance X1.",
+        ]
+    )
+
+    assert classify_netlist_import_log(text) == [
+        "missing master or device mapping",
+        "missing include or source netlist",
+        "pin mismatch",
+    ]

--- a/tests/test_netlist_import_result.py
+++ b/tests/test_netlist_import_result.py
@@ -24,6 +24,17 @@ def test_parse_netlist_import_output_from_skill_list() -> None:
     assert result.ok is True
 
 
+def test_parse_netlist_import_output_decodes_skill_string_escapes() -> None:
+    result = parse_netlist_import_output(
+        r'("imported" "demo\"Lib" "nand\\2" "/run/a\tb/spiceIn.il")'
+    )
+
+    assert result.status == "imported"
+    assert result.lib == 'demo"Lib'
+    assert result.cell == "nand\\2"
+    assert result.param_file == "/run/a\tb/spiceIn.il"
+
+
 def test_parse_netlist_import_output_from_json_error() -> None:
     result = parse_netlist_import_output(
         '{"status":"error","reason":"spicein_failed","libName":"demoLib",'

--- a/tests/test_netlist_import_result.py
+++ b/tests/test_netlist_import_result.py
@@ -24,6 +24,19 @@ def test_parse_netlist_import_output_from_skill_list() -> None:
     assert result.ok is True
 
 
+def test_parse_netlist_import_output_from_current_skill_list_without_conn2sch_log() -> None:
+    result = parse_netlist_import_output(
+        '("imported" "demoLib" "nand2" "/run/spiceIn.il" "/run/spiceIn.log")'
+    )
+
+    assert result.status == "imported"
+    assert result.lib == "demoLib"
+    assert result.cell == "nand2"
+    assert result.param_file == "/run/spiceIn.il"
+    assert result.spicein_log_file == "/run/spiceIn.log"
+    assert result.conn2sch_log_file is None
+
+
 def test_parse_netlist_import_output_decodes_skill_string_escapes() -> None:
     result = parse_netlist_import_output(
         r'("imported" "demo\"Lib" "nand\\2" "/run/a\tb/spiceIn.il")'

--- a/tests/test_schematic_netlist.py
+++ b/tests/test_schematic_netlist.py
@@ -7,6 +7,8 @@ import pytest
 from virtuoso_bridge.virtuoso.schematic import (
     SchematicOps,
     export_schematic_netlist,
+    import_netlist_schematic,
+    schematic_import_netlist_skill,
     schematic_export_netlist_skill,
 )
 
@@ -144,6 +146,67 @@ def test_schematic_ops_export_netlist_delegates_to_client(tmp_path) -> None:
     assert local_path.name.startswith(".tb_inv_netlist.tmp-")
     assert timeout == 75
     assert recursive is True
+
+
+def test_schematic_import_netlist_skill_uses_spicein_and_conn2sch() -> None:
+    skill = schematic_import_netlist_skill(
+        "demoLib",
+        "nand2",
+        "/tmp/nand2.scs",
+        run_dir="/tmp/import-nand2",
+        ref_libs=["analogLib", "basic"],
+        overwrite=True,
+    )
+
+    assert 'vbParamFile = strcat("/tmp/import-nand2" "/spiceIn.il")' in skill
+    assert 'fprintf(vbOut "  \'language %L\\n" "Spectre")' in skill
+    assert 'fprintf(vbOut "  \'netlistFile %L\\n" "/tmp/nand2.scs")' in skill
+    assert 'fprintf(vbOut "  \'refLibList %L\\n" "analogLib basic")' in skill
+    assert 'fprintf(vbOut "  \'overwriteCells %L\\n" "all")' in skill
+    assert 'system(strcat("cd " vbRunDir " && spiceIn -param " vbParamFile' in skill
+    assert 'conn2Sch("demoLib" "nand2" "netlist" ?destLibName "demoLib"' in skill
+    assert 'conn2sch -lib demoLib -cell nand2 -view netlist -destlib demoLib -destview schematic' in skill
+    assert 'list("imported" "demoLib" "nand2" vbParamFile vbSpiceInLog vbConn2SchLog)' in skill
+    assert "smic12sf" not in skill
+    assert "sinomos" not in skill
+
+
+def test_schematic_import_netlist_skill_rejects_same_target_views() -> None:
+    skill = schematic_import_netlist_skill(
+        "demoLib",
+        "nand2",
+        "/tmp/nand2.scs",
+        netlist_view="schematic",
+        schematic_view="schematic",
+    )
+
+    assert 'when("netlist" == "schematic"' not in skill
+    assert 'when("schematic" == "schematic" error("netlist and schematic views must differ"))' in skill
+
+
+def test_import_netlist_schematic_executes_generated_skill() -> None:
+    class Client:
+        skill: str | None = None
+        timeout: int | None = None
+
+        def execute_skill(self, skill: str, *, timeout: int):
+            self.skill = skill
+            self.timeout = timeout
+            return {"status": "success", "output": '("imported" "demoLib" "nand2")'}
+
+    client = Client()
+    result = import_netlist_schematic(
+        client,
+        "demoLib",
+        "nand2",
+        "/tmp/nand2.scs",
+        timeout=90,
+    )
+
+    assert result == {"status": "success", "output": '("imported" "demoLib" "nand2")'}
+    assert client.timeout == 90
+    assert client.skill is not None
+    assert 'fprintf(vbOut "  \'outputViewName %L\\n" "netlist")' in client.skill
 
 
 def test_export_schematic_netlist_replaces_existing_output_directory(tmp_path) -> None:

--- a/tests/test_schematic_netlist.py
+++ b/tests/test_schematic_netlist.py
@@ -166,6 +166,7 @@ def test_schematic_import_netlist_skill_converts_imported_netlist_view_only() ->
     assert "conn2sch -" not in skill
     assert "ddDeleteObj(vbSchematicObj)" not in skill
     assert "dbCopyCellView" in skill
+    assert "unwindProtect" in skill
     assert 'vbDestViewName = "__vb_import_' in skill
     assert 'conn2Sch("demoLib" "nand2" "netlist" ?destLibName "demoLib"' in skill
     assert '?destViewName vbDestViewName ?block t) nil)' in skill
@@ -248,6 +249,78 @@ def test_import_netlist_schematic_runs_spicein_outside_skill(monkeypatch, tmp_pa
     assert '  \'outputViewName "netlist"' in param_text
     assert all("spiceIn -param" not in skill and "system(" not in skill for skill in client.skills)
     assert 'conn2Sch("demoLib" "nand2" "netlist"' in client.skills[-1]
+
+
+def test_import_netlist_schematic_rejects_local_control_file_collision(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    work_dir = tmp_path / "virtuoso"
+    work_dir.mkdir()
+    (work_dir / "cds.lib").write_text("DEFINE demoLib ./demoLib\n", encoding="utf-8")
+    run_dir = tmp_path / "import-nand2"
+    run_dir.mkdir()
+    netlist_file = run_dir / "spiceIn.il"
+    netlist_file.write_text("original netlist\n", encoding="utf-8")
+
+    class Client:
+        ssh_runner = None
+        responses = [
+            {
+                "status": "success",
+                "output": f'("{work_dir}" "/cad/IC/bin:/usr/bin" "" "" "" "/cad/IC")',
+            },
+            {"status": "success", "output": "t"},
+            {"status": "success", "output": '("imported" "demoLib" "nand2")'},
+        ]
+
+        def execute_skill(self, skill: str, *, timeout: int):
+            return self.responses.pop(0)
+
+    def fake_run(*args, **kwargs):
+        raise AssertionError("spiceIn must not run when the input would be overwritten")
+
+    monkeypatch.setattr(schematic_netlist_module.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="local input file conflicts"):
+        import_netlist_schematic(
+            Client(),
+            "demoLib",
+            "nand2",
+            netlist_file,
+            run_dir=run_dir,
+            timeout=30,
+        )
+
+    assert netlist_file.read_text(encoding="utf-8") == "original netlist\n"
+
+
+def test_import_netlist_schematic_rejects_missing_local_input(tmp_path) -> None:
+    work_dir = tmp_path / "virtuoso"
+    work_dir.mkdir()
+
+    class Client:
+        ssh_runner = None
+        responses = [
+            {
+                "status": "success",
+                "output": f'("{work_dir}" "/cad/IC/bin:/usr/bin" "" "" "" "/cad/IC")',
+            },
+            {"status": "success", "output": "t"},
+        ]
+
+        def execute_skill(self, skill: str, *, timeout: int):
+            return self.responses.pop(0)
+
+    with pytest.raises(RuntimeError, match="local input file not found"):
+        import_netlist_schematic(
+            Client(),
+            "demoLib",
+            "nand2",
+            tmp_path / "missing.scs",
+            run_dir=tmp_path / "import-nand2",
+            timeout=30,
+        )
 
 
 def test_import_netlist_schematic_uses_unique_default_run_dirs(monkeypatch, tmp_path) -> None:
@@ -341,8 +414,8 @@ def test_import_netlist_schematic_uploads_inputs_and_runs_remote_shell(tmp_path)
 
     assert result["status"] == "success"
     uploaded_names = {(path.name, remote, timeout) for path, remote, timeout in client.uploads}
-    assert ("nand2.scs", "/remote/import-nand2/nand2.scs", 120) in uploaded_names
-    assert ("devmap.txt", "/remote/import-nand2/devmap.txt", 120) in uploaded_names
+    assert ("nand2.scs", "/remote/import-nand2/inputs/netlist_nand2.scs", 120) in uploaded_names
+    assert ("devmap.txt", "/remote/import-nand2/inputs/devmap_devmap.txt", 120) in uploaded_names
     assert ("spiceIn.il", "/remote/import-nand2/spiceIn.il", 120) in uploaded_names
     assert ("cds.lib", "/remote/import-nand2/cds.lib", 120) in uploaded_names
     commands = [command for command, _ in client.ssh_runner.commands]
@@ -402,6 +475,38 @@ def test_import_netlist_schematic_validates_assumed_remote_inputs() -> None:
     assert "nand2.scs" not in uploaded_names
     assert "devmap.txt" not in uploaded_names
     assert {"spiceIn.il", "cds.lib"}.issubset(set(uploaded_names))
+
+
+def test_import_netlist_schematic_rejects_relative_remote_input() -> None:
+    class Runner:
+        commands: list[tuple[str, int | None]] = []
+
+        def run_command(self, command: str, timeout: int | None = None) -> CommandResult:
+            self.commands.append((command, timeout))
+            return CommandResult(0, "", "")
+
+    class Client:
+        ssh_runner = Runner()
+        responses = [
+            {
+                "status": "success",
+                "output": '("/remote/work" "/cad/IC/bin:/usr/bin" "" "" "" "/cad/IC")',
+            },
+            {"status": "success", "output": "t"},
+        ]
+
+        def execute_skill(self, skill: str, *, timeout: int):
+            return self.responses.pop(0)
+
+    with pytest.raises(RuntimeError, match="remote input file must be absolute"):
+        import_netlist_schematic(
+            Client(),
+            "demoLib",
+            "nand2",
+            "relative/nand2.scs",
+            run_dir="/remote/import-nand2",
+            timeout=120,
+        )
 
 
 def test_import_netlist_schematic_quotes_assumed_remote_input_checks() -> None:
@@ -480,6 +585,43 @@ def test_import_netlist_schematic_rejects_missing_remote_input() -> None:
             "/missing/remote/nand2.scs",
             run_dir="/remote/import-nand2",
             timeout=120,
+        )
+
+
+def test_import_netlist_schematic_raises_on_conn2sch_error(monkeypatch, tmp_path) -> None:
+    work_dir = tmp_path / "virtuoso"
+    work_dir.mkdir()
+    (work_dir / "cds.lib").write_text("DEFINE demoLib ./demoLib\n", encoding="utf-8")
+    netlist_file = tmp_path / "nand2.scs"
+    netlist_file.write_text("simulator lang=spectre\n", encoding="utf-8")
+
+    class Client:
+        ssh_runner = None
+        responses = [
+            {
+                "status": "success",
+                "output": f'("{work_dir}" "/cad/IC/bin:/usr/bin" "" "" "" "/cad/IC")',
+            },
+            {"status": "success", "output": "t"},
+            {"status": "error", "errors": ["conn2Sch failed"], "output": ""},
+        ]
+
+        def execute_skill(self, skill: str, *, timeout: int):
+            return self.responses.pop(0)
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args[0], 0, stdout="", stderr="")
+
+    monkeypatch.setattr(schematic_netlist_module.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="conn2Sch failed"):
+        import_netlist_schematic(
+            Client(),
+            "demoLib",
+            "nand2",
+            netlist_file,
+            run_dir=tmp_path / "import-nand2",
+            timeout=30,
         )
 
 

--- a/tests/test_schematic_netlist.py
+++ b/tests/test_schematic_netlist.py
@@ -163,6 +163,9 @@ def test_schematic_import_netlist_skill_uses_spicein_and_conn2sch() -> None:
     assert 'fprintf(vbOut "  \'netlistFile %L\\n" "/tmp/nand2.scs")' in skill
     assert 'fprintf(vbOut "  \'refLibList %L\\n" "analogLib basic")' in skill
     assert 'fprintf(vbOut "  \'overwriteCells %L\\n" "all")' in skill
+    assert 'vbRunCdsLib = strcat("/tmp/import-nand2" "/cds.lib")' in skill
+    assert 'vbWorkCdsLib = strcat(getWorkingDir() "/cds.lib")' in skill
+    assert 'fprintf(vbOut "INCLUDE %s\\n" vbWorkCdsLib)' in skill
     assert 'system(strcat("cd " vbRunDir " && spiceIn -param " vbParamFile' in skill
     assert 'conn2Sch("demoLib" "nand2" "netlist" ?destLibName "demoLib"' in skill
     assert 'conn2sch -lib demoLib -cell nand2 -view netlist -destlib demoLib -destview schematic' in skill

--- a/tests/test_schematic_netlist.py
+++ b/tests/test_schematic_netlist.py
@@ -361,7 +361,8 @@ def test_import_netlist_schematic_uses_unique_default_run_dirs(monkeypatch, tmp_
     assert len(run_dirs) == 2
     assert run_dirs[0] != run_dirs[1]
     assert all(path.name.startswith("virtuoso_bridge_netlist_import_demoLib_nand2_") for path in run_dirs)
-    assert all(str(path).startswith("/tmp/") for path in run_dirs)
+    tmp_root = Path("/tmp").resolve()
+    assert all(path.resolve().is_relative_to(tmp_root) for path in run_dirs)
 
 
 def test_import_netlist_schematic_uploads_inputs_and_runs_remote_shell(tmp_path) -> None:

--- a/tests/test_schematic_netlist.py
+++ b/tests/test_schematic_netlist.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 import pytest
 
+from virtuoso_bridge.transport.ssh import CommandResult
 from virtuoso_bridge.virtuoso.schematic import (
     SchematicOps,
     export_schematic_netlist,
@@ -11,6 +13,7 @@ from virtuoso_bridge.virtuoso.schematic import (
     schematic_import_netlist_skill,
     schematic_export_netlist_skill,
 )
+from virtuoso_bridge.virtuoso.schematic import netlist as schematic_netlist_module
 
 
 def test_schematic_export_netlist_skill_uses_ocean_netlister() -> None:
@@ -148,28 +151,22 @@ def test_schematic_ops_export_netlist_delegates_to_client(tmp_path) -> None:
     assert recursive is True
 
 
-def test_schematic_import_netlist_skill_uses_spicein_and_conn2sch() -> None:
+def test_schematic_import_netlist_skill_converts_imported_netlist_view_only() -> None:
     skill = schematic_import_netlist_skill(
         "demoLib",
         "nand2",
-        "/tmp/nand2.scs",
-        run_dir="/tmp/import-nand2",
-        ref_libs=["analogLib", "basic"],
         overwrite=True,
+        param_file="/tmp/import-nand2/spiceIn.il",
+        spicein_log_file="/tmp/import-nand2/spiceIn.log",
+        conn2sch_log_file="/tmp/import-nand2/conn2sch.stdout",
     )
 
-    assert 'vbParamFile = strcat("/tmp/import-nand2" "/spiceIn.il")' in skill
-    assert 'fprintf(vbOut "  \'language %L\\n" "Spectre")' in skill
-    assert 'fprintf(vbOut "  \'netlistFile %L\\n" "/tmp/nand2.scs")' in skill
-    assert 'fprintf(vbOut "  \'refLibList %L\\n" "analogLib basic")' in skill
-    assert 'fprintf(vbOut "  \'overwriteCells %L\\n" "all")' in skill
-    assert 'vbRunCdsLib = strcat("/tmp/import-nand2" "/cds.lib")' in skill
-    assert 'vbWorkCdsLib = strcat(getWorkingDir() "/cds.lib")' in skill
-    assert 'fprintf(vbOut "INCLUDE %s\\n" vbWorkCdsLib)' in skill
-    assert 'system(strcat("cd " vbRunDir " && spiceIn -param " vbParamFile' in skill
+    assert "spiceIn -param" not in skill
+    assert "system(" not in skill
+    assert "conn2sch -" not in skill
     assert 'conn2Sch("demoLib" "nand2" "netlist" ?destLibName "demoLib"' in skill
-    assert 'conn2sch -lib demoLib -cell nand2 -view netlist -destlib demoLib -destview schematic' in skill
-    assert 'list("imported" "demoLib" "nand2" vbParamFile vbSpiceInLog vbConn2SchLog)' in skill
+    assert '?block t) nil) unless(vbConnOk && car(vbConnOk)' in skill
+    assert 'list("imported" "demoLib" "nand2" "/tmp/import-nand2/spiceIn.il"' in skill
     assert "smic12sf" not in skill
     assert "sinomos" not in skill
 
@@ -178,7 +175,6 @@ def test_schematic_import_netlist_skill_rejects_same_target_views() -> None:
     skill = schematic_import_netlist_skill(
         "demoLib",
         "nand2",
-        "/tmp/nand2.scs",
         netlist_view="schematic",
         schematic_view="schematic",
     )
@@ -187,29 +183,166 @@ def test_schematic_import_netlist_skill_rejects_same_target_views() -> None:
     assert 'when("schematic" == "schematic" error("netlist and schematic views must differ"))' in skill
 
 
-def test_import_netlist_schematic_executes_generated_skill() -> None:
+def test_import_netlist_schematic_runs_spicein_outside_skill(monkeypatch, tmp_path) -> None:
+    work_dir = tmp_path / "virtuoso"
+    work_dir.mkdir()
+    (work_dir / "cds.lib").write_text("DEFINE demoLib ./demoLib\n", encoding="utf-8")
+    netlist_file = tmp_path / "nand2.scs"
+    netlist_file.write_text("simulator lang=spectre\n", encoding="utf-8")
+    run_dir = tmp_path / "import-nand2"
+
     class Client:
-        skill: str | None = None
-        timeout: int | None = None
+        ssh_runner = None
+        skills: list[str] = []
+        timeouts: list[int] = []
+        responses = [
+            {
+                "status": "success",
+                "output": (
+                    f'("{work_dir}" "/cad/IC/bin:/usr/bin" "/cad/lib" '
+                    '"27080@lic" "/lic.dat" "/cad/IC")'
+                ),
+            },
+            {"status": "success", "output": "t"},
+            {"status": "success", "output": '("imported" "demoLib" "nand2")'},
+        ]
 
         def execute_skill(self, skill: str, *, timeout: int):
-            self.skill = skill
-            self.timeout = timeout
-            return {"status": "success", "output": '("imported" "demoLib" "nand2")'}
+            self.skills.append(skill)
+            self.timeouts.append(timeout)
+            return self.responses.pop(0)
+
+    subprocess_calls = []
+
+    def fake_run(*args, **kwargs):
+        subprocess_calls.append((args, kwargs))
+        return subprocess.CompletedProcess(args[0], 0, stdout="spiceIn ok\n", stderr="")
+
+    monkeypatch.setattr(schematic_netlist_module.subprocess, "run", fake_run)
 
     client = Client()
     result = import_netlist_schematic(
         client,
         "demoLib",
         "nand2",
-        "/tmp/nand2.scs",
+        netlist_file,
+        language="Spectre",
+        run_dir=run_dir,
         timeout=90,
     )
 
     assert result == {"status": "success", "output": '("imported" "demoLib" "nand2")'}
-    assert client.timeout == 90
-    assert client.skill is not None
-    assert 'fprintf(vbOut "  \'outputViewName %L\\n" "netlist")' in client.skill
+    assert len(subprocess_calls) == 1
+    args, kwargs = subprocess_calls[0]
+    assert args[0] == ["/cad/IC/bin/spiceIn", "-param", str(run_dir / "spiceIn.il")]
+    assert kwargs["cwd"] == run_dir
+    assert kwargs["timeout"] == 90
+    assert kwargs["env"]["PATH"].startswith("/cad/IC/bin")
+    assert (run_dir / "cds.lib").read_text(encoding="utf-8") == f"INCLUDE {work_dir / 'cds.lib'}\n"
+    param_text = (run_dir / "spiceIn.il").read_text(encoding="utf-8")
+    assert f'  \'netlistFile "{netlist_file}"' in param_text
+    assert '  \'outputViewName "netlist"' in param_text
+    assert all("spiceIn -param" not in skill and "system(" not in skill for skill in client.skills)
+    assert 'conn2Sch("demoLib" "nand2" "netlist"' in client.skills[-1]
+
+
+def test_import_netlist_schematic_uploads_inputs_and_runs_remote_shell(tmp_path) -> None:
+    netlist_file = tmp_path / "nand2.scs"
+    netlist_file.write_text("simulator lang=spectre\n", encoding="utf-8")
+    dev_map_file = tmp_path / "devmap.txt"
+    dev_map_file.write_text("devselect := resistor res\n", encoding="utf-8")
+
+    class Runner:
+        commands: list[tuple[str, int | None]] = []
+
+        def run_command(self, command: str, timeout: int | None = None) -> CommandResult:
+            self.commands.append((command, timeout))
+            return CommandResult(0, "", "")
+
+    class Client:
+        ssh_runner = Runner()
+        skills: list[str] = []
+        uploads: list[tuple[Path, str, int | None]] = []
+        responses = [
+            {
+                "status": "success",
+                "output": (
+                    '("/remote/work" "/cad/IC/bin:/usr/bin" "/cad/lib" '
+                    '"27080@lic" "/lic.dat" "/cad/IC")'
+                ),
+            },
+            {"status": "success", "output": "t"},
+            {"status": "success", "output": '("imported" "demoLib" "nand2")'},
+        ]
+
+        def execute_skill(self, skill: str, *, timeout: int):
+            self.skills.append(skill)
+            return self.responses.pop(0)
+
+        def upload_file(self, local_path: Path, remote_path: str, *, timeout: int | None = None):
+            self.uploads.append((Path(local_path), remote_path, timeout))
+            return {"status": "success", "output": remote_path}
+
+    client = Client()
+    result = import_netlist_schematic(
+        client,
+        "demoLib",
+        "nand2",
+        netlist_file,
+        dev_map_file=dev_map_file,
+        run_dir="/remote/import-nand2",
+        timeout=120,
+    )
+
+    assert result["status"] == "success"
+    uploaded_names = {(path.name, remote, timeout) for path, remote, timeout in client.uploads}
+    assert ("nand2.scs", "/remote/import-nand2/nand2.scs", 120) in uploaded_names
+    assert ("devmap.txt", "/remote/import-nand2/devmap.txt", 120) in uploaded_names
+    assert ("spiceIn.il", "/remote/import-nand2/spiceIn.il", 120) in uploaded_names
+    assert ("cds.lib", "/remote/import-nand2/cds.lib", 120) in uploaded_names
+    commands = [command for command, _ in client.ssh_runner.commands]
+    assert any(command.startswith("mkdir -p ") for command in commands)
+    spicein_commands = [command for command in commands if "spiceIn" in command]
+    assert len(spicein_commands) == 1
+    assert "bash -lc" in spicein_commands[0]
+    assert "/cad/IC/bin/spiceIn -param /remote/import-nand2/spiceIn.il" in spicein_commands[0]
+    assert all("spiceIn -param" not in skill and "system(" not in skill for skill in client.skills)
+    assert 'conn2Sch("demoLib" "nand2" "netlist"' in client.skills[-1]
+
+
+def test_schematic_ops_import_netlist_delegates_to_client(monkeypatch, tmp_path) -> None:
+    calls = []
+    netlist_file = tmp_path / "nand2.scs"
+    netlist_file.write_text("simulator lang=spectre\n", encoding="utf-8")
+
+    def fake_import(client, lib, cell, netlist_file_arg, **kwargs):
+        calls.append((client, lib, cell, netlist_file_arg, kwargs))
+        return {"status": "success"}
+
+    monkeypatch.setattr(schematic_netlist_module, "import_netlist_schematic", fake_import)
+
+    client = object()
+    result = SchematicOps(client).import_netlist(
+        "demoLib",
+        "nand2",
+        netlist_file,
+        timeout=12,
+    )
+
+    assert result == {"status": "success"}
+    assert calls[0][:4] == (client, "demoLib", "nand2", netlist_file)
+    assert calls[0][4] == {
+        "language": "Spectre",
+        "sim_name": "spectre",
+        "output_sim_name": "spectre",
+        "ref_libs": ("analogLib", "basic"),
+        "netlist_view": "netlist",
+        "schematic_view": "schematic",
+        "overwrite": False,
+        "dev_map_file": None,
+        "run_dir": "/tmp/virtuoso_bridge_netlist_import",
+        "timeout": 12,
+    }
 
 
 def test_export_schematic_netlist_replaces_existing_output_directory(tmp_path) -> None:

--- a/tests/test_schematic_netlist.py
+++ b/tests/test_schematic_netlist.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shlex
 import subprocess
 from pathlib import Path
 
@@ -158,15 +159,18 @@ def test_schematic_import_netlist_skill_converts_imported_netlist_view_only() ->
         overwrite=True,
         param_file="/tmp/import-nand2/spiceIn.il",
         spicein_log_file="/tmp/import-nand2/spiceIn.log",
-        conn2sch_log_file="/tmp/import-nand2/conn2sch.stdout",
     )
 
     assert "spiceIn -param" not in skill
     assert "system(" not in skill
     assert "conn2sch -" not in skill
+    assert "ddDeleteObj(vbSchematicObj)" not in skill
+    assert "dbCopyCellView" in skill
+    assert 'vbDestViewName = "__vb_import_' in skill
     assert 'conn2Sch("demoLib" "nand2" "netlist" ?destLibName "demoLib"' in skill
-    assert '?block t) nil) unless(vbConnOk && car(vbConnOk)' in skill
+    assert '?destViewName vbDestViewName ?block t) nil)' in skill
     assert 'list("imported" "demoLib" "nand2" "/tmp/import-nand2/spiceIn.il"' in skill
+    assert "conn2sch.stdout" not in skill
     assert "smic12sf" not in skill
     assert "sinomos" not in skill
 
@@ -246,6 +250,47 @@ def test_import_netlist_schematic_runs_spicein_outside_skill(monkeypatch, tmp_pa
     assert 'conn2Sch("demoLib" "nand2" "netlist"' in client.skills[-1]
 
 
+def test_import_netlist_schematic_uses_unique_default_run_dirs(monkeypatch, tmp_path) -> None:
+    work_dir = tmp_path / "virtuoso"
+    work_dir.mkdir()
+    (work_dir / "cds.lib").write_text("DEFINE demoLib ./demoLib\n", encoding="utf-8")
+    netlist_file = tmp_path / "nand2.scs"
+    netlist_file.write_text("simulator lang=spectre\n", encoding="utf-8")
+
+    class Client:
+        ssh_runner = None
+        skills: list[str] = []
+
+        def execute_skill(self, skill: str, *, timeout: int):
+            self.skills.append(skill)
+            if "getWorkingDir()" in skill:
+                return {
+                    "status": "success",
+                    "output": f'("{work_dir}" "/cad/IC/bin:/usr/bin" "" "" "" "/cad/IC")',
+                }
+            if "vbSchematicObj" in skill and "vbNetlistObj" in skill and "conn2Sch" not in skill:
+                return {"status": "success", "output": "t"}
+            return {"status": "success", "output": '("imported" "demoLib" "nand2")'}
+
+    subprocess_calls = []
+
+    def fake_run(*args, **kwargs):
+        subprocess_calls.append((args, kwargs))
+        return subprocess.CompletedProcess(args[0], 0, stdout="", stderr="")
+
+    monkeypatch.setattr(schematic_netlist_module.subprocess, "run", fake_run)
+
+    client = Client()
+    import_netlist_schematic(client, "demoLib", "nand2", netlist_file, timeout=30)
+    import_netlist_schematic(client, "demoLib", "nand2", netlist_file, timeout=30)
+
+    run_dirs = [kwargs["cwd"] for _, kwargs in subprocess_calls]
+    assert len(run_dirs) == 2
+    assert run_dirs[0] != run_dirs[1]
+    assert all(path.name.startswith("virtuoso_bridge_netlist_import_demoLib_nand2_") for path in run_dirs)
+    assert all(str(path).startswith("/tmp/") for path in run_dirs)
+
+
 def test_import_netlist_schematic_uploads_inputs_and_runs_remote_shell(tmp_path) -> None:
     netlist_file = tmp_path / "nand2.scs"
     netlist_file.write_text("simulator lang=spectre\n", encoding="utf-8")
@@ -310,6 +355,134 @@ def test_import_netlist_schematic_uploads_inputs_and_runs_remote_shell(tmp_path)
     assert 'conn2Sch("demoLib" "nand2" "netlist"' in client.skills[-1]
 
 
+def test_import_netlist_schematic_validates_assumed_remote_inputs() -> None:
+    class Runner:
+        commands: list[tuple[str, int | None]] = []
+
+        def run_command(self, command: str, timeout: int | None = None) -> CommandResult:
+            self.commands.append((command, timeout))
+            if command.startswith("test -f "):
+                return CommandResult(0, "", "")
+            return CommandResult(0, "", "")
+
+    class Client:
+        ssh_runner = Runner()
+        uploads: list[tuple[Path, str, int | None]] = []
+        responses = [
+            {
+                "status": "success",
+                "output": '("/remote/work" "/cad/IC/bin:/usr/bin" "" "" "" "/cad/IC")',
+            },
+            {"status": "success", "output": "t"},
+            {"status": "success", "output": '("imported" "demoLib" "nand2")'},
+        ]
+
+        def execute_skill(self, skill: str, *, timeout: int):
+            return self.responses.pop(0)
+
+        def upload_file(self, local_path: Path, remote_path: str, *, timeout: int | None = None):
+            self.uploads.append((Path(local_path), remote_path, timeout))
+            return {"status": "success", "output": remote_path}
+
+    client = Client()
+    import_netlist_schematic(
+        client,
+        "demoLib",
+        "nand2",
+        "/already/remote/nand2.scs",
+        dev_map_file="/already/remote/devmap.txt",
+        run_dir="/remote/import-nand2",
+        timeout=120,
+    )
+
+    commands = [command for command, _ in client.ssh_runner.commands]
+    assert "test -f /already/remote/nand2.scs" in commands
+    assert "test -f /already/remote/devmap.txt" in commands
+    uploaded_names = [path.name for path, _, _ in client.uploads]
+    assert "nand2.scs" not in uploaded_names
+    assert "devmap.txt" not in uploaded_names
+    assert {"spiceIn.il", "cds.lib"}.issubset(set(uploaded_names))
+
+
+def test_import_netlist_schematic_quotes_assumed_remote_input_checks() -> None:
+    netlist_file = "/already remote/nand'2.scs"
+    dev_map_file = "/already remote/dev map's.txt"
+    run_dir = "/remote/import dir/nand'2"
+
+    class Runner:
+        commands: list[tuple[str, int | None]] = []
+
+        def run_command(self, command: str, timeout: int | None = None) -> CommandResult:
+            self.commands.append((command, timeout))
+            return CommandResult(0, "", "")
+
+    class Client:
+        ssh_runner = Runner()
+        uploads: list[tuple[Path, str, int | None]] = []
+        responses = [
+            {
+                "status": "success",
+                "output": '("/remote/work" "/cad/IC/bin:/usr/bin" "" "" "" "/cad/IC")',
+            },
+            {"status": "success", "output": "t"},
+            {"status": "success", "output": '("imported" "demoLib" "nand2")'},
+        ]
+
+        def execute_skill(self, skill: str, *, timeout: int):
+            return self.responses.pop(0)
+
+        def upload_file(self, local_path: Path, remote_path: str, *, timeout: int | None = None):
+            self.uploads.append((Path(local_path), remote_path, timeout))
+            return {"status": "success", "output": remote_path}
+
+    client = Client()
+    import_netlist_schematic(
+        client,
+        "demoLib",
+        "nand2",
+        netlist_file,
+        dev_map_file=dev_map_file,
+        run_dir=run_dir,
+        timeout=120,
+    )
+
+    commands = [command for command, _ in client.ssh_runner.commands]
+    assert f"mkdir -p {shlex.quote(run_dir)}" in commands
+    assert f"test -f {shlex.quote(netlist_file)}" in commands
+    assert f"test -f {shlex.quote(dev_map_file)}" in commands
+
+
+def test_import_netlist_schematic_rejects_missing_remote_input() -> None:
+    class Runner:
+        def run_command(self, command: str, timeout: int | None = None) -> CommandResult:
+            if command.startswith("test -f "):
+                return CommandResult(1, "", "missing")
+            return CommandResult(0, "", "")
+
+    class Client:
+        ssh_runner = Runner()
+        responses = [
+            {
+                "status": "success",
+                "output": '("/remote/work" "/cad/IC/bin:/usr/bin" "" "" "" "/cad/IC")',
+            },
+            {"status": "success", "output": "t"},
+        ]
+
+        def execute_skill(self, skill: str, *, timeout: int):
+            return self.responses.pop(0)
+
+    with pytest.raises(RuntimeError, match="remote input file not found"):
+        import_netlist_schematic(
+            Client(),
+            "demoLib",
+            "nand2",
+            "/missing/remote/nand2.scs",
+            run_dir="/remote/import-nand2",
+            timeout=120,
+        )
+
+
 def test_schematic_ops_import_netlist_delegates_to_client(monkeypatch, tmp_path) -> None:
     calls = []
     netlist_file = tmp_path / "nand2.scs"
@@ -340,7 +513,7 @@ def test_schematic_ops_import_netlist_delegates_to_client(monkeypatch, tmp_path)
         "schematic_view": "schematic",
         "overwrite": False,
         "dev_map_file": None,
-        "run_dir": "/tmp/virtuoso_bridge_netlist_import",
+        "run_dir": None,
         "timeout": 12,
     }
 


### PR DESCRIPTION
## Summary

Add a schematic netlist import helper that runs Cadence `spiceIn` from the Python shell/SSH layer, then uses the live SKILL bridge only for DFII database work and `conn2Sch` conversion.

The helper is exposed through `client.schematic.import_netlist()` and lower-level schematic netlist APIs. It supports local and SSH-backed operation, stages the generated `spiceIn` parameter file and `cds.lib`, validates input paths, parses import output, and keeps external Cadence tool execution out of SKILL `system()`.

## Details

- Add `schematic_import_netlist_skill()` and `import_netlist_schematic()`.
- Add `NetlistImportResult`, `parse_netlist_import_output()`, and log classification helpers.
- Run `spiceIn` outside SKILL and reserve SKILL for preflight checks and `conn2Sch`.
- Use unique default import run directories.
- Stage remote uploaded inputs under an `inputs/` subdirectory to avoid collisions with generated control files.
- Reject ambiguous relative remote input paths and missing local/remote input files early.
- Make final `conn2Sch` failures raise consistently with preflight and `spiceIn` failures.
- Harden `overwrite=True` by converting through a temporary schematic view and cleaning it with `unwindProtect`.

## Validation

- `python -m pytest tests/test_schematic_netlist.py tests/test_netlist_import_result.py -q`
- `python -m pytest -q`
- `python -m compileall -q src/virtuoso_bridge/virtuoso/schematic/__init__.py src/virtuoso_bridge/virtuoso/schematic/netlist.py tests/test_schematic_netlist.py tests/test_netlist_import_result.py`
- `git diff --check`
- Local Virtuoso smoke test against a `localhost` bridge and the `sinomos` library: imported a CDL netlist with `overwrite=True`, verified `("netlist" "schematic")`, verified no `__vb_import_*` temporary view remained, then deleted the smoke cell.
