### PR TITLE
Fix Spectre AC example magnitude handling

### DIFF
--- a/examples/02_spectre/02_cap_dc_ac.py
+++ b/examples/02_spectre/02_cap_dc_ac.py
@@ -67,10 +67,11 @@ def main() -> int:
 
     # AC frequency response
     freq = result.data.get("ac_freq", [])
-    vo_mag = result.data.get("ac_VO", [])
+    vo_ac = result.data.get("ac_VO", [])
 
-    if freq and vo_mag and len(freq) > 1:
-        # Convert to dB (relative to DC gain = 1.0)
+    if freq and vo_ac and len(freq) > 1:
+        # AC data is parsed as complex phasors; use magnitude for response plots.
+        vo_mag = [abs(v) for v in vo_ac]
         vo_db = [20 * math.log10(max(v, 1e-30)) for v in vo_mag]
 
         # Find -3dB frequency

--- a/tests/test_spectre_parsers.py
+++ b/tests/test_spectre_parsers.py
@@ -89,6 +89,33 @@ def test_swept_signal_late_first_step_is_nan(parsed_late_signal):
     assert sig_b[2] == 0.7
 
 
+def test_swept_ac_signal_preserves_complex_phasor():
+    """AC PSF values are phasors; consumers must choose magnitude/phase."""
+    text = """\
+HEADER
+PROPERTIES
+SWEEP
+"freq" 1
+TRACE
+"VO" "V"
+VALUE
+"freq" 1e6
+"VO" (1.0 0.0)
+"freq" 1e9
+"VO" (0.5 -0.5)
+END
+"""
+    lines = text.splitlines()
+    parsed = _parse_psf_swept_data(
+        lines,
+        len(lines),
+        {"HEADER": 0, "PROPERTIES": 1, "SWEEP": 2, "TRACE": 4, "VALUE": 6, "END": 11},
+    )
+
+    assert parsed["freq"] == [1e6, 1e9]
+    assert parsed["VO"] == [complex(1.0, 0.0), complex(0.5, -0.5)]
+
+
 # ---------------------------------------------------------------------------
 # parse_sweep_psf_directory — both layouts
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- treat parsed AC voltages as complex phasors in the cap DC/AC example
- convert AC phasors to magnitude before dB conversion, printing, and plotting
- add a parser regression test documenting that AC PSF values preserve complex phasors

## Validation
- uv run pytest tests/test_spectre_parsers.py
- uv run python examples/02_spectre/02_cap_dc_ac.py