### PR TITLE
Add wire-bound schematic label option

### DIFF
--- a/src/virtuoso_bridge/virtuoso/schematic/ops.py
+++ b/src/virtuoso_bridge/virtuoso/schematic/ops.py
@@ -292,6 +292,7 @@ def schematic_label_instance_term(
     extension_length: float | None = None,
     cosmetic: str = "default",
     auto_rotation: bool = False,
+    bind_label_to_wire: bool = False,
 ) -> str:
     """Build SKILL to place a labeled wire stub at an instance terminal.
 
@@ -310,6 +311,11 @@ def schematic_label_instance_term(
     the geometric stub direction (the same ``rbDx`` / ``rbDy`` already
     computed inside the SKILL). Default False keeps the legacy explicit
     behavior.
+
+    ``bind_label_to_wire``: when True, pass the created wire object to
+    ``schCreateWireLabel`` instead of ``nil``. This avoids unconnected-label
+    warnings in flows that check the generated schematic immediately. Default
+    False keeps the legacy generated SKILL unchanged.
     """
     preset = _LABEL_TERM_COSMETIC_PRESETS.get(cosmetic, _LABEL_TERM_COSMETIC_PRESETS["default"])
     eff_just = justification if justification is not None else preset["justification"]
@@ -327,8 +333,18 @@ def schematic_label_instance_term(
     else:
         rotation_expr = f'"{escape_skill_string(rotation)}"'
 
+    wire_vars = "rbWire rbWireObj " if bind_label_to_wire else ""
+    wire_expr = (
+        f'rbWire = when(rbCtr && rbStubEnd schCreateWire({cv_expr} "route" "full" list(rbCtr rbStubEnd) 0 0 0 nil nil)) '
+        "rbWireObj = if(listp(rbWire) car(rbWire) rbWire) "
+        if bind_label_to_wire
+        else 'when(rbCtr && rbStubEnd schCreateWire(cv "route" "full" list(rbCtr rbStubEnd) 0 0 0 nil nil)) '
+    )
+    label_wire_expr = "rbWireObj" if bind_label_to_wire else "nil"
+    label_guard_expr = "rbWireObj && rbMid" if bind_label_to_wire else "rbMid"
+
     return (
-        "let((rbInst rbTerm rbPin rbFig rbLocalBBox rbLocalCtr rbLocalEnd rbCtr rbStubEnd rbMid "
+        f"let((rbInst rbTerm rbPin rbFig rbLocalBBox rbLocalCtr rbLocalEnd rbCtr rbStubEnd rbMid {wire_vars}"
         "rbInstBBox rbInstCtr rbDx rbDy rbMasterName rbTermName rbIsMos rbIsPmos rbOrigin rbLocalDir rbDirPt) "
         f"{_schematic_bind_instance_and_term_expr(instance_name, term_name, cv_expr=cv_expr)}"
         "rbLocalBBox = when(rbFig rbFig~>bBox) "
@@ -341,9 +357,9 @@ def schematic_label_instance_term(
         "rbMid = when(rbCtr && rbStubEnd "
         "list((xCoord(rbCtr) + xCoord(rbStubEnd)) / 2.0 "
         "(yCoord(rbCtr) + yCoord(rbStubEnd)) / 2.0)) "
-        "when(rbCtr && rbStubEnd schCreateWire(cv \"route\" \"full\" list(rbCtr rbStubEnd) 0 0 0 nil nil)) "
-        "when(rbMid "
-        f'schCreateWireLabel({cv_expr} nil rbMid "{escape_skill_string(net_name)}" '
+        f"{wire_expr}"
+        f"when({label_guard_expr} "
+        f'schCreateWireLabel({cv_expr} {label_wire_expr} rbMid "{escape_skill_string(net_name)}" '
         f'"{escape_skill_string(eff_just)}" '
         f'{rotation_expr} '
         f'"{escape_skill_string(style)}" {height:g} nil)))'

--- a/tests/test_schematic_ops.py
+++ b/tests/test_schematic_ops.py
@@ -5,6 +5,7 @@ import pytest
 from virtuoso_bridge.virtuoso.schematic.ops import (
     schematic_create_net_stub,
     schematic_create_net_expression,
+    schematic_label_instance_term,
     schematic_set_netset_property,
 )
 
@@ -86,3 +87,45 @@ def test_schematic_create_net_stub_rejects_non_positive_length() -> None:
 def test_schematic_create_net_stub_rejects_unknown_direction() -> None:
     with pytest.raises(ValueError, match="direction must be one of"):
         schematic_create_net_stub("IN", 0, 0, direction="diagonal")
+
+
+def test_schematic_label_instance_term_keeps_unbound_label_by_default() -> None:
+    skill = schematic_label_instance_term("M0", "D", "OUT")
+
+    assert 'schCreateWire(cv "route" "full" list(rbCtr rbStubEnd) 0 0 0 nil nil)' in skill
+    assert 'schCreateWireLabel(cv nil rbMid "OUT"' in skill
+    assert "rbWireObj" not in skill
+
+
+def test_schematic_label_instance_term_preserves_legacy_wire_cv_by_default() -> None:
+    skill = schematic_label_instance_term("M0", "D", "OUT", cv_expr="targetCv")
+
+    assert 'targetCv~>instances' in skill
+    assert 'schCreateWire(cv "route" "full" list(rbCtr rbStubEnd) 0 0 0 nil nil)' in skill
+    assert 'schCreateWireLabel(targetCv nil rbMid "OUT"' in skill
+    assert 'schCreateWire(targetCv "route" "full"' not in skill
+
+
+def test_schematic_label_instance_term_can_bind_label_to_created_wire() -> None:
+    skill = schematic_label_instance_term("M0", "D", "OUT", bind_label_to_wire=True)
+
+    assert 'rbWire = when(rbCtr && rbStubEnd schCreateWire(cv "route" "full" list(rbCtr rbStubEnd) 0 0 0 nil nil))' in skill
+    assert "rbWireObj = if(listp(rbWire) car(rbWire) rbWire)" in skill
+    assert "when(rbWireObj && rbMid" in skill
+    assert 'schCreateWireLabel(cv rbWireObj rbMid "OUT"' in skill
+
+
+def test_schematic_label_instance_term_bind_uses_custom_cellview_expr() -> None:
+    skill = schematic_label_instance_term(
+        "M0",
+        "D",
+        "OUT",
+        cv_expr="targetCv",
+        bind_label_to_wire=True,
+    )
+
+    assert 'targetCv~>instances' in skill
+    assert 'rbWire = when(rbCtr && rbStubEnd schCreateWire(targetCv "route" "full"' in skill
+    assert 'schCreateWireLabel(targetCv rbWireObj rbMid "OUT"' in skill
+    assert 'schCreateWire(cv "route" "full"' not in skill
+    assert 'schCreateWireLabel(cv ' not in skill


### PR DESCRIPTION
## Summary

- Add an opt-in `bind_label_to_wire` argument to `schematic_label_instance_term()`.
- Preserve the default unbound `schCreateWireLabel(... nil ...)` output and legacy `schCreateWire(cv ...)` behavior for compatibility.
- When enabled, capture the `schCreateWire` return value, normalize list returns with `car`, and pass the created wire object to `schCreateWireLabel`.
- Keep the bound wire and label on the same `cv_expr` when callers use a custom cellview expression.

## Why

Some generated schematics trigger SCH-7069 unconnected-label warnings when labels are created with `nil` as the target wire object. Binding the label to the wire returned by `schCreateWire` avoids that warning while keeping connectivity behavior and legacy output available by default.

## Validation

- `pixi run pytest tests/test_schematic_ops.py` - 13 passed
- `pixi run pytest` - 201 passed
- `git diff --check`