### PR TITLE
Fix default view type mapping

### DIFF
--- a/src/virtuoso_bridge/virtuoso/ops.py
+++ b/src/virtuoso_bridge/virtuoso/ops.py
@@ -24,6 +24,10 @@ def default_view_type_for(view: str) -> str:
         return "maskLayout"
     if normalized == "schematic":
         return "schematic"
+    if normalized == "symbol":
+        return "schematicSymbol"
+    if normalized == "maestro":
+        return "maestro"
     return view
 
 def skill_point(x: float, y: float) -> str:

--- a/tests/test_virtuoso_ops.py
+++ b/tests/test_virtuoso_ops.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from virtuoso_bridge.virtuoso.ops import (
+    default_view_type_for,
+    open_cell_view,
+    open_window,
+)
+
+
+def test_default_view_type_for_common_cellviews() -> None:
+    assert default_view_type_for("schematic") == "schematic"
+    assert default_view_type_for("layout") == "maskLayout"
+    assert default_view_type_for("layout1") == "maskLayout"
+    assert default_view_type_for("symbol") == "schematicSymbol"
+    assert default_view_type_for("maestro") == "maestro"
+    assert default_view_type_for(" Symbol ") == "schematicSymbol"
+    assert default_view_type_for("MAESTRO") == "maestro"
+    assert default_view_type_for("customView") == "customView"
+
+
+def test_open_window_uses_symbol_view_type_by_default() -> None:
+    skill = open_window("demoLib", "nand2", view="symbol")
+
+    assert '?view "symbol" ?viewType "schematicSymbol" ?mode "a"' in skill
+
+
+def test_open_cell_view_uses_symbol_view_type_by_default() -> None:
+    skill = open_cell_view("demoLib", "nand2", view="symbol", mode="r")
+
+    assert skill == 'cv = dbOpenCellViewByType("demoLib" "nand2" "symbol" "schematicSymbol" "r")'
+
+
+def test_open_window_uses_maestro_view_type_by_default() -> None:
+    skill = open_window("demoLib", "nand2", view="maestro")
+
+    assert '?view "maestro" ?viewType "maestro" ?mode "a"' in skill
+
+
+def test_open_cell_view_uses_maestro_view_type_by_default() -> None:
+    skill = open_cell_view("demoLib", "nand2", view="maestro", mode="r")
+
+    assert skill == 'cv = dbOpenCellViewByType("demoLib" "nand2" "maestro" "maestro" "r")'


### PR DESCRIPTION
## Summary

- Map `symbol` views to the Virtuoso `schematicSymbol` view type by default.
- Keep existing defaults for schematic and layout views, and explicitly preserve `maestro` as its own view type.
- Add unit coverage for `default_view_type_for()`, `open_window()`, and `open_cell_view()`.

## Why

Callers opening symbol views currently need to pass `view_type="schematicSymbol"` manually. Without that override, helpers such as `open_window(..., view="symbol")` generate `viewType "symbol"`, which can cause Virtuoso `geOpen` to return `nil`.

## Validation

- `pixi run pytest tests/test_virtuoso_ops.py`
- `pixi run pytest tests/test_virtuoso_ops.py tests/test_symbol_ops.py tests/test_symbol_reader.py tests/test_schematic_ops.py`
- `pixi run pytest`