### PR TITLE
[codex] Add native schematic-to-symbol helper

### DIFF
--- a/examples/01_virtuoso/schematic/08_import_cdl_cap_array.py
+++ b/examples/01_virtuoso/schematic/08_import_cdl_cap_array.py
@@ -207,7 +207,7 @@ cd {work_dir}
         return 1
 
     # 3. Generate symbol for cap_unit
-    client.execute_skill(f'schPinListToSymbol("{lib}" "cap_unit" "symbol" schSchemToPinList("{lib}" "cap_unit" "schematic"))')
+    client.symbol.generate_from_schematic(lib, "cap_unit", overwrite=True)
     r = client.execute_skill(f'ddGetObj("{lib}" "cap_unit")~>views~>name')
     print(f"[symbol] cap_unit: {r.output}")
 

--- a/examples/01_virtuoso/symbol/01_rc_create_with_symbol.py
+++ b/examples/01_virtuoso/symbol/01_rc_create_with_symbol.py
@@ -7,16 +7,14 @@ Two-step flow:
      pins (IN, OUT, GND).  The cell is auto-timestamped so reruns never
      overwrite earlier results.
 
-  2. Generate a symbol view via the Text-to-Symbol Generator (TSG) primitives::
+  2. Generate a symbol view through ``client.symbol.generate_from_schematic()``,
+     which wraps the Text-to-Symbol Generator (TSG) primitives::
 
         schSchemToPinList(lib, cell, "schematic")    → pin-list struct
         schPinListToSymbol(lib, cell, "symbol", pl)  → writes the symbol view
 
-     We deliberately use the low-level pair instead of the higher-level
-     ``schViewToView`` because the latter relies on ``hiRegTimer`` to dismiss
-     the "Replace existing symbol?" and CDF dialogs that can pop up — fragile
-     in headless automation.  With the low-level path no dialog appears
-     because we always start from a fresh, symbol-less cell.
+     The helper uses a temporary symbol view, verifies its terminals, and then
+     copies it into place without relying on GUI dialog dismissal.
 
 Pin order on the generated symbol comes from the schematic env var
 ``ssgSortPins``:
@@ -72,20 +70,11 @@ def _create_schematic(client: VirtuosoClient, lib: str, cell: str) -> None:
 
 def _generate_symbol(client: VirtuosoClient, lib: str, cell: str) -> None:
     """Run TSG: schematic → pin list → symbol view."""
-    # Pin order on the symbol — geometric preserves where pins live in the
-    # schematic.  Default would be alphanumeric (GND, IN, OUT).
-    client.execute_skill('schSetEnv("ssgSortPins" "geometric")')
-
-    # Two-call TSG pipeline.  The intermediate pinList is a SKILL struct
-    # that we don't need to inspect from Python — keep it inside one
-    # ``let`` so we don't pollute the global SKILL namespace.
-    r = client.execute_skill(
-        'let((pl) '
-        f'pl = schSchemToPinList("{lib}" "{cell}" "schematic") '
-        f'schPinListToSymbol("{lib}" "{cell}" "symbol" pl))'
+    client.symbol.generate_from_schematic(
+        lib,
+        cell,
+        sort_pins="geometric",
     )
-    if r.errors:
-        raise RuntimeError(f"TSG failed: {r.errors[0]}")
 
 
 def _verify_views(client: VirtuosoClient, lib: str, cell: str) -> list[str]:

--- a/examples/01_virtuoso/symbol/02_bus10_create_with_symbol.py
+++ b/examples/01_virtuoso/symbol/02_bus10_create_with_symbol.py
@@ -57,14 +57,11 @@ def _create_schematic(client: VirtuosoClient, lib: str, cell: str) -> None:
 def _generate_symbol(client: VirtuosoClient, lib: str, cell: str) -> None:
     # Geometric sort → pin order on the symbol mirrors schematic position
     # (top-to-bottom).  Default alphanumeric would sort IN10 before IN2 etc.
-    client.execute_skill('schSetEnv("ssgSortPins" "geometric")')
-    r = client.execute_skill(
-        'let((pl) '
-        f'pl = schSchemToPinList("{lib}" "{cell}" "schematic") '
-        f'schPinListToSymbol("{lib}" "{cell}" "symbol" pl))'
+    client.symbol.generate_from_schematic(
+        lib,
+        cell,
+        sort_pins="geometric",
     )
-    if r.errors:
-        raise RuntimeError(f"TSG failed: {r.errors[0]}")
 
 
 def _verify(client: VirtuosoClient, lib: str, cell: str) -> tuple[list[str], list[str]]:

--- a/examples/01_virtuoso/veriloga/README.md
+++ b/examples/01_virtuoso/veriloga/README.md
@@ -17,9 +17,9 @@ The IC618-supported way is mechanical but multi-step. There is no
 1. **Placeholder schematic** with floating pins matching the .va's
    ports.  The symbol generator works off the schematic pin list, not
    off .va text — schematic must exist first.
-2. **Symbol** generated from the schematic via `schSchemToPinList` +
-   `schPinListToSymbol`.  Geometric pin sort ⇒ symbol layout follows
-   schematic placement.
+2. **Symbol** generated through `client.symbol.generate_from_schematic()`,
+   which wraps `schSchemToPinList` + `schPinListToSymbol`. Geometric pin sort
+   ⇒ symbol layout follows schematic placement.
 3. **Veriloga skeleton** generated from the symbol via
    `schViewToView ... "symbol" "veriloga" "schSymbolToPinList"
    "ahdlPinListToveriloga"`.  This drops a default

--- a/examples/01_virtuoso/veriloga/import_veriloga.py
+++ b/examples/01_virtuoso/veriloga/import_veriloga.py
@@ -9,9 +9,10 @@ exposes as a single high-level helper today (this example is the helper):
    Cadence's symbol generator works off the schematic's pin list, not
    off the .va text — so we need a schematic first, even though it
    never gets simulated.
-2. **Symbol** auto-generated from the schematic via
-   ``schSchemToPinList`` + ``schPinListToSymbol``. Geometric pin sort
-   so the symbol layout follows the schematic's pin placement.
+2. **Symbol** auto-generated through
+   ``client.symbol.generate_from_schematic()``. The helper wraps
+   ``schSchemToPinList`` + ``schPinListToSymbol``; geometric pin sort makes
+   the symbol layout follow the schematic's pin placement.
    (Do **not** use ``schPinListToSymbolGen`` — it builds an
    empty-terminal symbol that the veriloga generator chokes on.)
 3. **Veriloga skeleton** generated from the symbol via
@@ -99,14 +100,11 @@ def _build_placeholder_schematic(
 
 
 def _generate_symbol(client: VirtuosoClient, lib: str, cell: str) -> None:
-    client.execute_skill('schSetEnv("ssgSortPins" "geometric")')
-    r = client.execute_skill(
-        'let((pl) '
-        f'pl = schSchemToPinList("{lib}" "{cell}" "schematic") '
-        f'schPinListToSymbol("{lib}" "{cell}" "symbol" pl))'
+    client.symbol.generate_from_schematic(
+        lib,
+        cell,
+        sort_pins="geometric",
     )
-    if r.errors:
-        raise RuntimeError(f"symbol generation failed: {r.errors[0]}")
 
 
 def _generate_veriloga_skeleton(
@@ -191,7 +189,7 @@ def main() -> int:
         args.inputs, args.outputs, args.inouts,
     )
 
-    print(f"[2/5] symbol via schPinListToSymbol")
+    print("[2/5] symbol via client.symbol.generate_from_schematic")
     _generate_symbol(client, args.lib, args.cell)
 
     print(f"[3/5] veriloga skeleton via schViewToView")

--- a/skills/virtuoso/SKILL.md
+++ b/skills/virtuoso/SKILL.md
@@ -47,6 +47,7 @@ Always use the highest level that works. Drop to a lower level only when needed.
 | Domain | What it does | Python package | API docs |
 |--------|-------------|----------------|----------|
 | **Schematic** | Create/edit schematics, wire instances, add pins | `client.schematic.*` | `references/schematic-python-api.md`, `references/schematic-skill-api.md` |
+| **Symbol** | Generate, edit, and read symbol views | `client.symbol.*` | `references/symbol-python-api.md` |
 | **Layout** | Create/edit layout, add shapes/vias/instances | `client.layout.*` | `references/layout-python-api.md`, `references/layout-skill-api.md` |
 | **Maestro** | Read/write ADE Assembler config, run simulations | `virtuoso_bridge.virtuoso.maestro` | `references/maestro-python-api.md`, `references/maestro-skill-api.md` |
 | **Netlist (si)** | Batch netlist generation without Maestro | `simInitEnvWithArgs` + `si` CLI | See "Batch Netlist (si)" section below |

--- a/skills/virtuoso/references/netlist.md
+++ b/skills/virtuoso/references/netlist.md
@@ -100,7 +100,7 @@ result = client.symbol.generate_from_schematic(
     sort_pins="alphanumeric",
     overwrite=False,
 )
-print(result.terminal_names, result.term_order)
+print(result.terminal_names, result.pin_order)
 ```
 The helper wraps `schSchemToPinList` + `schPinListToSymbol`, restores the
 session's prior pin-sort setting, and verifies the generated terminals and

--- a/skills/virtuoso/references/netlist.md
+++ b/skills/virtuoso/references/netlist.md
@@ -94,11 +94,18 @@ devselect := inductor ind
 
 **Symbol generation** after spiceIn import:
 ```python
-# IMPORTANT: must be a single-line SKILL string — multi-line f-strings
-# with newlines cause SKILL parsing failure via bridge
-client.execute_skill(f'schPinListToSymbol("{lib}" "{cell}" "symbol" schSchemToPinList("{lib}" "{cell}" "schematic"))')
+result = client.symbol.generate_from_schematic(
+    lib,
+    cell,
+    sort_pins="alphanumeric",
+    overwrite=False,
+)
+print(result.terminal_names, result.term_order)
 ```
-The function works for all cells. Never manually create symbols. Verify with `ddGetObj(lib cell)~>views~>name`.
+The helper wraps `schSchemToPinList` + `schPinListToSymbol`, restores the
+session's prior pin-sort setting, and verifies the generated terminals through
+symbol readback. Set `overwrite=True` to replace an existing symbol through a
+verified temporary view instead of a GUI replace dialog.
 
 Key points:
 - **Auto-wires** everything — instances, nets, pins all connected automatically

--- a/skills/virtuoso/references/netlist.md
+++ b/skills/virtuoso/references/netlist.md
@@ -103,9 +103,10 @@ result = client.symbol.generate_from_schematic(
 print(result.terminal_names, result.term_order)
 ```
 The helper wraps `schSchemToPinList` + `schPinListToSymbol`, restores the
-session's prior pin-sort setting, and verifies the generated terminals through
-symbol readback. Set `overwrite=True` to replace an existing symbol through a
-verified temporary view instead of a GUI replace dialog.
+session's prior pin-sort setting, and verifies the generated terminals and
+effective pin order before returning. Set `overwrite=True` to replace a closed
+existing symbol through a backed-up, rollback-capable transaction instead of a
+GUI replace dialog.
 
 Key points:
 - **Auto-wires** everything — instances, nets, pins all connected automatically

--- a/skills/virtuoso/references/symbol-python-api.md
+++ b/skills/virtuoso/references/symbol-python-api.md
@@ -31,14 +31,14 @@ and verifies the requested symbol view in the same SKILL transaction.
 - `sort_pins` accepts `"alphanumeric"`, `"geometric"`, or `None`. A requested
   value temporarily overrides `ssgSortPins`; the previous value is restored
   before the destination is modified. This setting controls physical pin
-  placement, not the logical order returned in `term_order`.
+  placement, not the logical order returned in `pin_order`.
 - `overwrite` defaults to `False`. When `True`, the existing target is replaced
   only after temporary-view validation succeeds. An open target is rejected;
   otherwise the helper creates a private backup and restores it if the copy or
   final validation fails.
 - `SymbolGenerationResult.action` is `"created"` or `"replaced"`.
 - `terminal_names` contains the generated terminal names.
-- `term_order` is the effective order returned by Cadence's
+- `pin_order` is the effective order returned by Cadence's
   `schGetPinOrder()`, which resolves an explicit `portOrder` or the native
   default order.
 

--- a/skills/virtuoso/references/symbol-python-api.md
+++ b/skills/virtuoso/references/symbol-python-api.md
@@ -1,0 +1,59 @@
+# Symbol Python API
+
+Python wrappers for Cadence Virtuoso symbol generation, editing, and readback.
+
+**Package:** `virtuoso_bridge.virtuoso.symbol`
+
+```python
+from virtuoso_bridge import VirtuosoClient
+
+client = VirtuosoClient.from_env()
+```
+
+## Generate From Schematic
+
+```python
+result = client.symbol.generate_from_schematic(
+    "demoLib",
+    "nand2",
+    schematic_view="schematic",
+    symbol_view="symbol",
+    sort_pins="geometric",
+    overwrite=False,
+    timeout=60,
+)
+```
+
+The helper runs `schSchemToPinList` and `schPinListToSymbol` on a unique
+temporary view, validates its terminals, copies it to the requested symbol
+view, and verifies the final view with `client.symbol.read_ports()`.
+
+- `sort_pins` accepts `"alphanumeric"`, `"geometric"`, or `None`. A requested
+  value temporarily overrides `ssgSortPins`; the previous value is restored.
+- `overwrite` defaults to `False`. When `True`, the existing target is replaced
+  only after temporary-view generation and terminal validation succeed.
+- `SymbolGenerationResult.action` is `"created"` or `"replaced"`.
+- `terminal_names` contains the generated terminal names.
+- `term_order` uses explicit `portOrder`, then legacy `termOrder`, then the
+  Cadence default order: output, inputOutput, input; names are sorted within
+  each direction.
+
+The overwrite path avoids GUI replacement dialogs, but it is not a rollback
+transaction: a failure after the final database copy can leave the new symbol
+in place.
+
+## Read Ports
+
+```python
+ports = client.symbol.read_ports("demoLib", "nand2")
+```
+
+The returned dictionary contains `terms`, `labels`, `portOrder`, and
+`termOrder`. `portOrder` is the native symbol property; `termOrder` is retained
+separately for existing callers and manually authored symbols.
+
+## Edit Symbol
+
+Use `client.symbol.edit()` as a context manager with the builders exported by
+`virtuoso_bridge.virtuoso.symbol.ops`. The editor runs `schCheck`, saves, and
+closes the symbol on context exit.

--- a/skills/virtuoso/references/symbol-python-api.md
+++ b/skills/virtuoso/references/symbol-python-api.md
@@ -34,9 +34,9 @@ view, and verifies the final view with `client.symbol.read_ports()`.
   only after temporary-view generation and terminal validation succeed.
 - `SymbolGenerationResult.action` is `"created"` or `"replaced"`.
 - `terminal_names` contains the generated terminal names.
-- `term_order` uses explicit `portOrder`, then legacy `termOrder`, then the
-  Cadence default order: output, inputOutput, input; names are sorted within
-  each direction.
+- `term_order` is the effective order returned by Cadence's
+  `schGetPinOrder()`, which resolves an explicit `portOrder` or the native
+  default order.
 
 The overwrite path avoids GUI replacement dialogs, but it is not a rollback
 transaction: a failure after the final database copy can leave the new symbol
@@ -48,8 +48,9 @@ in place.
 ports = client.symbol.read_ports("demoLib", "nand2")
 ```
 
-The returned dictionary contains `terms`, `labels`, `portOrder`, and
-`termOrder`. `portOrder` is the native symbol property; `termOrder` is retained
+The returned dictionary contains `terms`, `labels`, `pinOrder`, `portOrder`,
+and `termOrder`. `pinOrder` is the effective value from `schGetPinOrder()`,
+`portOrder` is the native symbol property, and `termOrder` is retained
 separately for existing callers and manually authored symbols.
 
 ## Edit Symbol

--- a/skills/virtuoso/references/symbol-python-api.md
+++ b/skills/virtuoso/references/symbol-python-api.md
@@ -25,22 +25,26 @@ result = client.symbol.generate_from_schematic(
 ```
 
 The helper runs `schSchemToPinList` and `schPinListToSymbol` on a unique
-temporary view, validates its terminals, copies it to the requested symbol
-view, and verifies the final view with `client.symbol.read_ports()`.
+temporary view, validates its terminals and effective pin order, then installs
+and verifies the requested symbol view in the same SKILL transaction.
 
 - `sort_pins` accepts `"alphanumeric"`, `"geometric"`, or `None`. A requested
-  value temporarily overrides `ssgSortPins`; the previous value is restored.
+  value temporarily overrides `ssgSortPins`; the previous value is restored
+  before the destination is modified. This setting controls physical pin
+  placement, not the logical order returned in `term_order`.
 - `overwrite` defaults to `False`. When `True`, the existing target is replaced
-  only after temporary-view generation and terminal validation succeed.
+  only after temporary-view validation succeeds. An open target is rejected;
+  otherwise the helper creates a private backup and restores it if the copy or
+  final validation fails.
 - `SymbolGenerationResult.action` is `"created"` or `"replaced"`.
 - `terminal_names` contains the generated terminal names.
 - `term_order` is the effective order returned by Cadence's
   `schGetPinOrder()`, which resolves an explicit `portOrder` or the native
   default order.
 
-The overwrite path avoids GUI replacement dialogs, but it is not a rollback
-transaction: a failure after the final database copy can leave the new symbol
-in place.
+Temporary-view, backup, pin-sort restoration, and rollback failures are
+reported instead of being reduced to CIW warnings. If rollback itself fails,
+the exception identifies the retained backup view for manual recovery.
 
 ## Read Ports
 

--- a/src/virtuoso_bridge/virtuoso/response.py
+++ b/src/virtuoso_bridge/virtuoso/response.py
@@ -1,0 +1,28 @@
+"""Shared helpers for normalizing SKILL transport responses."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def response_fields(response: Any) -> tuple[Any, Any, str]:
+    """Return errors, status, and output from object or dictionary responses."""
+    if isinstance(response, dict):
+        result = response.get("result") if isinstance(response.get("result"), dict) else {}
+        errors = response.get("errors") or result.get("errors")
+        status = response.get("status") or result.get("status")
+        output = response.get("output")
+        if output is None:
+            output = result.get("output", "")
+        if response.get("ok") is False and not errors:
+            errors = [response.get("error") or result.get("error") or "request failed"]
+        return errors, status, output or ""
+
+    return (
+        getattr(response, "errors", None),
+        getattr(response, "status", None),
+        getattr(response, "output", "") or "",
+    )
+
+
+__all__ = ["response_fields"]

--- a/src/virtuoso_bridge/virtuoso/response.py
+++ b/src/virtuoso_bridge/virtuoso/response.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import Any
 
 
-def response_fields(response: Any) -> tuple[Any, Any, str]:
+def response_fields(response: Any) -> tuple[list[str], Any, str]:
     """Return errors, status, and output from object or dictionary responses."""
     if isinstance(response, dict):
         result = response.get("result") if isinstance(response.get("result"), dict) else {}
@@ -16,13 +17,31 @@ def response_fields(response: Any) -> tuple[Any, Any, str]:
             output = result.get("output", "")
         if response.get("ok") is False and not errors:
             errors = [response.get("error") or result.get("error") or "request failed"]
-        return errors, status, output or ""
+        return _error_messages(errors), status, _output_text(output)
 
     return (
-        getattr(response, "errors", None),
+        _error_messages(getattr(response, "errors", None)),
         getattr(response, "status", None),
-        getattr(response, "output", "") or "",
+        _output_text(getattr(response, "output", "")),
     )
+
+
+def _error_messages(errors: Any) -> list[str]:
+    if errors is None or errors == "":
+        return []
+    if isinstance(errors, str):
+        return [errors]
+    if isinstance(errors, Iterable):
+        return [str(error) for error in errors]
+    return [str(errors)]
+
+
+def _output_text(output: Any) -> str:
+    if output is None:
+        return ""
+    if isinstance(output, str):
+        return output
+    return str(output)
 
 
 __all__ = ["response_fields"]

--- a/src/virtuoso_bridge/virtuoso/skill_output.py
+++ b/src/virtuoso_bridge/virtuoso/skill_output.py
@@ -95,6 +95,35 @@ def parse_sexpr(tok: str):
     return tok
 
 
+def is_single_complete_skill_list(raw: str) -> bool:
+    """Return whether text is exactly one balanced top-level SKILL list."""
+    text = (raw or "").strip()
+    if not text.startswith("("):
+        return False
+
+    depth = 0
+    in_string = False
+    escaped = False
+    for index, character in enumerate(text):
+        if in_string:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                in_string = False
+            continue
+        if character == '"':
+            in_string = True
+        elif character == "(":
+            depth += 1
+        elif character == ")":
+            depth -= 1
+            if depth < 0 or (depth == 0 and index != len(text) - 1):
+                return False
+    return depth == 0 and not in_string
+
+
 def _scan_string(text: str, start: int) -> int:
     i = start + 1
     while i < len(text):

--- a/src/virtuoso_bridge/virtuoso/symbol/__init__.py
+++ b/src/virtuoso_bridge/virtuoso/symbol/__init__.py
@@ -5,6 +5,13 @@ from __future__ import annotations
 from typing import Any, TYPE_CHECKING
 
 from virtuoso_bridge.virtuoso.symbol.editor import SymbolEditor
+from virtuoso_bridge.virtuoso.symbol.generator import (
+    SymbolGenerationAction,
+    SymbolGenerationResult,
+    SymbolPinSort,
+    generate_symbol_from_schematic,
+    symbol_generate_from_schematic_skill,
+)
 from virtuoso_bridge.virtuoso.symbol.ops import (
     symbol_check,
     symbol_create_ellipse,
@@ -51,6 +58,29 @@ class SymbolOps:
             timeout=timeout,
         )
 
+    def generate_from_schematic(
+        self,
+        lib: str,
+        cell: str,
+        *,
+        schematic_view: str = "schematic",
+        symbol_view: str = "symbol",
+        sort_pins: SymbolPinSort | None = None,
+        overwrite: bool = False,
+        timeout: int = 60,
+    ) -> SymbolGenerationResult:
+        """Generate and verify a symbol from a schematic cellview."""
+        return generate_symbol_from_schematic(
+            self._owner,
+            lib,
+            cell,
+            schematic_view=schematic_view,
+            symbol_view=symbol_view,
+            sort_pins=sort_pins,
+            overwrite=overwrite,
+            timeout=timeout,
+        )
+
     def read_ports(
         self,
         lib: str,
@@ -59,7 +89,7 @@ class SymbolOps:
         view_type: str = "schematicSymbol",
         timeout: int = 30,
     ) -> dict[str, Any]:
-        """Read symbol terminals, labels, and term order."""
+        """Read symbol terminals, labels, port order, and term order."""
         return read_symbol_ports(
             self._owner,
             lib,
@@ -73,6 +103,11 @@ class SymbolOps:
 __all__ = [
     "SymbolOps",
     "SymbolEditor",
+    "SymbolGenerationAction",
+    "SymbolGenerationResult",
+    "SymbolPinSort",
+    "generate_symbol_from_schematic",
+    "symbol_generate_from_schematic_skill",
     "symbol_create_line",
     "symbol_create_rect",
     "symbol_create_polygon",

--- a/src/virtuoso_bridge/virtuoso/symbol/generator.py
+++ b/src/virtuoso_bridge/virtuoso/symbol/generator.py
@@ -15,7 +15,6 @@ SymbolPinSort = Literal["alphanumeric", "geometric"]
 SymbolGenerationAction = Literal["created", "replaced"]
 
 _PIN_SORT_MODES = {"alphanumeric", "geometric"}
-_DEFAULT_DIRECTION_ORDER = {"output": 0, "inputOutput": 1, "input": 2}
 
 
 @dataclass(frozen=True)
@@ -71,7 +70,7 @@ def symbol_generate_from_schematic_skill(
     return (
         "let((vbSourceCv vbTargetObj vbTempObj vbTempCv vbTargetCv vbPinList vbGenerated "
         "vbReplacing vbAction vbExpectedTerms vbActualTerms vbExpectedTerm vbOldSort "
-        "vbSortChanged vbCleanup) "
+        "vbSortChanged vbCleanup vbCleanupFailed vbResult) "
         f'vbTargetObj = ddGetObj("{escaped_lib}" "{escaped_cell}" "{escaped_symbol_view}") '
         "vbReplacing = if(vbTargetObj t nil) "
         'vbAction = if(vbReplacing "replaced" "created") '
@@ -80,7 +79,7 @@ def symbol_generate_from_schematic_skill(
         f'vbTempObj = ddGetObj("{escaped_lib}" "{escaped_cell}" "{escaped_temp_view}") '
         'when(vbTempObj unless(ddDeleteObj(vbTempObj) error("temporary symbol delete failed"))) '
         f"{sort_capture}"
-        "unwindProtect("
+        "vbResult = unwindProtect("
         "progn("
         f'vbSourceCv = dbOpenCellViewByType("{escaped_lib}" "{escaped_cell}" '
         f'"{escaped_schematic_view}" "schematic" "r") '
@@ -122,8 +121,11 @@ def symbol_generate_from_schematic_skill(
         "when(vbTempObj "
         "vbCleanup = errset(ddDeleteObj(vbTempObj) nil) "
         "unless(vbCleanup && car(vbCleanup) "
-        'warn("temporary symbol cleanup failed"))) '
-        ")))"
+        "vbCleanupFailed = t))) "
+        ") "
+        "if(vbCleanupFailed "
+        'then list("cleanupFailed" "temporary symbol cleanup failed") '
+        "else vbResult))"
     )
 
 
@@ -179,13 +181,12 @@ def generate_symbol_from_schematic(
         )
 
     terminal_names = tuple(term["name"] for term in ports["terms"])
-    explicit_order = tuple(ports["portOrder"] or ports["termOrder"])
-    if explicit_order and Counter(explicit_order) != Counter(terminal_names):
+    term_order = tuple(ports["pinOrder"])
+    if Counter(term_order) != Counter(terminal_names):
         raise RuntimeError(
             f"generated symbol term order mismatch for {lib}/{cell}: "
-            f"terminals {terminal_names}, order {explicit_order}"
+            f"terminals {terminal_names}, order {term_order}"
         )
-    term_order = explicit_order or _default_term_order(ports["terms"])
     return SymbolGenerationResult(
         lib=lib,
         cell=cell,
@@ -201,17 +202,6 @@ def _validate_sort_pins(sort_pins: str | None) -> None:
     if sort_pins is not None and sort_pins not in _PIN_SORT_MODES:
         choices = ", ".join(sorted(_PIN_SORT_MODES))
         raise ValueError(f"sort_pins must be one of: {choices}")
-
-
-def _default_term_order(terms: list[dict[str, Any]]) -> tuple[str, ...]:
-    ordered = sorted(
-        terms,
-        key=lambda term: (
-            _DEFAULT_DIRECTION_ORDER.get(str(term.get("direction", "")), 3),
-            str(term.get("name", "")),
-        ),
-    )
-    return tuple(str(term.get("name", "")) for term in ordered)
 
 
 def _require_generation_success(response: Any, *, lib: str, cell: str) -> str:
@@ -231,6 +221,8 @@ def _parse_generation_output(
     output: str,
 ) -> tuple[SymbolGenerationAction, dict[str, tuple[str, int]]]:
     parsed = parse_sexpr(output)
+    if isinstance(parsed, list) and len(parsed) >= 2 and parsed[0] == "cleanupFailed":
+        raise RuntimeError(f"symbol generation cleanup failed: {parsed[1]}")
     if not isinstance(parsed, list) or len(parsed) < 3 or parsed[0] != "generated":
         raise RuntimeError(f"unexpected symbol generation output: {output}")
     action = str(parsed[1])

--- a/src/virtuoso_bridge/virtuoso/symbol/generator.py
+++ b/src/virtuoso_bridge/virtuoso/symbol/generator.py
@@ -9,7 +9,10 @@ from typing import Any, Literal, cast
 
 from virtuoso_bridge.virtuoso.ops import escape_skill_string
 from virtuoso_bridge.virtuoso.response import response_fields
-from virtuoso_bridge.virtuoso.skill_output import parse_sexpr
+from virtuoso_bridge.virtuoso.skill_output import (
+    is_single_complete_skill_list,
+    parse_sexpr,
+)
 
 SymbolPinSort = Literal["alphanumeric", "geometric"]
 SymbolGenerationAction = Literal["created", "replaced"]
@@ -328,7 +331,12 @@ def _require_generation_success(response: Any, *, lib: str, cell: str) -> str:
 def _parse_generation_output(
     output: str,
 ) -> tuple[SymbolGenerationAction, dict[str, tuple[str, int]], tuple[str, ...]]:
-    parsed = parse_sexpr(output)
+    text = (output or "").strip()
+    if not is_single_complete_skill_list(text):
+        raise RuntimeError(
+            "symbol generation output must be a single complete SKILL list"
+        )
+    parsed = parse_sexpr(text)
     if isinstance(parsed, list) and len(parsed) >= 3 and parsed[0] == "failed":
         body_failure = parsed[1]
         cleanup_failures = parsed[2]

--- a/src/virtuoso_bridge/virtuoso/symbol/generator.py
+++ b/src/virtuoso_bridge/virtuoso/symbol/generator.py
@@ -9,7 +9,7 @@ from typing import Any, Literal, cast
 
 from virtuoso_bridge.virtuoso.ops import escape_skill_string
 from virtuoso_bridge.virtuoso.skill_output import parse_sexpr
-from virtuoso_bridge.virtuoso.symbol.reader import _response_fields, read_symbol_ports
+from virtuoso_bridge.virtuoso.symbol.reader import _response_fields
 
 SymbolPinSort = Literal["alphanumeric", "geometric"]
 SymbolGenerationAction = Literal["created", "replaced"]
@@ -48,10 +48,12 @@ def symbol_generate_from_schematic_skill(
     escaped_schematic_view = escape_skill_string(schematic_view)
     escaped_symbol_view = escape_skill_string(symbol_view)
     escaped_temp_view = escape_skill_string(f"__vb_symbol_{uuid.uuid4().hex}")
+    escaped_backup_view = escape_skill_string(f"__vb_symbol_backup_{uuid.uuid4().hex}")
     overwrite_expr = "t" if overwrite else "nil"
 
     sort_capture = ""
     sort_setup = ""
+    sort_finalize = ""
     sort_restore = ""
     if sort_pins is not None:
         escaped_sort = escape_skill_string(sort_pins)
@@ -60,17 +62,28 @@ def symbol_generate_from_schematic_skill(
             f'vbSortChanged = schSetEnv("ssgSortPins" "{escaped_sort}") '
             'unless(vbSortChanged error("failed to set ssgSortPins")) '
         )
+        sort_finalize = (
+            "when(vbSortChanged "
+            'vbCleanup = errset(schSetEnv("ssgSortPins" vbOldSort) nil) '
+            'unless(vbCleanup && car(vbCleanup) error("failed to restore ssgSortPins")) '
+            "vbSortChanged = nil) "
+        )
         sort_restore = (
             "when(vbSortChanged "
-            'unless(schSetEnv("ssgSortPins" vbOldSort) '
-            'warn("failed to restore ssgSortPins")) '
+            'vbCleanup = errset(schSetEnv("ssgSortPins" vbOldSort) nil) '
+            "unless(vbCleanup && car(vbCleanup) "
+            'vbCleanupFailures = cons("failed to restore ssgSortPins" '
+            "vbCleanupFailures)) "
             "vbSortChanged = nil) "
         )
 
     return (
         "let((vbSourceCv vbTargetObj vbTempObj vbTempCv vbTargetCv vbPinList vbGenerated "
         "vbReplacing vbAction vbExpectedTerms vbActualTerms vbExpectedTerm vbOldSort "
-        "vbSortChanged vbCleanup vbCleanupFailed vbResult) "
+        "vbExpectedOrder vbActualOrder vbFinalTerms vbFinalOrder vbBackupSourceCv "
+        "vbOriginalTerms vbOriginalOrder vbBackupCv vbBackupObj vbSortChanged vbCleanup "
+        "vbCleanupFailures vbBodyResult vbBodyAttempt vbBodyFailure vbResult vbBackupReady "
+        "vbInstallAttempted vbInstalled vbCommitOk vbRollback vbRollbackSucceeded) "
         f'vbTargetObj = ddGetObj("{escaped_lib}" "{escaped_cell}" "{escaped_symbol_view}") '
         "vbReplacing = if(vbTargetObj t nil) "
         'vbAction = if(vbReplacing "replaced" "created") '
@@ -78,16 +91,21 @@ def symbol_generate_from_schematic_skill(
         f'when(vbReplacing && !{overwrite_expr} error("target symbol exists")) '
         f'vbTempObj = ddGetObj("{escaped_lib}" "{escaped_cell}" "{escaped_temp_view}") '
         'when(vbTempObj unless(ddDeleteObj(vbTempObj) error("temporary symbol delete failed"))) '
+        f'vbBackupObj = ddGetObj("{escaped_lib}" "{escaped_cell}" "{escaped_backup_view}") '
+        'when(vbBackupObj unless(ddDeleteObj(vbBackupObj) error("symbol backup delete failed"))) '
         f"{sort_capture}"
-        "vbResult = unwindProtect("
-        "progn("
+        'vbBodyFailure = "symbol generation failed" '
+        "vbBodyResult = unwindProtect(progn("
+        "vbBodyAttempt = errset(progn("
         f'vbSourceCv = dbOpenCellViewByType("{escaped_lib}" "{escaped_cell}" '
         f'"{escaped_schematic_view}" "schematic" "r") '
         'unless(vbSourceCv error("source schematic not found")) '
         "vbExpectedTerms = mapcar(lambda((vbTerm) "
         'list(vbTerm~>name if(vbTerm~>direction vbTerm~>direction "inputOutput") '
         "if(vbTerm~>numBits vbTerm~>numBits 1))) vbSourceCv~>terminals) "
-        "dbClose(vbSourceCv) vbSourceCv = nil "
+        "vbExpectedOrder = schGetPinOrder(vbSourceCv) "
+        'unless(dbClose(vbSourceCv) error("source schematic close failed")) '
+        "vbSourceCv = nil "
         f"{sort_setup}"
         f'vbPinList = schSchemToPinList("{escaped_lib}" "{escaped_cell}" "{escaped_schematic_view}") '
         'unless(vbPinList error("schematic to pin list failed")) '
@@ -100,32 +118,127 @@ def symbol_generate_from_schematic_skill(
         "vbActualTerms = mapcar(lambda((vbTerm) "
         'list(vbTerm~>name if(vbTerm~>direction vbTerm~>direction "inputOutput") '
         "if(vbTerm~>numBits vbTerm~>numBits 1))) vbTempCv~>terminals) "
+        "vbActualOrder = schGetPinOrder(vbTempCv) "
         "unless(length(vbExpectedTerms) == length(vbActualTerms) "
         'error("generated symbol terminals mismatch")) '
         "foreach(vbExpectedTerm vbExpectedTerms "
         "unless(member(vbExpectedTerm vbActualTerms) "
         'error("generated symbol terminals mismatch"))) '
+        'unless(equal(vbExpectedOrder vbActualOrder) error("generated symbol pin order mismatch")) '
+        f"{sort_finalize}"
         "unless(isCallable('dbCopyCellView) error(\"dbCopyCellView API unavailable\")) "
+        f'when(dbFindOpenCellViewByName("{escaped_lib}" "{escaped_cell}" '
+        f'"{escaped_symbol_view}") error("target symbol is open")) '
+        "when(vbReplacing "
+        f'vbBackupSourceCv = dbOpenCellViewByType("{escaped_lib}" "{escaped_cell}" '
+        f'"{escaped_symbol_view}" "schematicSymbol" "r") '
+        'unless(vbBackupSourceCv error("target symbol backup source open failed")) '
+        "vbOriginalTerms = mapcar(lambda((vbTerm) "
+        'list(vbTerm~>name if(vbTerm~>direction vbTerm~>direction "inputOutput") '
+        "if(vbTerm~>numBits vbTerm~>numBits 1))) vbBackupSourceCv~>terminals) "
+        "vbOriginalOrder = schGetPinOrder(vbBackupSourceCv) "
+        f'vbBackupCv = dbCopyCellView(vbBackupSourceCv "{escaped_lib}" "{escaped_cell}" '
+        f'"{escaped_backup_view}" nil nil nil) '
+        'unless(vbBackupCv error("target symbol backup failed")) '
+        "vbBackupReady = t "
+        'unless(dbClose(vbBackupCv) error("target symbol backup close failed")) '
+        "vbBackupCv = nil "
+        'unless(dbClose(vbBackupSourceCv) error("target symbol backup source close failed")) '
+        "vbBackupSourceCv = nil) "
+        "vbInstallAttempted = t "
         f'vbTargetCv = dbCopyCellView(vbTempCv "{escaped_lib}" "{escaped_cell}" '
-        f'"{escaped_symbol_view}" nil nil vbReplacing) '
+        f'"{escaped_symbol_view}" nil nil {overwrite_expr}) '
         'unless(vbTargetCv error("target symbol copy failed")) '
-        "dbClose(vbTargetCv) vbTargetCv = nil "
-        "dbClose(vbTempCv) vbTempCv = nil "
-        'list("generated" vbAction vbExpectedTerms)) '
+        "vbInstalled = t "
+        "vbFinalTerms = mapcar(lambda((vbTerm) "
+        'list(vbTerm~>name if(vbTerm~>direction vbTerm~>direction "inputOutput") '
+        "if(vbTerm~>numBits vbTerm~>numBits 1))) vbTargetCv~>terminals) "
+        "vbFinalOrder = schGetPinOrder(vbTargetCv) "
+        "unless(length(vbExpectedTerms) == length(vbFinalTerms) "
+        'error("installed symbol terminals mismatch")) '
+        "foreach(vbExpectedTerm vbExpectedTerms "
+        "unless(member(vbExpectedTerm vbFinalTerms) "
+        'error("installed symbol terminals mismatch"))) '
+        'unless(equal(vbExpectedOrder vbFinalOrder) error("installed symbol pin order mismatch")) '
+        'unless(dbClose(vbTargetCv) error("installed symbol close failed")) '
+        "vbTargetCv = nil "
+        'unless(dbClose(vbTempCv) error("temporary symbol close failed")) '
+        "vbTempCv = nil "
+        'vbResult = list("generated" vbAction vbFinalTerms vbFinalOrder) '
+        "vbCommitOk = t "
+        "vbResult) nil) "
+        'unless(vbBodyAttempt vbBodyFailure = sprintf(nil "%L" errset.errset)) '
+        "vbBodyAttempt) "
         "progn("
         f"{sort_restore}"
         "when(vbSourceCv errset(dbClose(vbSourceCv) nil) vbSourceCv = nil) "
         "when(vbTargetCv errset(dbClose(vbTargetCv) nil) vbTargetCv = nil) "
         "when(vbTempCv errset(dbClose(vbTempCv) nil) vbTempCv = nil) "
+        "when(vbBackupSourceCv errset(dbClose(vbBackupSourceCv) nil) "
+        "vbBackupSourceCv = nil) "
+        "when(vbBackupCv errset(dbClose(vbBackupCv) nil) vbBackupCv = nil) "
+        "unless(vbCommitOk "
+        "when(vbInstallAttempted "
+        "if(vbReplacing "
+        "then if(vbBackupReady "
+        "then vbRollback = errset(progn("
+        f'vbBackupCv = dbOpenCellViewByType("{escaped_lib}" "{escaped_cell}" '
+        f'"{escaped_backup_view}" "schematicSymbol" "r") '
+        'unless(vbBackupCv error("symbol backup open failed")) '
+        f'vbTargetCv = dbCopyCellView(vbBackupCv "{escaped_lib}" "{escaped_cell}" '
+        f'"{escaped_symbol_view}" nil nil t) '
+        'unless(vbTargetCv error("target symbol rollback copy failed")) '
+        "vbActualTerms = mapcar(lambda((vbTerm) "
+        'list(vbTerm~>name if(vbTerm~>direction vbTerm~>direction "inputOutput") '
+        "if(vbTerm~>numBits vbTerm~>numBits 1))) vbTargetCv~>terminals) "
+        "vbActualOrder = schGetPinOrder(vbTargetCv) "
+        "unless(length(vbOriginalTerms) == length(vbActualTerms) "
+        'error("target symbol rollback terminals mismatch")) '
+        "foreach(vbExpectedTerm vbOriginalTerms "
+        "unless(member(vbExpectedTerm vbActualTerms) "
+        'error("target symbol rollback terminals mismatch"))) '
+        'unless(equal(vbOriginalOrder vbActualOrder) '
+        'error("target symbol rollback pin order mismatch")) '
+        'unless(dbClose(vbTargetCv) error("target symbol rollback close failed")) '
+        "vbTargetCv = nil "
+        'unless(dbClose(vbBackupCv) error("symbol backup close failed")) '
+        "vbBackupCv = nil t) nil) "
+        "if(vbRollback && car(vbRollback) "
+        "then vbRollbackSucceeded = t "
+        "else vbCleanupFailures = cons("
+        f'sprintf(nil "target symbol rollback failed; backup retained as %s" '
+        f'"{escaped_backup_view}") vbCleanupFailures)) '
+        "else vbCleanupFailures = cons("
+        '"target symbol rollback failed; backup unavailable" vbCleanupFailures)) '
+        "else when(vbInstalled "
+        f'vbTargetObj = ddGetObj("{escaped_lib}" "{escaped_cell}" "{escaped_symbol_view}") '
+        "if(vbTargetObj "
+        "then vbRollback = errset(ddDeleteObj(vbTargetObj) nil) "
+        "if(vbRollback && car(vbRollback) "
+        "then vbRollbackSucceeded = t "
+        "else vbCleanupFailures = cons("
+        '"created symbol rollback failed" vbCleanupFailures)) '
+        "else vbRollbackSucceeded = t)))) "
         f'vbTempObj = ddGetObj("{escaped_lib}" "{escaped_cell}" "{escaped_temp_view}") '
         "when(vbTempObj "
         "vbCleanup = errset(ddDeleteObj(vbTempObj) nil) "
         "unless(vbCleanup && car(vbCleanup) "
-        "vbCleanupFailed = t))) "
+        'vbCleanupFailures = cons("temporary symbol cleanup failed" vbCleanupFailures)))) '
+        "when(vbBackupReady && "
+        "(!vbInstallAttempted || vbCommitOk || vbRollbackSucceeded) "
+        f'vbBackupObj = ddGetObj("{escaped_lib}" "{escaped_cell}" "{escaped_backup_view}") '
+        "when(vbBackupObj "
+        "vbCleanup = errset(ddDeleteObj(vbBackupObj) nil) "
+        "unless(vbCleanup && car(vbCleanup) "
+        "vbCleanupFailures = cons("
+        f'sprintf(nil "symbol backup cleanup failed; backup retained as %s" '
+        f'"{escaped_backup_view}") vbCleanupFailures)))) '
         ") "
-        "if(vbCleanupFailed "
-        'then list("cleanupFailed" "temporary symbol cleanup failed") '
-        "else vbResult))"
+        ") "
+        "if(vbBodyResult && vbCommitOk && !vbCleanupFailures "
+        "then car(vbBodyResult) "
+        "else list(\"failed\" if(vbBodyResult nil vbBodyFailure) "
+        "reverse(vbCleanupFailures))))"
     )
 
 
@@ -144,8 +257,8 @@ def generate_symbol_from_schematic(
 
     ``sort_pins`` temporarily overrides ``ssgSortPins`` for this operation and
     is restored even when generation fails. Existing symbols are rejected by
-    default; ``overwrite=True`` generates and validates a temporary view before
-    copying it over the destination.
+    default; ``overwrite=True`` rejects open targets, backs up the existing
+    view, and rolls it back if installation or final validation fails.
     """
     response = client.execute_skill(
         symbol_generate_from_schematic_skill(
@@ -159,29 +272,8 @@ def generate_symbol_from_schematic(
         timeout=timeout,
     )
     output = _require_generation_success(response, lib=lib, cell=cell)
-    action, expected_terms = _parse_generation_output(output)
-    ports = read_symbol_ports(
-        client,
-        lib,
-        cell,
-        view=symbol_view,
-        timeout=timeout,
-    )
-    generated_terms = {
-        str(term.get("name", "")): (
-            str(term.get("direction", "")),
-            int(term.get("numBits", 1)),
-        )
-        for term in ports["terms"]
-    }
-    if generated_terms != expected_terms:
-        raise RuntimeError(
-            f"generated symbol readback mismatch for {lib}/{cell}: "
-            f"expected {expected_terms}, got {generated_terms}"
-        )
-
-    terminal_names = tuple(term["name"] for term in ports["terms"])
-    term_order = tuple(ports["pinOrder"])
+    action, final_terms, term_order = _parse_generation_output(output)
+    terminal_names = tuple(final_terms)
     if Counter(term_order) != Counter(terminal_names):
         raise RuntimeError(
             f"generated symbol term order mismatch for {lib}/{cell}: "
@@ -219,22 +311,51 @@ def _require_generation_success(response: Any, *, lib: str, cell: str) -> str:
 
 def _parse_generation_output(
     output: str,
-) -> tuple[SymbolGenerationAction, dict[str, tuple[str, int]]]:
+) -> tuple[SymbolGenerationAction, dict[str, tuple[str, int]], tuple[str, ...]]:
     parsed = parse_sexpr(output)
-    if isinstance(parsed, list) and len(parsed) >= 2 and parsed[0] == "cleanupFailed":
-        raise RuntimeError(f"symbol generation cleanup failed: {parsed[1]}")
+    if isinstance(parsed, list) and len(parsed) >= 3 and parsed[0] == "failed":
+        body_failure = parsed[1]
+        cleanup_failures = parsed[2]
+        if cleanup_failures is None:
+            cleanup_failures = []
+        if not isinstance(cleanup_failures, list):
+            raise RuntimeError(f"unexpected symbol generation failure output: {output}")
+        cleanup_detail = ", ".join(str(item) for item in cleanup_failures)
+        if body_failure is not None:
+            detail = f"symbol generation failed: {body_failure}"
+            if cleanup_detail:
+                detail += f"; cleanup failed: {cleanup_detail}"
+            raise RuntimeError(detail)
+        if cleanup_detail:
+            raise RuntimeError(f"symbol generation cleanup failed: {cleanup_detail}")
+        raise RuntimeError(f"symbol generation failed without details: {output}")
     if not isinstance(parsed, list) or len(parsed) < 3 or parsed[0] != "generated":
         raise RuntimeError(f"unexpected symbol generation output: {output}")
     action = str(parsed[1])
     if action not in {"created", "replaced"}:
         raise RuntimeError(f"unexpected symbol generation action: {action}")
-    records = parsed[2] if isinstance(parsed[2], list) else []
+    raw_records = parsed[2]
+    if raw_records is None:
+        records = []
+    elif isinstance(raw_records, list):
+        records = raw_records
+    else:
+        raise RuntimeError(f"unexpected final terminal payload: {raw_records}")
     expected_terms: dict[str, tuple[str, int]] = {}
     for record in records:
         if not isinstance(record, list) or len(record) < 3:
-            raise RuntimeError(f"unexpected source terminal record: {record}")
+            raise RuntimeError(f"unexpected final terminal record: {record}")
         expected_terms[str(record[0])] = (str(record[1]), int(record[2]))
-    return cast(SymbolGenerationAction, action), expected_terms
+    if len(parsed) < 4:
+        raise RuntimeError("unexpected final pin order payload: missing")
+    raw_order = parsed[3]
+    if raw_order is None:
+        expected_order: tuple[str, ...] = ()
+    elif isinstance(raw_order, list):
+        expected_order = tuple(str(item) for item in raw_order)
+    else:
+        raise RuntimeError(f"unexpected final pin order payload: {raw_order}")
+    return cast(SymbolGenerationAction, action), expected_terms, expected_order
 
 
 __all__ = [

--- a/src/virtuoso_bridge/virtuoso/symbol/generator.py
+++ b/src/virtuoso_bridge/virtuoso/symbol/generator.py
@@ -1,0 +1,254 @@
+"""Native schematic-to-symbol generation helpers."""
+
+from __future__ import annotations
+
+import uuid
+from collections import Counter
+from dataclasses import dataclass
+from typing import Any, Literal, cast
+
+from virtuoso_bridge.virtuoso.ops import escape_skill_string
+from virtuoso_bridge.virtuoso.skill_output import parse_sexpr
+from virtuoso_bridge.virtuoso.symbol.reader import _response_fields, read_symbol_ports
+
+SymbolPinSort = Literal["alphanumeric", "geometric"]
+SymbolGenerationAction = Literal["created", "replaced"]
+
+_PIN_SORT_MODES = {"alphanumeric", "geometric"}
+_DEFAULT_DIRECTION_ORDER = {"output": 0, "inputOutput": 1, "input": 2}
+
+
+@dataclass(frozen=True)
+class SymbolGenerationResult:
+    """Verified source, destination, action, and terminal readback."""
+
+    lib: str
+    cell: str
+    schematic_view: str
+    symbol_view: str
+    action: SymbolGenerationAction
+    terminal_names: tuple[str, ...]
+    term_order: tuple[str, ...]
+
+
+def symbol_generate_from_schematic_skill(
+    lib: str,
+    cell: str,
+    *,
+    schematic_view: str = "schematic",
+    symbol_view: str = "symbol",
+    sort_pins: SymbolPinSort | None = None,
+    overwrite: bool = False,
+) -> str:
+    """Build SKILL for Cadence's native schematic-to-symbol pipeline."""
+    _validate_sort_pins(sort_pins)
+    if schematic_view == symbol_view:
+        raise ValueError("schematic_view and symbol_view must differ")
+    escaped_lib = escape_skill_string(lib)
+    escaped_cell = escape_skill_string(cell)
+    escaped_schematic_view = escape_skill_string(schematic_view)
+    escaped_symbol_view = escape_skill_string(symbol_view)
+    escaped_temp_view = escape_skill_string(f"__vb_symbol_{uuid.uuid4().hex}")
+    overwrite_expr = "t" if overwrite else "nil"
+
+    sort_capture = ""
+    sort_setup = ""
+    sort_restore = ""
+    if sort_pins is not None:
+        escaped_sort = escape_skill_string(sort_pins)
+        sort_capture = 'vbOldSort = schGetEnv("ssgSortPins") '
+        sort_setup = (
+            f'vbSortChanged = schSetEnv("ssgSortPins" "{escaped_sort}") '
+            'unless(vbSortChanged error("failed to set ssgSortPins")) '
+        )
+        sort_restore = (
+            "when(vbSortChanged "
+            'unless(schSetEnv("ssgSortPins" vbOldSort) '
+            'warn("failed to restore ssgSortPins")) '
+            "vbSortChanged = nil) "
+        )
+
+    return (
+        "let((vbSourceCv vbTargetObj vbTempObj vbTempCv vbTargetCv vbPinList vbGenerated "
+        "vbReplacing vbAction vbExpectedTerms vbActualTerms vbExpectedTerm vbOldSort "
+        "vbSortChanged vbCleanup) "
+        f'vbTargetObj = ddGetObj("{escaped_lib}" "{escaped_cell}" "{escaped_symbol_view}") '
+        "vbReplacing = if(vbTargetObj t nil) "
+        'vbAction = if(vbReplacing "replaced" "created") '
+        "when(vbTargetObj ddReleaseObj(vbTargetObj) vbTargetObj = nil) "
+        f'when(vbReplacing && !{overwrite_expr} error("target symbol exists")) '
+        f'vbTempObj = ddGetObj("{escaped_lib}" "{escaped_cell}" "{escaped_temp_view}") '
+        'when(vbTempObj unless(ddDeleteObj(vbTempObj) error("temporary symbol delete failed"))) '
+        f"{sort_capture}"
+        "unwindProtect("
+        "progn("
+        f'vbSourceCv = dbOpenCellViewByType("{escaped_lib}" "{escaped_cell}" '
+        f'"{escaped_schematic_view}" "schematic" "r") '
+        'unless(vbSourceCv error("source schematic not found")) '
+        "vbExpectedTerms = mapcar(lambda((vbTerm) "
+        'list(vbTerm~>name if(vbTerm~>direction vbTerm~>direction "inputOutput") '
+        "if(vbTerm~>numBits vbTerm~>numBits 1))) vbSourceCv~>terminals) "
+        "dbClose(vbSourceCv) vbSourceCv = nil "
+        f"{sort_setup}"
+        f'vbPinList = schSchemToPinList("{escaped_lib}" "{escaped_cell}" "{escaped_schematic_view}") '
+        'unless(vbPinList error("schematic to pin list failed")) '
+        f'vbGenerated = schPinListToSymbol("{escaped_lib}" "{escaped_cell}" '
+        f'"{escaped_temp_view}" vbPinList) '
+        'unless(vbGenerated error("symbol generation failed")) '
+        f'vbTempCv = dbOpenCellViewByType("{escaped_lib}" "{escaped_cell}" '
+        f'"{escaped_temp_view}" "schematicSymbol" "r") '
+        'unless(vbTempCv error("temporary symbol open failed")) '
+        "vbActualTerms = mapcar(lambda((vbTerm) "
+        'list(vbTerm~>name if(vbTerm~>direction vbTerm~>direction "inputOutput") '
+        "if(vbTerm~>numBits vbTerm~>numBits 1))) vbTempCv~>terminals) "
+        "unless(length(vbExpectedTerms) == length(vbActualTerms) "
+        'error("generated symbol terminals mismatch")) '
+        "foreach(vbExpectedTerm vbExpectedTerms "
+        "unless(member(vbExpectedTerm vbActualTerms) "
+        'error("generated symbol terminals mismatch"))) '
+        "unless(isCallable('dbCopyCellView) error(\"dbCopyCellView API unavailable\")) "
+        f'vbTargetCv = dbCopyCellView(vbTempCv "{escaped_lib}" "{escaped_cell}" '
+        f'"{escaped_symbol_view}" nil nil vbReplacing) '
+        'unless(vbTargetCv error("target symbol copy failed")) '
+        "dbClose(vbTargetCv) vbTargetCv = nil "
+        "dbClose(vbTempCv) vbTempCv = nil "
+        'list("generated" vbAction vbExpectedTerms)) '
+        "progn("
+        f"{sort_restore}"
+        "when(vbSourceCv errset(dbClose(vbSourceCv) nil) vbSourceCv = nil) "
+        "when(vbTargetCv errset(dbClose(vbTargetCv) nil) vbTargetCv = nil) "
+        "when(vbTempCv errset(dbClose(vbTempCv) nil) vbTempCv = nil) "
+        f'vbTempObj = ddGetObj("{escaped_lib}" "{escaped_cell}" "{escaped_temp_view}") '
+        "when(vbTempObj "
+        "vbCleanup = errset(ddDeleteObj(vbTempObj) nil) "
+        "unless(vbCleanup && car(vbCleanup) "
+        'warn("temporary symbol cleanup failed"))) '
+        ")))"
+    )
+
+
+def generate_symbol_from_schematic(
+    client: Any,
+    lib: str,
+    cell: str,
+    *,
+    schematic_view: str = "schematic",
+    symbol_view: str = "symbol",
+    sort_pins: SymbolPinSort | None = None,
+    overwrite: bool = False,
+    timeout: int = 60,
+) -> SymbolGenerationResult:
+    """Generate and verify a symbol view using Cadence's native generator.
+
+    ``sort_pins`` temporarily overrides ``ssgSortPins`` for this operation and
+    is restored even when generation fails. Existing symbols are rejected by
+    default; ``overwrite=True`` generates and validates a temporary view before
+    copying it over the destination.
+    """
+    response = client.execute_skill(
+        symbol_generate_from_schematic_skill(
+            lib,
+            cell,
+            schematic_view=schematic_view,
+            symbol_view=symbol_view,
+            sort_pins=sort_pins,
+            overwrite=overwrite,
+        ),
+        timeout=timeout,
+    )
+    output = _require_generation_success(response, lib=lib, cell=cell)
+    action, expected_terms = _parse_generation_output(output)
+    ports = read_symbol_ports(
+        client,
+        lib,
+        cell,
+        view=symbol_view,
+        timeout=timeout,
+    )
+    generated_terms = {
+        str(term.get("name", "")): (
+            str(term.get("direction", "")),
+            int(term.get("numBits", 1)),
+        )
+        for term in ports["terms"]
+    }
+    if generated_terms != expected_terms:
+        raise RuntimeError(
+            f"generated symbol readback mismatch for {lib}/{cell}: "
+            f"expected {expected_terms}, got {generated_terms}"
+        )
+
+    terminal_names = tuple(term["name"] for term in ports["terms"])
+    explicit_order = tuple(ports["portOrder"] or ports["termOrder"])
+    if explicit_order and Counter(explicit_order) != Counter(terminal_names):
+        raise RuntimeError(
+            f"generated symbol term order mismatch for {lib}/{cell}: "
+            f"terminals {terminal_names}, order {explicit_order}"
+        )
+    term_order = explicit_order or _default_term_order(ports["terms"])
+    return SymbolGenerationResult(
+        lib=lib,
+        cell=cell,
+        schematic_view=schematic_view,
+        symbol_view=symbol_view,
+        action=action,
+        terminal_names=terminal_names,
+        term_order=term_order,
+    )
+
+
+def _validate_sort_pins(sort_pins: str | None) -> None:
+    if sort_pins is not None and sort_pins not in _PIN_SORT_MODES:
+        choices = ", ".join(sorted(_PIN_SORT_MODES))
+        raise ValueError(f"sort_pins must be one of: {choices}")
+
+
+def _default_term_order(terms: list[dict[str, Any]]) -> tuple[str, ...]:
+    ordered = sorted(
+        terms,
+        key=lambda term: (
+            _DEFAULT_DIRECTION_ORDER.get(str(term.get("direction", "")), 3),
+            str(term.get("name", "")),
+        ),
+    )
+    return tuple(str(term.get("name", "")) for term in ordered)
+
+
+def _require_generation_success(response: Any, *, lib: str, cell: str) -> str:
+    errors, status, output = _response_fields(response)
+    if errors:
+        raise RuntimeError(f"symbol generation failed for {lib}/{cell}: {errors[0]}")
+    status_value = getattr(status, "value", status)
+    if status_value is not None and str(status_value).lower() not in {"success", "ok"}:
+        detail = output or f"status={status_value}"
+        raise RuntimeError(f"symbol generation failed for {lib}/{cell}: {detail}")
+    if not output.strip():
+        raise RuntimeError(f"symbol generation returned empty output for {lib}/{cell}")
+    return output.strip()
+
+
+def _parse_generation_output(
+    output: str,
+) -> tuple[SymbolGenerationAction, dict[str, tuple[str, int]]]:
+    parsed = parse_sexpr(output)
+    if not isinstance(parsed, list) or len(parsed) < 3 or parsed[0] != "generated":
+        raise RuntimeError(f"unexpected symbol generation output: {output}")
+    action = str(parsed[1])
+    if action not in {"created", "replaced"}:
+        raise RuntimeError(f"unexpected symbol generation action: {action}")
+    records = parsed[2] if isinstance(parsed[2], list) else []
+    expected_terms: dict[str, tuple[str, int]] = {}
+    for record in records:
+        if not isinstance(record, list) or len(record) < 3:
+            raise RuntimeError(f"unexpected source terminal record: {record}")
+        expected_terms[str(record[0])] = (str(record[1]), int(record[2]))
+    return cast(SymbolGenerationAction, action), expected_terms
+
+
+__all__ = [
+    "SymbolGenerationAction",
+    "SymbolGenerationResult",
+    "SymbolPinSort",
+    "generate_symbol_from_schematic",
+    "symbol_generate_from_schematic_skill",
+]

--- a/src/virtuoso_bridge/virtuoso/symbol/generator.py
+++ b/src/virtuoso_bridge/virtuoso/symbol/generator.py
@@ -8,13 +8,24 @@ from dataclasses import dataclass
 from typing import Any, Literal, cast
 
 from virtuoso_bridge.virtuoso.ops import escape_skill_string
+from virtuoso_bridge.virtuoso.response import response_fields
 from virtuoso_bridge.virtuoso.skill_output import parse_sexpr
-from virtuoso_bridge.virtuoso.symbol.reader import _response_fields
 
 SymbolPinSort = Literal["alphanumeric", "geometric"]
 SymbolGenerationAction = Literal["created", "replaced"]
 
 _PIN_SORT_MODES = {"alphanumeric", "geometric"}
+
+
+def _cleanup_close_skill(variable: str, failure: str) -> str:
+    escaped_failure = escape_skill_string(failure)
+    return (
+        f"when({variable} "
+        f"vbCleanup = errset(dbClose({variable}) nil) "
+        "unless(vbCleanup && car(vbCleanup) "
+        f'vbCleanupFailures = cons("{escaped_failure}" vbCleanupFailures)) '
+        f"{variable} = nil) "
+    )
 
 
 @dataclass(frozen=True)
@@ -27,7 +38,7 @@ class SymbolGenerationResult:
     symbol_view: str
     action: SymbolGenerationAction
     terminal_names: tuple[str, ...]
-    term_order: tuple[str, ...]
+    pin_order: tuple[str, ...]
 
 
 def symbol_generate_from_schematic_skill(
@@ -171,13 +182,17 @@ def symbol_generate_from_schematic_skill(
         "vbBodyAttempt) "
         "progn("
         f"{sort_restore}"
-        "when(vbSourceCv errset(dbClose(vbSourceCv) nil) vbSourceCv = nil) "
-        "when(vbTargetCv errset(dbClose(vbTargetCv) nil) vbTargetCv = nil) "
-        "when(vbTempCv errset(dbClose(vbTempCv) nil) vbTempCv = nil) "
-        "when(vbBackupSourceCv errset(dbClose(vbBackupSourceCv) nil) "
-        "vbBackupSourceCv = nil) "
-        "when(vbBackupCv errset(dbClose(vbBackupCv) nil) vbBackupCv = nil) "
-        "unless(vbCommitOk "
+        f'{_cleanup_close_skill("vbSourceCv", "source schematic cleanup close failed")}'
+        f'{_cleanup_close_skill("vbTargetCv", "target symbol cleanup close failed")}'
+        f'{_cleanup_close_skill("vbTempCv", "temporary symbol cleanup close failed")}'
+        f'{_cleanup_close_skill("vbBackupSourceCv", "symbol backup source cleanup close failed")}'
+        f'{_cleanup_close_skill("vbBackupCv", "symbol backup cleanup close failed")}'
+        f'vbTempObj = ddGetObj("{escaped_lib}" "{escaped_cell}" "{escaped_temp_view}") '
+        "when(vbTempObj "
+        "vbCleanup = errset(ddDeleteObj(vbTempObj) nil) "
+        "unless(vbCleanup && car(vbCleanup) "
+        'vbCleanupFailures = cons("temporary symbol cleanup failed" vbCleanupFailures))) '
+        "when(!vbCommitOk || vbCleanupFailures "
         "when(vbInstallAttempted "
         "if(vbReplacing "
         "then if(vbBackupReady "
@@ -218,14 +233,10 @@ def symbol_generate_from_schematic_skill(
         "then vbRollbackSucceeded = t "
         "else vbCleanupFailures = cons("
         '"created symbol rollback failed" vbCleanupFailures)) '
-        "else vbRollbackSucceeded = t)))) "
-        f'vbTempObj = ddGetObj("{escaped_lib}" "{escaped_cell}" "{escaped_temp_view}") '
-        "when(vbTempObj "
-        "vbCleanup = errset(ddDeleteObj(vbTempObj) nil) "
-        "unless(vbCleanup && car(vbCleanup) "
-        'vbCleanupFailures = cons("temporary symbol cleanup failed" vbCleanupFailures)))) '
+        "else vbRollbackSucceeded = t))))) "
         "when(vbBackupReady && "
-        "(!vbInstallAttempted || vbCommitOk || vbRollbackSucceeded) "
+        "(!vbInstallAttempted || (vbCommitOk && !vbCleanupFailures) || "
+        "vbRollbackSucceeded) "
         f'vbBackupObj = ddGetObj("{escaped_lib}" "{escaped_cell}" "{escaped_backup_view}") '
         "when(vbBackupObj "
         "vbCleanup = errset(ddDeleteObj(vbBackupObj) nil) "
@@ -272,12 +283,17 @@ def generate_symbol_from_schematic(
         timeout=timeout,
     )
     output = _require_generation_success(response, lib=lib, cell=cell)
-    action, final_terms, term_order = _parse_generation_output(output)
-    terminal_names = tuple(final_terms)
-    if Counter(term_order) != Counter(terminal_names):
+    try:
+        action, final_terms, pin_order = _parse_generation_output(output)
+    except RuntimeError as exc:
         raise RuntimeError(
-            f"generated symbol term order mismatch for {lib}/{cell}: "
-            f"terminals {terminal_names}, order {term_order}"
+            f"symbol generation response error for {lib}/{cell}: {exc}"
+        ) from exc
+    terminal_names = tuple(final_terms)
+    if Counter(pin_order) != Counter(terminal_names):
+        raise RuntimeError(
+            f"generated symbol pin order mismatch for {lib}/{cell}: "
+            f"terminals {terminal_names}, order {pin_order}"
         )
     return SymbolGenerationResult(
         lib=lib,
@@ -286,7 +302,7 @@ def generate_symbol_from_schematic(
         symbol_view=symbol_view,
         action=action,
         terminal_names=terminal_names,
-        term_order=term_order,
+        pin_order=pin_order,
     )
 
 
@@ -297,7 +313,7 @@ def _validate_sort_pins(sort_pins: str | None) -> None:
 
 
 def _require_generation_success(response: Any, *, lib: str, cell: str) -> str:
-    errors, status, output = _response_fields(response)
+    errors, status, output = response_fields(response)
     if errors:
         raise RuntimeError(f"symbol generation failed for {lib}/{cell}: {errors[0]}")
     status_value = getattr(status, "value", status)
@@ -343,9 +359,20 @@ def _parse_generation_output(
         raise RuntimeError(f"unexpected final terminal payload: {raw_records}")
     expected_terms: dict[str, tuple[str, int]] = {}
     for record in records:
-        if not isinstance(record, list) or len(record) < 3:
+        if not isinstance(record, list) or len(record) != 3:
             raise RuntimeError(f"unexpected final terminal record: {record}")
-        expected_terms[str(record[0])] = (str(record[1]), int(record[2]))
+        name, direction, raw_width = record
+        if not isinstance(name, str) or not isinstance(direction, str):
+            raise RuntimeError(f"unexpected final terminal record: {record}")
+        if name in expected_terms:
+            raise RuntimeError(f"duplicate final terminal: {name}")
+        try:
+            width = int(raw_width)
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError(f"invalid final terminal width: {raw_width}") from exc
+        if width < 1:
+            raise RuntimeError(f"invalid final terminal width: {raw_width}")
+        expected_terms[name] = (direction, width)
     if len(parsed) < 4:
         raise RuntimeError("unexpected final pin order payload: missing")
     raw_order = parsed[3]

--- a/src/virtuoso_bridge/virtuoso/symbol/reader.py
+++ b/src/virtuoso_bridge/virtuoso/symbol/reader.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from virtuoso_bridge.virtuoso.ops import open_cell_view
+from virtuoso_bridge.virtuoso.response import response_fields
 from virtuoso_bridge.virtuoso.skill_output import parse_sexpr
 
 
@@ -18,9 +19,11 @@ def symbol_read_ports_skill(
     """Build SKILL to report terminals, labels, port order, and term order."""
     open_expr = open_cell_view(lib, cell, view=view, view_type=view_type, mode="r")
     return (
-        "let((cv term pin fig label bbox xy result) "
-        "unwindProtect("
-        "progn("
+        "let((cv term pin fig label bbox xy result bodyAttempt bodyResult bodyFailure "
+        "closeResult closeFailures) "
+        'bodyFailure = "symbol read failed" '
+        "bodyResult = unwindProtect(progn("
+        "bodyAttempt = errset(progn("
         f"{open_expr} "
         'unless(cv error("open symbol failed")) '
         "result = nil "
@@ -45,8 +48,17 @@ def symbol_read_ports_skill(
         'result = cons(list("pinOrder" schGetPinOrder(cv)) result) '
         'result = cons(list("portOrder" cv~>portOrder) result) '
         'result = cons(list("termOrder" cv~>termOrder) result) '
-        "reverse(result)) "
-        "when(cv errset(dbClose(cv) nil) cv = nil)))"
+        "reverse(result)) nil) "
+        'unless(bodyAttempt bodyFailure = sprintf(nil "%L" errset.errset)) '
+        "bodyAttempt) "
+        "progn(when(cv "
+        "closeResult = errset(dbClose(cv) nil) "
+        "unless(closeResult && car(closeResult) "
+        'closeFailures = cons("symbol close failed" closeFailures)) '
+        "cv = nil))) "
+        "if(bodyResult && !closeFailures "
+        "then car(bodyResult) "
+        'else list("readFailed" if(bodyResult nil bodyFailure) reverse(closeFailures))))'
     )
 
 
@@ -111,13 +123,32 @@ def read_symbol_ports(
         symbol_read_ports_skill(lib, cell, view=view, view_type=view_type),
         timeout=timeout,
     )
-    errors, status, output = _response_fields(response)
+    errors, status, output = response_fields(response)
     _raise_for_symbol_read_error(errors, status, output, lib=lib, cell=cell)
     raw = (output or "").strip()
     if raw.strip() == "ERROR":
         raise RuntimeError(f"read_symbol_ports could not open symbol {lib}/{cell}")
     if not raw.strip():
         raise RuntimeError(f"read_symbol_ports returned empty output for {lib}/{cell}")
+    parsed = parse_sexpr(raw)
+    if isinstance(parsed, list) and len(parsed) >= 3 and parsed[0] == "readFailed":
+        body_failure = parsed[1]
+        close_failures = parsed[2]
+        if close_failures is None:
+            close_failures = []
+        if not isinstance(close_failures, list):
+            raise RuntimeError(
+                f"unexpected read_symbol_ports failure output for {lib}/{cell}: {raw}"
+            )
+        details: list[str] = []
+        if body_failure is not None:
+            details.append(str(body_failure))
+        if close_failures:
+            details.append(
+                "cleanup failed: " + ", ".join(str(item) for item in close_failures)
+            )
+        detail = "; ".join(details) or "unknown failure"
+        raise RuntimeError(f"read_symbol_ports failed for {lib}/{cell}: {detail}")
     return parse_symbol_ports_output(raw)
 
 
@@ -158,25 +189,6 @@ def _bbox_value(value: Any) -> list[list[float]] | None:
     if any(point is None for point in points):
         return None
     return [point for point in points if point is not None]
-
-
-def _response_fields(response: Any) -> tuple[Any, Any, str]:
-    if isinstance(response, dict):
-        result = response.get("result") if isinstance(response.get("result"), dict) else {}
-        errors = response.get("errors") or result.get("errors")
-        status = response.get("status") or result.get("status")
-        output = response.get("output")
-        if output is None:
-            output = result.get("output", "")
-        if response.get("ok") is False and not errors:
-            errors = [response.get("error") or result.get("error") or "request failed"]
-        return errors, status, output or ""
-
-    return (
-        getattr(response, "errors", None),
-        getattr(response, "status", None),
-        getattr(response, "output", "") or "",
-    )
 
 
 def _raise_for_symbol_read_error(

--- a/src/virtuoso_bridge/virtuoso/symbol/reader.py
+++ b/src/virtuoso_bridge/virtuoso/symbol/reader.py
@@ -6,7 +6,10 @@ from typing import Any
 
 from virtuoso_bridge.virtuoso.ops import open_cell_view
 from virtuoso_bridge.virtuoso.response import response_fields
-from virtuoso_bridge.virtuoso.skill_output import parse_sexpr
+from virtuoso_bridge.virtuoso.skill_output import (
+    is_single_complete_skill_list,
+    parse_sexpr,
+)
 
 
 class _SymbolReadFailure(ValueError):
@@ -73,37 +76,13 @@ def parse_symbol_ports_output(output: str) -> dict[str, Any]:
     text = (output or "").strip()
     if not text.startswith("("):
         raise ValueError("symbol readback output must be a structured SKILL list")
-    if not _is_single_complete_skill_list(text):
+    if not is_single_complete_skill_list(text):
         raise ValueError("symbol readback output must be a single complete SKILL list")
     parsed = parse_sexpr(text)
     failure_detail = _symbol_read_failure_detail(parsed, output=text)
     if failure_detail is not None:
         raise _SymbolReadFailure(failure_detail)
     return _parse_symbol_ports_records(parsed)
-
-
-def _is_single_complete_skill_list(text: str) -> bool:
-    depth = 0
-    in_string = False
-    escaped = False
-    for index, character in enumerate(text):
-        if in_string:
-            if escaped:
-                escaped = False
-            elif character == "\\":
-                escaped = True
-            elif character == '"':
-                in_string = False
-            continue
-        if character == '"':
-            in_string = True
-        elif character == "(":
-            depth += 1
-        elif character == ")":
-            depth -= 1
-            if depth < 0 or (depth == 0 and index != len(text) - 1):
-                return False
-    return depth == 0 and not in_string
 
 
 def _parse_symbol_ports_records(parsed: Any) -> dict[str, Any]:

--- a/src/virtuoso_bridge/virtuoso/symbol/reader.py
+++ b/src/virtuoso_bridge/virtuoso/symbol/reader.py
@@ -19,6 +19,8 @@ def symbol_read_ports_skill(
     open_expr = open_cell_view(lib, cell, view=view, view_type=view_type, mode="r")
     return (
         "let((cv term pin fig label bbox xy result) "
+        "unwindProtect("
+        "progn("
         f"{open_expr} "
         'unless(cv error("open symbol failed")) '
         "result = nil "
@@ -40,10 +42,11 @@ def symbol_read_ports_skill(
         "when(label~>xy xy = list(xCoord(label~>xy) yCoord(label~>xy))) "
         'result = cons(list("label" if(label~>theLabel label~>theLabel "") '
         'if(label~>labelType label~>labelType "") xy) result))) '
+        'result = cons(list("pinOrder" schGetPinOrder(cv)) result) '
         'result = cons(list("portOrder" cv~>portOrder) result) '
         'result = cons(list("termOrder" cv~>termOrder) result) '
-        "dbClose(cv) "
-        "reverse(result))"
+        "reverse(result)) "
+        "when(cv errset(dbClose(cv) nil) cv = nil)))"
     )
 
 
@@ -59,6 +62,7 @@ def _parse_symbol_ports_records(output: str) -> dict[str, Any]:
     result: dict[str, Any] = {
         "terms": [],
         "labels": [],
+        "pinOrder": [],
         "portOrder": [],
         "termOrder": [],
     }
@@ -87,7 +91,7 @@ def _parse_symbol_ports_records(output: str) -> dict[str, Any]:
                     "xy": _point_value(record[3]),
                 }
             )
-        elif kind in {"portOrder", "termOrder"} and len(record) >= 2:
+        elif kind in {"pinOrder", "portOrder", "termOrder"} and len(record) >= 2:
             order = record[1] if isinstance(record[1], list) else []
             result[kind] = [_string_value(item) for item in order]
     return result

--- a/src/virtuoso_bridge/virtuoso/symbol/reader.py
+++ b/src/virtuoso_bridge/virtuoso/symbol/reader.py
@@ -9,6 +9,12 @@ from virtuoso_bridge.virtuoso.response import response_fields
 from virtuoso_bridge.virtuoso.skill_output import parse_sexpr
 
 
+class _SymbolReadFailure(ValueError):
+    def __init__(self, detail: str) -> None:
+        self.detail = detail
+        super().__init__(f"symbol readback failed: {detail}")
+
+
 def symbol_read_ports_skill(
     lib: str,
     cell: str,
@@ -67,10 +73,14 @@ def parse_symbol_ports_output(output: str) -> dict[str, Any]:
     text = (output or "").strip()
     if not text.startswith("("):
         raise ValueError("symbol readback output must be a structured SKILL list")
-    return _parse_symbol_ports_records(text)
+    parsed = parse_sexpr(text)
+    failure_detail = _symbol_read_failure_detail(parsed, output=text)
+    if failure_detail is not None:
+        raise _SymbolReadFailure(failure_detail)
+    return _parse_symbol_ports_records(parsed)
 
 
-def _parse_symbol_ports_records(output: str) -> dict[str, Any]:
+def _parse_symbol_ports_records(parsed: Any) -> dict[str, Any]:
     result: dict[str, Any] = {
         "terms": [],
         "labels": [],
@@ -78,7 +88,6 @@ def _parse_symbol_ports_records(output: str) -> dict[str, Any]:
         "portOrder": [],
         "termOrder": [],
     }
-    parsed = parse_sexpr(output)
     if not isinstance(parsed, list):
         return result
 
@@ -130,26 +139,41 @@ def read_symbol_ports(
         raise RuntimeError(f"read_symbol_ports could not open symbol {lib}/{cell}")
     if not raw.strip():
         raise RuntimeError(f"read_symbol_ports returned empty output for {lib}/{cell}")
-    parsed = parse_sexpr(raw)
-    if isinstance(parsed, list) and len(parsed) >= 3 and parsed[0] == "readFailed":
-        body_failure = parsed[1]
-        close_failures = parsed[2]
-        if close_failures is None:
-            close_failures = []
-        if not isinstance(close_failures, list):
-            raise RuntimeError(
-                f"unexpected read_symbol_ports failure output for {lib}/{cell}: {raw}"
-            )
-        details: list[str] = []
-        if body_failure is not None:
-            details.append(str(body_failure))
-        if close_failures:
-            details.append(
-                "cleanup failed: " + ", ".join(str(item) for item in close_failures)
-            )
-        detail = "; ".join(details) or "unknown failure"
-        raise RuntimeError(f"read_symbol_ports failed for {lib}/{cell}: {detail}")
-    return parse_symbol_ports_output(raw)
+    try:
+        return parse_symbol_ports_output(raw)
+    except _SymbolReadFailure as exc:
+        raise RuntimeError(
+            f"read_symbol_ports failed for {lib}/{cell}: {exc.detail}"
+        ) from exc
+    except ValueError as exc:
+        raise RuntimeError(
+            f"read_symbol_ports response error for {lib}/{cell}: {exc}"
+        ) from exc
+
+
+def _symbol_read_failure_detail(parsed: Any, *, output: str) -> str | None:
+    if not isinstance(parsed, list) or not parsed or parsed[0] != "readFailed":
+        return None
+    if len(parsed) != 3:
+        raise ValueError(f"malformed symbol read failure output: {output}")
+
+    body_failure = parsed[1]
+    close_failures = parsed[2]
+    if body_failure is not None and not isinstance(body_failure, str):
+        raise ValueError(f"malformed symbol read failure output: {output}")
+    if close_failures is None:
+        close_failures = []
+    if not isinstance(close_failures, list) or any(
+        not isinstance(item, str) for item in close_failures
+    ):
+        raise ValueError(f"malformed symbol read failure output: {output}")
+
+    details: list[str] = []
+    if body_failure is not None:
+        details.append(body_failure)
+    if close_failures:
+        details.append("cleanup failed: " + ", ".join(close_failures))
+    return "; ".join(details) or "unknown failure"
 
 
 def _string_value(value: Any) -> str:
@@ -200,7 +224,9 @@ def _raise_for_symbol_read_error(
     cell: str,
 ) -> None:
     if errors:
-        raise RuntimeError(f"read_symbol_ports SKILL error: {errors[0]}")
+        raise RuntimeError(
+            f"read_symbol_ports SKILL error for {lib}/{cell}: {errors[0]}"
+        )
 
     status_value = getattr(status, "value", status)
     if status_value is not None and str(status_value).lower() not in {"success", "ok"}:

--- a/src/virtuoso_bridge/virtuoso/symbol/reader.py
+++ b/src/virtuoso_bridge/virtuoso/symbol/reader.py
@@ -73,11 +73,37 @@ def parse_symbol_ports_output(output: str) -> dict[str, Any]:
     text = (output or "").strip()
     if not text.startswith("("):
         raise ValueError("symbol readback output must be a structured SKILL list")
+    if not _is_single_complete_skill_list(text):
+        raise ValueError("symbol readback output must be a single complete SKILL list")
     parsed = parse_sexpr(text)
     failure_detail = _symbol_read_failure_detail(parsed, output=text)
     if failure_detail is not None:
         raise _SymbolReadFailure(failure_detail)
     return _parse_symbol_ports_records(parsed)
+
+
+def _is_single_complete_skill_list(text: str) -> bool:
+    depth = 0
+    in_string = False
+    escaped = False
+    for index, character in enumerate(text):
+        if in_string:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                in_string = False
+            continue
+        if character == '"':
+            in_string = True
+        elif character == "(":
+            depth += 1
+        elif character == ")":
+            depth -= 1
+            if depth < 0 or (depth == 0 and index != len(text) - 1):
+                return False
+    return depth == 0 and not in_string
 
 
 def _parse_symbol_ports_records(parsed: Any) -> dict[str, Any]:

--- a/src/virtuoso_bridge/virtuoso/symbol/reader.py
+++ b/src/virtuoso_bridge/virtuoso/symbol/reader.py
@@ -15,7 +15,7 @@ def symbol_read_ports_skill(
     view: str = "symbol",
     view_type: str = "schematicSymbol",
 ) -> str:
-    """Build SKILL to report symbol terminals, labels, and term order."""
+    """Build SKILL to report terminals, labels, port order, and term order."""
     open_expr = open_cell_view(lib, cell, view=view, view_type=view_type, mode="r")
     return (
         "let((cv term pin fig label bbox xy result) "
@@ -40,6 +40,7 @@ def symbol_read_ports_skill(
         "when(label~>xy xy = list(xCoord(label~>xy) yCoord(label~>xy))) "
         'result = cons(list("label" if(label~>theLabel label~>theLabel "") '
         'if(label~>labelType label~>labelType "") xy) result))) '
+        'result = cons(list("portOrder" cv~>portOrder) result) '
         'result = cons(list("termOrder" cv~>termOrder) result) '
         "dbClose(cv) "
         "reverse(result))"
@@ -55,7 +56,12 @@ def parse_symbol_ports_output(output: str) -> dict[str, Any]:
 
 
 def _parse_symbol_ports_records(output: str) -> dict[str, Any]:
-    result: dict[str, Any] = {"terms": [], "labels": [], "termOrder": []}
+    result: dict[str, Any] = {
+        "terms": [],
+        "labels": [],
+        "portOrder": [],
+        "termOrder": [],
+    }
     parsed = parse_sexpr(output)
     if not isinstance(parsed, list):
         return result
@@ -81,9 +87,9 @@ def _parse_symbol_ports_records(output: str) -> dict[str, Any]:
                     "xy": _point_value(record[3]),
                 }
             )
-        elif kind == "termOrder" and len(record) >= 2:
+        elif kind in {"portOrder", "termOrder"} and len(record) >= 2:
             order = record[1] if isinstance(record[1], list) else []
-            result["termOrder"] = [_string_value(item) for item in order]
+            result[kind] = [_string_value(item) for item in order]
     return result
 
 
@@ -96,7 +102,7 @@ def read_symbol_ports(
     view_type: str = "schematicSymbol",
     timeout: int = 30,
 ) -> dict[str, Any]:
-    """Read symbol terminals, labels, and term order."""
+    """Read symbol terminals, labels, port order, and term order."""
     response = client.execute_skill(
         symbol_read_ports_skill(lib, cell, view=view, view_type=view_type),
         timeout=timeout,

--- a/tests/test_symbol_generator.py
+++ b/tests/test_symbol_generator.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from virtuoso_bridge.models import ExecutionStatus, VirtuosoResult
+from virtuoso_bridge.virtuoso.symbol import (
+    SymbolGenerationResult,
+    SymbolOps,
+    symbol_generate_from_schematic_skill,
+)
+
+
+def test_symbol_ops_exposes_generate_from_schematic() -> None:
+    ops = SymbolOps(object())
+
+    assert callable(ops.generate_from_schematic)
+
+
+def test_generate_from_schematic_returns_verified_created_symbol() -> None:
+    class Client:
+        calls: list[tuple[str, int]]
+
+        def __init__(self) -> None:
+            self.calls = []
+
+        def execute_skill(self, skill: str, *, timeout: int) -> VirtuosoResult:
+            self.calls.append((skill, timeout))
+            if "schSchemToPinList" in skill:
+                return VirtuosoResult(
+                    status=ExecutionStatus.SUCCESS,
+                    output='("generated" "created" (("A" "input" 1) ("Y" "output" 1)))',
+                )
+            return VirtuosoResult(
+                status=ExecutionStatus.SUCCESS,
+                output=(
+                    '(("term" "A" "input" 1 nil) '
+                    '("term" "Y" "output" 1 nil) '
+                    '("termOrder" ("A" "Y")))'
+                ),
+            )
+
+    client = Client()
+
+    result = SymbolOps(client).generate_from_schematic(
+        "demoLib",
+        "nand2",
+        sort_pins="geometric",
+        timeout=17,
+    )
+
+    assert result.lib == "demoLib"
+    assert result.cell == "nand2"
+    assert result.schematic_view == "schematic"
+    assert result.symbol_view == "symbol"
+    assert result.action == "created"
+    assert result.terminal_names == ("A", "Y")
+    assert result.term_order == ("A", "Y")
+    assert len(client.calls) == 2
+    assert client.calls[0][1] == 17
+    assert client.calls[1][1] == 17
+
+
+def test_generate_from_schematic_rejects_same_source_and_target_view() -> None:
+    with pytest.raises(ValueError, match="schematic_view and symbol_view must differ"):
+        symbol_generate_from_schematic_skill(
+            "demoLib",
+            "nand2",
+            schematic_view="schematic",
+            symbol_view="schematic",
+        )
+
+
+def test_symbol_generation_skill_escapes_names_and_restores_pin_sort() -> None:
+    skill = symbol_generate_from_schematic_skill(
+        'demo"\\Lib',
+        'nand"\\2',
+        schematic_view='schem"\\atic',
+        symbol_view='sym"\\bol',
+        sort_pins="geometric",
+    )
+
+    assert 'dbOpenCellViewByType("demo\\"\\\\Lib" "nand\\"\\\\2"' in skill
+    assert '"schem\\"\\\\atic" "schematic" "r")' in skill
+    assert 'ddGetObj("demo\\"\\\\Lib" "nand\\"\\\\2" "sym\\"\\\\bol")' in skill
+    assert 'schSchemToPinList("demo\\"\\\\Lib" "nand\\"\\\\2" "schem\\"\\\\atic")' in skill
+    assert 'schGetEnv("ssgSortPins")' in skill
+    assert 'vbSortChanged = schSetEnv("ssgSortPins" "geometric")' in skill
+    assert "unwindProtect(" in skill
+    assert 'schSetEnv("ssgSortPins" vbOldSort)' in skill
+    assert skill.index("unwindProtect(") < skill.index('schSetEnv("ssgSortPins" "geometric")')
+    assert skill.index('schSetEnv("ssgSortPins" "geometric")') < skill.index("schSchemToPinList")
+    assert skill.index("schSchemToPinList") < skill.index('schSetEnv("ssgSortPins" vbOldSort)')
+    assert skill.index('schSetEnv("ssgSortPins" vbOldSort)') < skill.index("when(vbSourceCv")
+    assert 'warn("temporary symbol cleanup failed")' in skill
+
+    temp_match = re.search(r'schPinListToSymbol\([^)]*"(__vb_symbol_[0-9a-f]+)" vbPinList\)', skill)
+    assert temp_match is not None
+    temp_view = temp_match.group(1)
+    assert f'"{temp_view}" "schematicSymbol" "r")' in skill
+    assert f'ddGetObj("demo\\"\\\\Lib" "nand\\"\\\\2" "{temp_view}")' in skill
+    assert (
+        'dbCopyCellView(vbTempCv "demo\\"\\\\Lib" "nand\\"\\\\2" '
+        '"sym\\"\\\\bol" nil nil vbReplacing)'
+    ) in skill
+
+
+def test_symbol_generation_skill_leaves_pin_sort_unchanged_when_not_requested() -> None:
+    skill = symbol_generate_from_schematic_skill("demoLib", "nand2")
+
+    assert "schGetEnv" not in skill
+    assert "schSetEnv" not in skill
+    assert "unwindProtect(" in skill
+
+
+@pytest.mark.parametrize("sort_pins", ["alphabetic", "GEOMETRIC", ""])
+def test_symbol_generation_rejects_unknown_pin_sort(sort_pins: str) -> None:
+    with pytest.raises(ValueError, match="sort_pins must be one of: alphanumeric, geometric"):
+        symbol_generate_from_schematic_skill("demoLib", "nand2", sort_pins=sort_pins)  # type: ignore[arg-type]
+
+
+def test_symbol_generation_skill_disables_existing_target_by_default() -> None:
+    skill = symbol_generate_from_schematic_skill("demoLib", "nand2")
+
+    assert 'when(vbReplacing && !nil error("target symbol exists"))' in skill
+    assert 'schPinListToSymbol("demoLib" "nand2" "__vb_symbol_' in skill
+    assert 'schPinListToSymbol("demoLib" "nand2" "symbol"' not in skill
+
+
+def test_symbol_generation_skill_allows_verified_temporary_copy_when_overwriting() -> None:
+    skill = symbol_generate_from_schematic_skill("demoLib", "nand2", overwrite=True)
+
+    assert 'when(vbReplacing && !t error("target symbol exists"))' in skill
+    assert 'error("generated symbol terminals mismatch")' in skill
+    assert 'dbCopyCellView(vbTempCv "demoLib" "nand2" "symbol" nil nil vbReplacing)' in skill
+    assert "dbClose(vbTargetCv) vbTargetCv = nil" in skill
+    assert 'ddDeleteObj(vbTargetObj)' not in skill
+
+
+def test_generate_from_schematic_reports_replaced_custom_view() -> None:
+    class Client:
+        skills: list[str]
+
+        def __init__(self) -> None:
+            self.skills = []
+
+        def execute_skill(self, skill: str, *, timeout: int) -> VirtuosoResult:
+            self.skills.append(skill)
+            if "schSchemToPinList" in skill:
+                return VirtuosoResult(
+                    status=ExecutionStatus.SUCCESS,
+                    output='("generated" "replaced" (("A" "input" 1)))',
+                )
+            return VirtuosoResult(
+                status=ExecutionStatus.SUCCESS,
+                output='(("term" "A" "input" 1 nil) ("termOrder" ("A")))',
+            )
+
+    client = Client()
+    result = SymbolOps(client).generate_from_schematic(
+        "demoLib",
+        "nand2",
+        schematic_view="schematic_alt",
+        symbol_view="symbol_alt",
+        overwrite=True,
+    )
+
+    assert isinstance(result, SymbolGenerationResult)
+    assert result.action == "replaced"
+    assert result.schematic_view == "schematic_alt"
+    assert result.symbol_view == "symbol_alt"
+    assert 'schSchemToPinList("demoLib" "nand2" "schematic_alt")' in client.skills[0]
+    assert 'dbOpenCellViewByType("demoLib" "nand2" "symbol_alt" "schematicSymbol" "r")' in client.skills[1]
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        "source schematic not found",
+        "target symbol exists",
+        "schematic to pin list failed",
+        "symbol generation failed",
+    ],
+)
+def test_generate_from_schematic_raises_for_skill_failure(error: str) -> None:
+    class Client:
+        def execute_skill(self, skill: str, *, timeout: int) -> VirtuosoResult:
+            return VirtuosoResult(status=ExecutionStatus.ERROR, errors=[error])
+
+    with pytest.raises(RuntimeError, match=re.escape(error)):
+        SymbolOps(Client()).generate_from_schematic("demoLib", "nand2")
+
+
+def test_generate_from_schematic_rejects_terminal_readback_mismatch() -> None:
+    class Client:
+        def execute_skill(self, skill: str, *, timeout: int) -> VirtuosoResult:
+            if "schSchemToPinList" in skill:
+                return VirtuosoResult(
+                    status=ExecutionStatus.SUCCESS,
+                    output='("generated" "created" (("A" "input" 1)))',
+                )
+            return VirtuosoResult(
+                status=ExecutionStatus.SUCCESS,
+                output='(("term" "B" "input" 1 nil) ("termOrder" ("B")))',
+            )
+
+    with pytest.raises(RuntimeError, match="generated symbol readback mismatch"):
+        SymbolOps(Client()).generate_from_schematic("demoLib", "nand2")
+
+
+def test_generate_from_schematic_rejects_term_order_mismatch() -> None:
+    class Client:
+        def execute_skill(self, skill: str, *, timeout: int) -> VirtuosoResult:
+            if "schSchemToPinList" in skill:
+                return VirtuosoResult(
+                    status=ExecutionStatus.SUCCESS,
+                    output='("generated" "created" (("A" "input" 1) ("Y" "output" 1)))',
+                )
+            return VirtuosoResult(
+                status=ExecutionStatus.SUCCESS,
+                output=(
+                    '(("term" "A" "input" 1 nil) '
+                    '("term" "Y" "output" 1 nil) '
+                    '("termOrder" ("A")))'
+                ),
+            )
+
+    with pytest.raises(RuntimeError, match="generated symbol term order mismatch"):
+        SymbolOps(Client()).generate_from_schematic("demoLib", "nand2")
+
+
+def test_generate_from_schematic_uses_cadence_default_when_order_is_not_explicit() -> None:
+    class Client:
+        def execute_skill(self, skill: str, *, timeout: int) -> VirtuosoResult:
+            if "schSchemToPinList" in skill:
+                return VirtuosoResult(
+                    status=ExecutionStatus.SUCCESS,
+                    output='("generated" "created" (("A" "input" 1) ("Y" "output" 1)))',
+                )
+            return VirtuosoResult(
+                status=ExecutionStatus.SUCCESS,
+                output=(
+                    '(("term" "A" "input" 1 nil) '
+                    '("term" "Y" "output" 1 nil) '
+                    '("portOrder" nil) ("termOrder" nil))'
+                ),
+            )
+
+    result = SymbolOps(Client()).generate_from_schematic("demoLib", "nand2")
+
+    assert result.terminal_names == ("A", "Y")
+    assert result.term_order == ("Y", "A")

--- a/tests/test_symbol_generator.py
+++ b/tests/test_symbol_generator.py
@@ -30,7 +30,10 @@ def test_generate_from_schematic_returns_verified_created_symbol() -> None:
             if "schSchemToPinList" in skill:
                 return VirtuosoResult(
                     status=ExecutionStatus.SUCCESS,
-                    output='("generated" "created" (("A" "input" 1) ("Y" "output" 1)))',
+                    output=(
+                        '("generated" "created" '
+                        '(("A" "input" 1) ("Y" "output" 1)) ("A" "Y"))'
+                    ),
                 )
             return VirtuosoResult(
                 status=ExecutionStatus.SUCCESS,
@@ -58,9 +61,8 @@ def test_generate_from_schematic_returns_verified_created_symbol() -> None:
     assert result.action == "created"
     assert result.terminal_names == ("A", "Y")
     assert result.term_order == ("A", "Y")
-    assert len(client.calls) == 2
+    assert len(client.calls) == 1
     assert client.calls[0][1] == 17
-    assert client.calls[1][1] == 17
 
 
 def test_generate_from_schematic_rejects_same_source_and_target_view() -> None:
@@ -93,8 +95,14 @@ def test_symbol_generation_skill_escapes_names_and_restores_pin_sort() -> None:
     assert skill.index("unwindProtect(") < skill.index('schSetEnv("ssgSortPins" "geometric")')
     assert skill.index('schSetEnv("ssgSortPins" "geometric")') < skill.index("schSchemToPinList")
     assert skill.index("schSchemToPinList") < skill.index('schSetEnv("ssgSortPins" vbOldSort)')
+    assert skill.index('schSetEnv("ssgSortPins" vbOldSort)') < skill.index(
+        "dbCopyCellView(vbTempCv"
+    )
     assert skill.index('schSetEnv("ssgSortPins" vbOldSort)') < skill.index("when(vbSourceCv")
-    assert 'list("cleanupFailed" "temporary symbol cleanup failed")' in skill
+    assert (
+        'list("failed" if(vbBodyResult nil vbBodyFailure) reverse(vbCleanupFailures))'
+        in skill
+    )
 
     temp_match = re.search(r'schPinListToSymbol\([^)]*"(__vb_symbol_[0-9a-f]+)" vbPinList\)', skill)
     assert temp_match is not None
@@ -103,7 +111,7 @@ def test_symbol_generation_skill_escapes_names_and_restores_pin_sort() -> None:
     assert f'ddGetObj("demo\\"\\\\Lib" "nand\\"\\\\2" "{temp_view}")' in skill
     assert (
         'dbCopyCellView(vbTempCv "demo\\"\\\\Lib" "nand\\"\\\\2" '
-        '"sym\\"\\\\bol" nil nil vbReplacing)'
+        '"sym\\"\\\\bol" nil nil nil)'
     ) in skill
 
 
@@ -134,16 +142,118 @@ def test_symbol_generation_skill_allows_verified_temporary_copy_when_overwriting
 
     assert 'when(vbReplacing && !t error("target symbol exists"))' in skill
     assert 'error("generated symbol terminals mismatch")' in skill
-    assert 'dbCopyCellView(vbTempCv "demoLib" "nand2" "symbol" nil nil vbReplacing)' in skill
-    assert "dbClose(vbTargetCv) vbTargetCv = nil" in skill
-    assert 'ddDeleteObj(vbTargetObj)' not in skill
+    assert 'dbCopyCellView(vbTempCv "demoLib" "nand2" "symbol" nil nil t)' in skill
+    assert 'unless(dbClose(vbTargetCv) error("installed symbol close failed"))' in skill
+    assert 'dbFindOpenCellViewByName("demoLib" "nand2" "symbol")' in skill
 
 
-def test_symbol_generation_skill_returns_cleanup_status_inside_let() -> None:
+def test_symbol_generation_skill_rolls_back_failed_overwrite_from_backup() -> None:
+    skill = symbol_generate_from_schematic_skill("demoLib", "nand2", overwrite=True)
+
+    backup_match = re.search(r'"(__vb_symbol_backup_[0-9a-f]+)"', skill)
+    assert backup_match is not None
+    backup_view = backup_match.group(1)
+    open_guard = 'error("target symbol is open")'
+    backup_copy = (
+        f'dbCopyCellView(vbBackupSourceCv "demoLib" "nand2" "{backup_view}" nil nil nil)'
+    )
+    target_copy = 'dbCopyCellView(vbTempCv "demoLib" "nand2" "symbol" nil nil t)'
+    final_order = "vbFinalOrder = schGetPinOrder(vbTargetCv)"
+    rollback_copy = 'dbCopyCellView(vbBackupCv "demoLib" "nand2" "symbol" nil nil t)'
+
+    assert 'dbFindOpenCellViewByName("demoLib" "nand2" "symbol")' in skill
+    assert open_guard in skill
+    assert backup_copy in skill
+    assert target_copy in skill
+    assert final_order in skill
+    assert rollback_copy in skill
+    assert "target symbol rollback failed" in skill
+    assert skill.index(open_guard) < skill.index(backup_copy) < skill.index(target_copy)
+    assert skill.index(target_copy) < skill.index(final_order) < skill.index("vbCommitOk = t")
+
+
+def test_generate_from_schematic_does_not_depend_on_post_commit_readback() -> None:
+    class Client:
+        calls = 0
+
+        def execute_skill(self, skill: str, *, timeout: int) -> VirtuosoResult:
+            self.calls += 1
+            if self.calls > 1:
+                raise AssertionError("committed symbol must be verified in the generation call")
+            return VirtuosoResult(
+                status=ExecutionStatus.SUCCESS,
+                output=(
+                    '("generated" "replaced" '
+                    '(("A" "input" 1) ("Y" "output" 1)) ("A" "Y"))'
+                ),
+            )
+
+    client = Client()
+
+    result = SymbolOps(client).generate_from_schematic(
+        "demoLib",
+        "nand2",
+        overwrite=True,
+    )
+
+    assert result.action == "replaced"
+    assert result.terminal_names == ("A", "Y")
+    assert result.term_order == ("A", "Y")
+    assert client.calls == 1
+
+
+def test_symbol_generation_skill_preserves_effective_source_pin_order() -> None:
     skill = symbol_generate_from_schematic_skill("demoLib", "nand2")
 
-    assert "vbCleanupFailed = t))) ) if(vbCleanupFailed" in skill
-    assert "vbCleanupFailed = t))) )) if(vbCleanupFailed" not in skill
+    source_order = "vbExpectedOrder = schGetPinOrder(vbSourceCv)"
+    temp_order = "vbActualOrder = schGetPinOrder(vbTempCv)"
+    order_check = 'unless(equal(vbExpectedOrder vbActualOrder) error("generated symbol pin order mismatch"))'
+    target_copy = 'dbCopyCellView(vbTempCv "demoLib" "nand2" "symbol"'
+
+    assert source_order in skill
+    assert temp_order in skill
+    assert order_check in skill
+    assert 'unless(dbClose(vbSourceCv) error("source schematic close failed"))' in skill
+    assert skill.index(source_order) < skill.index("dbClose(vbSourceCv)")
+    assert skill.index(temp_order) < skill.index(order_check) < skill.index(target_copy)
+    assert 'list("generated" vbAction vbFinalTerms vbFinalOrder)' in skill
+
+
+def test_symbol_generation_skill_captures_body_failure_before_cleanup_reporting() -> None:
+    skill = symbol_generate_from_schematic_skill("demoLib", "nand2")
+
+    body_attempt = "vbBodyAttempt = errset(progn("
+    failure_capture = 'vbBodyFailure = sprintf(nil "%L" errset.errset)'
+    cleanup_start = "progn(when(vbSourceCv"
+
+    assert "vbBodyResult = unwindProtect(progn(" in skill
+    assert body_attempt in skill
+    assert 'vbBodyFailure = "symbol generation failed"' in skill
+    assert failure_capture in skill
+    assert skill.index(body_attempt) < skill.index(failure_capture) < skill.index(cleanup_start)
+    assert (
+        'vbCleanupFailures = cons("temporary symbol cleanup failed" vbCleanupFailures)'
+        in skill
+    )
+    assert (
+        'list("failed" if(vbBodyResult nil vbBodyFailure) reverse(vbCleanupFailures))'
+        in skill
+    )
+
+
+def test_symbol_generation_skill_reports_pin_sort_restore_failure() -> None:
+    skill = symbol_generate_from_schematic_skill(
+        "demoLib",
+        "nand2",
+        sort_pins="geometric",
+    )
+
+    assert 'vbCleanup = errset(schSetEnv("ssgSortPins" vbOldSort) nil)' in skill
+    assert (
+        'vbCleanupFailures = cons("failed to restore ssgSortPins" vbCleanupFailures)'
+        in skill
+    )
+    assert 'warn("failed to restore ssgSortPins")' not in skill
 
 
 def test_generate_from_schematic_reports_replaced_custom_view() -> None:
@@ -158,7 +268,7 @@ def test_generate_from_schematic_reports_replaced_custom_view() -> None:
             if "schSchemToPinList" in skill:
                 return VirtuosoResult(
                     status=ExecutionStatus.SUCCESS,
-                    output='("generated" "replaced" (("A" "input" 1)))',
+                    output='("generated" "replaced" (("A" "input" 1)) ("A"))',
                 )
             return VirtuosoResult(
                 status=ExecutionStatus.SUCCESS,
@@ -182,7 +292,10 @@ def test_generate_from_schematic_reports_replaced_custom_view() -> None:
     assert result.schematic_view == "schematic_alt"
     assert result.symbol_view == "symbol_alt"
     assert 'schSchemToPinList("demoLib" "nand2" "schematic_alt")' in client.skills[0]
-    assert 'dbOpenCellViewByType("demoLib" "nand2" "symbol_alt" "schematicSymbol" "r")' in client.skills[1]
+    assert (
+        'dbOpenCellViewByType("demoLib" "nand2" "symbol_alt" "schematicSymbol" "r")'
+        in client.skills[0]
+    )
 
 
 @pytest.mark.parametrize(
@@ -203,42 +316,45 @@ def test_generate_from_schematic_raises_for_skill_failure(error: str) -> None:
         SymbolOps(Client()).generate_from_schematic("demoLib", "nand2")
 
 
-def test_generate_from_schematic_rejects_terminal_readback_mismatch() -> None:
-    class Client:
-        def execute_skill(self, skill: str, *, timeout: int) -> VirtuosoResult:
-            if "schSchemToPinList" in skill:
-                return VirtuosoResult(
-                    status=ExecutionStatus.SUCCESS,
-                    output='("generated" "created" (("A" "input" 1)))',
-                )
-            return VirtuosoResult(
-                status=ExecutionStatus.SUCCESS,
-                output='(("term" "B" "input" 1 nil) ("termOrder" ("B")))',
-            )
+def test_symbol_generation_skill_validates_installed_terminal_readback() -> None:
+    skill = symbol_generate_from_schematic_skill("demoLib", "nand2")
 
-    with pytest.raises(RuntimeError, match="generated symbol readback mismatch"):
-        SymbolOps(Client()).generate_from_schematic("demoLib", "nand2")
+    target_copy = 'dbCopyCellView(vbTempCv "demoLib" "nand2" "symbol"'
+    final_terms = "vbFinalTerms = mapcar("
+    terminal_check = 'error("installed symbol terminals mismatch")'
+
+    assert target_copy in skill
+    assert final_terms in skill
+    assert terminal_check in skill
+    assert skill.index(target_copy) < skill.index(final_terms) < skill.index(terminal_check)
 
 
 def test_generate_from_schematic_rejects_term_order_mismatch() -> None:
     class Client:
         def execute_skill(self, skill: str, *, timeout: int) -> VirtuosoResult:
-            if "schSchemToPinList" in skill:
-                return VirtuosoResult(
-                    status=ExecutionStatus.SUCCESS,
-                    output='("generated" "created" (("A" "input" 1) ("Y" "output" 1)))',
-                )
             return VirtuosoResult(
                 status=ExecutionStatus.SUCCESS,
                 output=(
-                    '(("term" "A" "input" 1 nil) '
-                    '("term" "Y" "output" 1 nil) '
-                    '("pinOrder" ("A")) ("termOrder" ("A" "Y")))'
+                    '("generated" "created" '
+                    '(("A" "input" 1) ("Y" "output" 1)) ("A"))'
                 ),
             )
 
     with pytest.raises(RuntimeError, match="generated symbol term order mismatch"):
         SymbolOps(Client()).generate_from_schematic("demoLib", "nand2")
+
+
+def test_symbol_generation_skill_rejects_reordered_installed_pin_order() -> None:
+    skill = symbol_generate_from_schematic_skill("demoLib", "nand2")
+
+    final_order = "vbFinalOrder = schGetPinOrder(vbTargetCv)"
+    order_check = 'unless(equal(vbExpectedOrder vbFinalOrder) '
+    order_error = 'error("installed symbol pin order mismatch"))'
+
+    assert final_order in skill
+    assert order_check in skill
+    assert order_error in skill
+    assert skill.index(final_order) < skill.index(order_check) < skill.index(order_error)
 
 
 def test_generate_from_schematic_uses_sch_get_pin_order() -> None:
@@ -247,7 +363,10 @@ def test_generate_from_schematic_uses_sch_get_pin_order() -> None:
             if "schSchemToPinList" in skill:
                 return VirtuosoResult(
                     status=ExecutionStatus.SUCCESS,
-                    output='("generated" "created" (("A" "input" 1) ("Y" "output" 1)))',
+                    output=(
+                        '("generated" "created" '
+                        '(("A" "input" 1) ("Y" "output" 1)) ("A" "Y"))'
+                    ),
                 )
             return VirtuosoResult(
                 status=ExecutionStatus.SUCCESS,
@@ -273,7 +392,7 @@ def test_generate_from_schematic_reports_temporary_view_cleanup_failure() -> Non
             self.calls += 1
             return VirtuosoResult(
                 status=ExecutionStatus.SUCCESS,
-                output='("cleanupFailed" "temporary symbol cleanup failed")',
+                output='("failed" nil ("temporary symbol cleanup failed"))',
             )
 
     client = Client()
@@ -285,3 +404,101 @@ def test_generate_from_schematic_reports_temporary_view_cleanup_failure() -> Non
         SymbolOps(client).generate_from_schematic("demoLib", "nand2")
 
     assert client.calls == 1
+
+
+def test_generate_from_schematic_combines_body_and_cleanup_failures() -> None:
+    class Client:
+        calls = 0
+
+        def execute_skill(self, skill: str, *, timeout: int) -> VirtuosoResult:
+            self.calls += 1
+            return VirtuosoResult(
+                status=ExecutionStatus.SUCCESS,
+                output=(
+                    '("failed" "symbol generation failed" '
+                    '("temporary symbol cleanup failed"))'
+                ),
+            )
+
+    client = Client()
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "symbol generation failed: symbol generation failed; "
+            "cleanup failed: temporary symbol cleanup failed"
+        ),
+    ):
+        SymbolOps(client).generate_from_schematic("demoLib", "nand2")
+
+    assert client.calls == 1
+
+
+def test_generate_from_schematic_rejects_non_list_terminal_payload() -> None:
+    class Client:
+        calls = 0
+
+        def execute_skill(self, skill: str, *, timeout: int) -> VirtuosoResult:
+            self.calls += 1
+            if self.calls == 1:
+                return VirtuosoResult(
+                    status=ExecutionStatus.SUCCESS,
+                    output='("generated" "created" "not-a-terminal-list" nil)',
+                )
+            raise AssertionError("malformed generation output must fail before readback")
+
+    client = Client()
+
+    with pytest.raises(RuntimeError, match="unexpected final terminal payload"):
+        SymbolOps(client).generate_from_schematic("demoLib", "nand2")
+
+    assert client.calls == 1
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        '("generated" "created" (("A" "input" 1)))',
+        '("generated" "created" (("A" "input" 1)) "not-a-pin-order")',
+    ],
+)
+def test_generate_from_schematic_rejects_missing_or_scalar_pin_order(output: str) -> None:
+    class Client:
+        calls = 0
+
+        def execute_skill(self, skill: str, *, timeout: int) -> VirtuosoResult:
+            self.calls += 1
+            if self.calls == 1:
+                return VirtuosoResult(status=ExecutionStatus.SUCCESS, output=output)
+            raise AssertionError("malformed generation output must fail before readback")
+
+    client = Client()
+
+    with pytest.raises(RuntimeError, match="unexpected final pin order payload"):
+        SymbolOps(client).generate_from_schematic("demoLib", "nand2")
+
+    assert client.calls == 1
+
+
+def test_generate_from_schematic_accepts_nil_terminal_payload() -> None:
+    class Client:
+        calls = 0
+
+        def execute_skill(self, skill: str, *, timeout: int) -> VirtuosoResult:
+            self.calls += 1
+            if self.calls == 1:
+                return VirtuosoResult(
+                    status=ExecutionStatus.SUCCESS,
+                    output='("generated" "created" nil nil)',
+                )
+            return VirtuosoResult(
+                status=ExecutionStatus.SUCCESS,
+                output=(
+                    '(("pinOrder" nil) ("portOrder" nil) ("termOrder" nil))'
+                ),
+            )
+
+    result = SymbolOps(Client()).generate_from_schematic("demoLib", "empty")
+
+    assert result.terminal_names == ()
+    assert result.term_order == ()

--- a/tests/test_symbol_generator.py
+++ b/tests/test_symbol_generator.py
@@ -12,6 +12,31 @@ from virtuoso_bridge.virtuoso.symbol import (
 )
 
 
+def _matching_parenthesis(text: str, open_index: int) -> int:
+    depth = 0
+    in_string = False
+    escaped = False
+    for index in range(open_index, len(text)):
+        character = text[index]
+        if in_string:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                in_string = False
+            continue
+        if character == '"':
+            in_string = True
+        elif character == "(":
+            depth += 1
+        elif character == ")":
+            depth -= 1
+            if depth == 0:
+                return index
+    raise AssertionError("unbalanced generated SKILL")
+
+
 def test_symbol_ops_exposes_generate_from_schematic() -> None:
     ops = SymbolOps(object())
 
@@ -60,7 +85,7 @@ def test_generate_from_schematic_returns_verified_created_symbol() -> None:
     assert result.symbol_view == "symbol"
     assert result.action == "created"
     assert result.terminal_names == ("A", "Y")
-    assert result.term_order == ("A", "Y")
+    assert result.pin_order == ("A", "Y")
     assert len(client.calls) == 1
     assert client.calls[0][1] == 17
 
@@ -172,6 +197,21 @@ def test_symbol_generation_skill_rolls_back_failed_overwrite_from_backup() -> No
     assert skill.index(target_copy) < skill.index(final_order) < skill.index("vbCommitOk = t")
 
 
+def test_symbol_generation_skill_rolls_back_after_temporary_cleanup_failure() -> None:
+    skill = symbol_generate_from_schematic_skill("demoLib", "nand2", overwrite=True)
+
+    rollback_start = skill.index("when(!vbCommitOk || vbCleanupFailures ")
+    rollback_open = skill.index("(", rollback_start)
+    rollback_end = _matching_parenthesis(skill, rollback_open)
+    temp_cleanup = skill.rfind("vbTempObj = ddGetObj", 0, rollback_start)
+    backup_cleanup = skill.index("when(vbBackupReady &&", rollback_end)
+
+    assert temp_cleanup >= 0
+    assert temp_cleanup < rollback_start < rollback_end < backup_cleanup
+    assert "(vbCommitOk && !vbCleanupFailures)" in skill[backup_cleanup:]
+    assert _matching_parenthesis(skill, skill.index("(")) == len(skill) - 1
+
+
 def test_generate_from_schematic_does_not_depend_on_post_commit_readback() -> None:
     class Client:
         calls = 0
@@ -198,7 +238,7 @@ def test_generate_from_schematic_does_not_depend_on_post_commit_readback() -> No
 
     assert result.action == "replaced"
     assert result.terminal_names == ("A", "Y")
-    assert result.term_order == ("A", "Y")
+    assert result.pin_order == ("A", "Y")
     assert client.calls == 1
 
 
@@ -254,6 +294,26 @@ def test_symbol_generation_skill_reports_pin_sort_restore_failure() -> None:
         in skill
     )
     assert 'warn("failed to restore ssgSortPins")' not in skill
+
+
+@pytest.mark.parametrize(
+    ("variable", "failure"),
+    [
+        ("vbSourceCv", "source schematic cleanup close failed"),
+        ("vbTargetCv", "target symbol cleanup close failed"),
+        ("vbTempCv", "temporary symbol cleanup close failed"),
+        ("vbBackupSourceCv", "symbol backup source cleanup close failed"),
+        ("vbBackupCv", "symbol backup cleanup close failed"),
+    ],
+)
+def test_symbol_generation_skill_reports_cleanup_close_failure(
+    variable: str,
+    failure: str,
+) -> None:
+    skill = symbol_generate_from_schematic_skill("demoLib", "nand2", overwrite=True)
+
+    assert f"vbCleanup = errset(dbClose({variable}) nil)" in skill
+    assert f'vbCleanupFailures = cons("{failure}" vbCleanupFailures)' in skill
 
 
 def test_generate_from_schematic_reports_replaced_custom_view() -> None:
@@ -329,7 +389,7 @@ def test_symbol_generation_skill_validates_installed_terminal_readback() -> None
     assert skill.index(target_copy) < skill.index(final_terms) < skill.index(terminal_check)
 
 
-def test_generate_from_schematic_rejects_term_order_mismatch() -> None:
+def test_generate_from_schematic_rejects_pin_order_terminal_set_mismatch() -> None:
     class Client:
         def execute_skill(self, skill: str, *, timeout: int) -> VirtuosoResult:
             return VirtuosoResult(
@@ -340,7 +400,7 @@ def test_generate_from_schematic_rejects_term_order_mismatch() -> None:
                 ),
             )
 
-    with pytest.raises(RuntimeError, match="generated symbol term order mismatch"):
+    with pytest.raises(RuntimeError, match="generated symbol pin order mismatch"):
         SymbolOps(Client()).generate_from_schematic("demoLib", "nand2")
 
 
@@ -381,7 +441,7 @@ def test_generate_from_schematic_uses_sch_get_pin_order() -> None:
     result = SymbolOps(Client()).generate_from_schematic("demoLib", "nand2")
 
     assert result.terminal_names == ("A", "Y")
-    assert result.term_order == ("A", "Y")
+    assert result.pin_order == ("A", "Y")
 
 
 def test_generate_from_schematic_reports_temporary_view_cleanup_failure() -> None:
@@ -456,6 +516,35 @@ def test_generate_from_schematic_rejects_non_list_terminal_payload() -> None:
 
 
 @pytest.mark.parametrize(
+    ("output", "error"),
+    [
+        (
+            '("generated" "created" '
+            '(("A" "input" 1) ("A" "output" 1)) ("A"))',
+            "duplicate final terminal: A",
+        ),
+        (
+            '("generated" "created" (("A" "input" "wide")) ("A"))',
+            "invalid final terminal width",
+        ),
+    ],
+)
+def test_generate_from_schematic_rejects_invalid_terminal_records(
+    output: str,
+    error: str,
+) -> None:
+    class Client:
+        def execute_skill(self, skill: str, *, timeout: int) -> VirtuosoResult:
+            return VirtuosoResult(status=ExecutionStatus.SUCCESS, output=output)
+
+    with pytest.raises(
+        RuntimeError,
+        match=rf"symbol generation response error for demoLib/nand2: {error}",
+    ):
+        SymbolOps(Client()).generate_from_schematic("demoLib", "nand2")
+
+
+@pytest.mark.parametrize(
     "output",
     [
         '("generated" "created" (("A" "input" 1)))',
@@ -501,4 +590,4 @@ def test_generate_from_schematic_accepts_nil_terminal_payload() -> None:
     result = SymbolOps(Client()).generate_from_schematic("demoLib", "empty")
 
     assert result.terminal_names == ()
-    assert result.term_order == ()
+    assert result.pin_order == ()

--- a/tests/test_symbol_generator.py
+++ b/tests/test_symbol_generator.py
@@ -37,6 +37,7 @@ def test_generate_from_schematic_returns_verified_created_symbol() -> None:
                 output=(
                     '(("term" "A" "input" 1 nil) '
                     '("term" "Y" "output" 1 nil) '
+                    '("pinOrder" ("A" "Y")) '
                     '("termOrder" ("A" "Y")))'
                 ),
             )
@@ -93,7 +94,7 @@ def test_symbol_generation_skill_escapes_names_and_restores_pin_sort() -> None:
     assert skill.index('schSetEnv("ssgSortPins" "geometric")') < skill.index("schSchemToPinList")
     assert skill.index("schSchemToPinList") < skill.index('schSetEnv("ssgSortPins" vbOldSort)')
     assert skill.index('schSetEnv("ssgSortPins" vbOldSort)') < skill.index("when(vbSourceCv")
-    assert 'warn("temporary symbol cleanup failed")' in skill
+    assert 'list("cleanupFailed" "temporary symbol cleanup failed")' in skill
 
     temp_match = re.search(r'schPinListToSymbol\([^)]*"(__vb_symbol_[0-9a-f]+)" vbPinList\)', skill)
     assert temp_match is not None
@@ -138,6 +139,13 @@ def test_symbol_generation_skill_allows_verified_temporary_copy_when_overwriting
     assert 'ddDeleteObj(vbTargetObj)' not in skill
 
 
+def test_symbol_generation_skill_returns_cleanup_status_inside_let() -> None:
+    skill = symbol_generate_from_schematic_skill("demoLib", "nand2")
+
+    assert "vbCleanupFailed = t))) ) if(vbCleanupFailed" in skill
+    assert "vbCleanupFailed = t))) )) if(vbCleanupFailed" not in skill
+
+
 def test_generate_from_schematic_reports_replaced_custom_view() -> None:
     class Client:
         skills: list[str]
@@ -154,7 +162,10 @@ def test_generate_from_schematic_reports_replaced_custom_view() -> None:
                 )
             return VirtuosoResult(
                 status=ExecutionStatus.SUCCESS,
-                output='(("term" "A" "input" 1 nil) ("termOrder" ("A")))',
+                output=(
+                    '(("term" "A" "input" 1 nil) '
+                    '("pinOrder" ("A")) ("termOrder" ("A")))'
+                ),
             )
 
     client = Client()
@@ -222,7 +233,7 @@ def test_generate_from_schematic_rejects_term_order_mismatch() -> None:
                 output=(
                     '(("term" "A" "input" 1 nil) '
                     '("term" "Y" "output" 1 nil) '
-                    '("termOrder" ("A")))'
+                    '("pinOrder" ("A")) ("termOrder" ("A" "Y")))'
                 ),
             )
 
@@ -230,7 +241,7 @@ def test_generate_from_schematic_rejects_term_order_mismatch() -> None:
         SymbolOps(Client()).generate_from_schematic("demoLib", "nand2")
 
 
-def test_generate_from_schematic_uses_cadence_default_when_order_is_not_explicit() -> None:
+def test_generate_from_schematic_uses_sch_get_pin_order() -> None:
     class Client:
         def execute_skill(self, skill: str, *, timeout: int) -> VirtuosoResult:
             if "schSchemToPinList" in skill:
@@ -243,6 +254,7 @@ def test_generate_from_schematic_uses_cadence_default_when_order_is_not_explicit
                 output=(
                     '(("term" "A" "input" 1 nil) '
                     '("term" "Y" "output" 1 nil) '
+                    '("pinOrder" ("A" "Y")) '
                     '("portOrder" nil) ("termOrder" nil))'
                 ),
             )
@@ -250,4 +262,26 @@ def test_generate_from_schematic_uses_cadence_default_when_order_is_not_explicit
     result = SymbolOps(Client()).generate_from_schematic("demoLib", "nand2")
 
     assert result.terminal_names == ("A", "Y")
-    assert result.term_order == ("Y", "A")
+    assert result.term_order == ("A", "Y")
+
+
+def test_generate_from_schematic_reports_temporary_view_cleanup_failure() -> None:
+    class Client:
+        calls = 0
+
+        def execute_skill(self, skill: str, *, timeout: int) -> VirtuosoResult:
+            self.calls += 1
+            return VirtuosoResult(
+                status=ExecutionStatus.SUCCESS,
+                output='("cleanupFailed" "temporary symbol cleanup failed")',
+            )
+
+    client = Client()
+
+    with pytest.raises(
+        RuntimeError,
+        match="symbol generation cleanup failed: temporary symbol cleanup failed",
+    ):
+        SymbolOps(client).generate_from_schematic("demoLib", "nand2")
+
+    assert client.calls == 1

--- a/tests/test_symbol_generator.py
+++ b/tests/test_symbol_generator.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import re
+import subprocess
+import sys
 
 import pytest
 
@@ -513,6 +515,43 @@ def test_generate_from_schematic_rejects_non_list_terminal_payload() -> None:
         SymbolOps(client).generate_from_schematic("demoLib", "nand2")
 
     assert client.calls == 1
+
+
+def test_generate_from_schematic_rejects_trailing_protocol_data_without_hanging() -> None:
+    code = """
+import sys
+sys.path.insert(0, "src")
+
+from virtuoso_bridge.models import ExecutionStatus, VirtuosoResult
+from virtuoso_bridge.virtuoso.symbol import SymbolOps
+
+class Client:
+    def execute_skill(self, skill: str, *, timeout: int) -> VirtuosoResult:
+        return VirtuosoResult(
+            status=ExecutionStatus.SUCCESS,
+            output='("generated" "created" (("A" "input" 1)) ("A")) ("tail")',
+        )
+
+SymbolOps(Client()).generate_from_schematic("demoLib", "nand2")
+"""
+
+    try:
+        completed = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        pytest.fail("malformed generation response must not hang")
+
+    assert completed.returncode != 0
+    assert (
+        "symbol generation response error for demoLib/nand2: "
+        "symbol generation output must be a single complete SKILL list"
+        in completed.stderr
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_symbol_reader.py
+++ b/tests/test_symbol_reader.py
@@ -22,11 +22,13 @@ def test_symbol_read_ports_skill_opens_symbol_and_reports_terms_labels_and_order
     assert "list(xCoord(cadr(fig~>bBox)) yCoord(cadr(fig~>bBox))))" in skill
     assert 'result = cons(list("label"' in skill
     assert "xy = list(xCoord(label~>xy) yCoord(label~>xy))" in skill
+    assert "unwindProtect(" in skill
+    assert 'result = cons(list("pinOrder" schGetPinOrder(cv)) result)' in skill
     assert 'result = cons(list("portOrder" cv~>portOrder) result)' in skill
     assert 'result = cons(list("termOrder" cv~>termOrder) result)' in skill
     assert "cv~>terminals~>name" not in skill
-    assert "dbClose(cv)" in skill
-    assert skill.endswith("reverse(result))")
+    assert "when(cv errset(dbClose(cv) nil) cv = nil)" in skill
+    assert skill.endswith(")))")
 
 
 def test_parse_symbol_ports_output_rejects_legacy_tsv() -> None:
@@ -40,6 +42,7 @@ def test_parse_symbol_ports_output_preserves_label_delimiters_from_sexpr() -> No
     parsed = parse_symbol_ports_output(
         r'(("label" "foo\tbar\nbaz\"\\end" "normalLabel" (0.2 0.0))'
         r' ("term" "A" "input" 1 ((0 0) (0.1 0.1)))'
+        r' ("pinOrder" ("A" "Y"))'
         r' ("portOrder" ("Y" "A"))'
         r' ("termOrder" ("A" "Y")))'
     )
@@ -50,6 +53,7 @@ def test_parse_symbol_ports_output_preserves_label_delimiters_from_sexpr() -> No
     assert parsed["terms"] == [
         {"name": "A", "direction": "input", "numBits": 1, "bbox": [[0.0, 0.0], [0.1, 0.1]]}
     ]
+    assert parsed["pinOrder"] == ["A", "Y"]
     assert parsed["portOrder"] == ["Y", "A"]
     assert parsed["termOrder"] == ["A", "Y"]
 

--- a/tests/test_symbol_reader.py
+++ b/tests/test_symbol_reader.py
@@ -27,8 +27,10 @@ def test_symbol_read_ports_skill_opens_symbol_and_reports_terms_labels_and_order
     assert 'result = cons(list("portOrder" cv~>portOrder) result)' in skill
     assert 'result = cons(list("termOrder" cv~>termOrder) result)' in skill
     assert "cv~>terminals~>name" not in skill
-    assert "when(cv errset(dbClose(cv) nil) cv = nil)" in skill
-    assert skill.endswith(")))")
+    assert "bodyAttempt = errset(progn(" in skill
+    assert "closeResult = errset(dbClose(cv) nil)" in skill
+    assert 'closeFailures = cons("symbol close failed" closeFailures)' in skill
+    assert 'list("readFailed" if(bodyResult nil bodyFailure) reverse(closeFailures))' in skill
 
 
 def test_parse_symbol_ports_output_rejects_legacy_tsv() -> None:
@@ -102,6 +104,27 @@ def test_read_symbol_ports_raises_on_skill_error() -> None:
             )
 
     with pytest.raises(RuntimeError, match="read_symbol_ports SKILL error: open symbol failed"):
+        read_symbol_ports(Client(), "demoLib", "missing")
+
+
+def test_read_symbol_ports_combines_body_and_close_failures() -> None:
+    class Client:
+        def execute_skill(self, skill: str, *, timeout: int):
+            return VirtuosoResult(
+                status=ExecutionStatus.SUCCESS,
+                output=(
+                    '("readFailed" "open symbol failed" '
+                    '("symbol close failed"))'
+                ),
+            )
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "read_symbol_ports failed for demoLib/missing: open symbol failed; "
+            "cleanup failed: symbol close failed"
+        ),
+    ):
         read_symbol_ports(Client(), "demoLib", "missing")
 
 

--- a/tests/test_symbol_reader.py
+++ b/tests/test_symbol_reader.py
@@ -22,7 +22,9 @@ def test_symbol_read_ports_skill_opens_symbol_and_reports_terms_labels_and_order
     assert "list(xCoord(cadr(fig~>bBox)) yCoord(cadr(fig~>bBox))))" in skill
     assert 'result = cons(list("label"' in skill
     assert "xy = list(xCoord(label~>xy) yCoord(label~>xy))" in skill
+    assert 'result = cons(list("portOrder" cv~>portOrder) result)' in skill
     assert 'result = cons(list("termOrder" cv~>termOrder) result)' in skill
+    assert "cv~>terminals~>name" not in skill
     assert "dbClose(cv)" in skill
     assert skill.endswith("reverse(result))")
 
@@ -38,7 +40,8 @@ def test_parse_symbol_ports_output_preserves_label_delimiters_from_sexpr() -> No
     parsed = parse_symbol_ports_output(
         r'(("label" "foo\tbar\nbaz\"\\end" "normalLabel" (0.2 0.0))'
         r' ("term" "A" "input" 1 ((0 0) (0.1 0.1)))'
-        r' ("termOrder" ("A")))'
+        r' ("portOrder" ("Y" "A"))'
+        r' ("termOrder" ("A" "Y")))'
     )
 
     assert parsed["labels"] == [
@@ -47,7 +50,8 @@ def test_parse_symbol_ports_output_preserves_label_delimiters_from_sexpr() -> No
     assert parsed["terms"] == [
         {"name": "A", "direction": "input", "numBits": 1, "bbox": [[0.0, 0.0], [0.1, 0.1]]}
     ]
-    assert parsed["termOrder"] == ["A"]
+    assert parsed["portOrder"] == ["Y", "A"]
+    assert parsed["termOrder"] == ["A", "Y"]
 
 
 def test_read_symbol_ports_executes_skill() -> None:

--- a/tests/test_symbol_reader.py
+++ b/tests/test_symbol_reader.py
@@ -61,6 +61,20 @@ def test_parse_symbol_ports_output_rejects_malformed_read_failure() -> None:
         parse_symbol_ports_output(output)
 
 
+@pytest.mark.parametrize(
+    "output",
+    [
+        '("readFailed" "open symbol failed" nil',
+        '(("term" "A" "input" 1 nil)) ("unexpected")',
+    ],
+)
+def test_parse_symbol_ports_output_rejects_incomplete_or_trailing_data(
+    output: str,
+) -> None:
+    with pytest.raises(ValueError, match="single complete SKILL list"):
+        parse_symbol_ports_output(output)
+
+
 def test_parse_symbol_ports_output_preserves_label_delimiters_from_sexpr() -> None:
     parsed = parse_symbol_ports_output(
         r'(("label" "foo\tbar\nbaz\"\\end" "normalLabel" (0.2 0.0))'
@@ -147,6 +161,24 @@ def test_read_symbol_ports_combines_body_and_close_failures() -> None:
         match=(
             "read_symbol_ports failed for demoLib/missing: open symbol failed; "
             "cleanup failed: symbol close failed"
+        ),
+    ):
+        read_symbol_ports(Client(), "demoLib", "missing")
+
+
+def test_read_symbol_ports_rejects_truncated_failure_output() -> None:
+    class Client:
+        def execute_skill(self, skill: str, *, timeout: int):
+            return VirtuosoResult(
+                status=ExecutionStatus.SUCCESS,
+                output='("readFailed" "open symbol failed" nil',
+            )
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "read_symbol_ports response error for demoLib/missing: "
+            "symbol readback output must be a single complete SKILL list"
         ),
     ):
         read_symbol_ports(Client(), "demoLib", "missing")

--- a/tests/test_symbol_reader.py
+++ b/tests/test_symbol_reader.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from virtuoso_bridge.models import ExecutionStatus, VirtuosoResult
+from virtuoso_bridge.virtuoso.response import response_fields
 from virtuoso_bridge.virtuoso.symbol import SymbolOps
 from virtuoso_bridge.virtuoso.symbol.reader import (
     parse_symbol_ports_output,
@@ -37,6 +38,26 @@ def test_parse_symbol_ports_output_rejects_legacy_tsv() -> None:
     output = "term\tname=A\tdirection=input\tnumBits=1\tbbox=nil\ntermOrder\t(\"A\")"
 
     with pytest.raises(ValueError, match="structured SKILL list"):
+        parse_symbol_ports_output(output)
+
+
+def test_parse_symbol_ports_output_rejects_read_failure() -> None:
+    output = '("readFailed" "open symbol failed" ("symbol close failed"))'
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "symbol readback failed: open symbol failed; "
+            "cleanup failed: symbol close failed"
+        ),
+    ):
+        parse_symbol_ports_output(output)
+
+
+def test_parse_symbol_ports_output_rejects_malformed_read_failure() -> None:
+    output = '("readFailed" "open symbol failed")'
+
+    with pytest.raises(ValueError, match="malformed symbol read failure output"):
         parse_symbol_ports_output(output)
 
 
@@ -103,7 +124,10 @@ def test_read_symbol_ports_raises_on_skill_error() -> None:
                 errors=["open symbol failed"],
             )
 
-    with pytest.raises(RuntimeError, match="read_symbol_ports SKILL error: open symbol failed"):
+    with pytest.raises(
+        RuntimeError,
+        match="read_symbol_ports SKILL error for demoLib/missing: open symbol failed",
+    ):
         read_symbol_ports(Client(), "demoLib", "missing")
 
 
@@ -142,7 +166,10 @@ def test_read_symbol_ports_raises_on_dict_transport_error() -> None:
         def execute_skill(self, skill: str, *, timeout: int):
             return {"ok": False, "error": "transport failed"}
 
-    with pytest.raises(RuntimeError, match="read_symbol_ports SKILL error: transport failed"):
+    with pytest.raises(
+        RuntimeError,
+        match="read_symbol_ports SKILL error for demoLib/missing: transport failed",
+    ):
         read_symbol_ports(Client(), "demoLib", "missing")
 
 
@@ -193,3 +220,19 @@ def test_read_symbol_ports_accepts_nested_dict_output() -> None:
 
     assert parsed["terms"][0]["name"] == "A"
     assert parsed["termOrder"] == ["A"]
+
+
+def test_response_fields_normalizes_scalar_error() -> None:
+    errors, status, output = response_fields({"errors": "transport failed"})
+
+    assert errors == ["transport failed"]
+    assert status is None
+    assert output == ""
+
+
+def test_response_fields_normalizes_non_string_output() -> None:
+    errors, status, output = response_fields({"output": 17})
+
+    assert errors == []
+    assert status is None
+    assert output == "17"


### PR DESCRIPTION
## Summary

- Add `client.symbol.generate_from_schematic()` around Cadence's native `schSchemToPinList` and `schPinListToSymbol` flow.
- Generate through a private temporary view, verify terminals and effective pin order, restore pin-sort settings, and support guarded overwrite with backup and rollback.
- Report cleanup, close, rollback, and malformed transport-response failures instead of silently leaving ambiguous state.
- Update symbol documentation and examples to use the reusable helper instead of ad hoc SKILL calls.

## Why

Existing examples invoked the native symbol generator directly and did not provide reusable validation, overwrite protection, or rollback behavior. This helper provides a general Python API that keeps generation and verification in one SKILL transaction and makes failure states observable.

## User impact

Callers can generate verified symbols with `client.symbol.generate_from_schematic(...)`, choose pin sorting, and safely replace a closed existing symbol. The returned `SymbolGenerationResult` reports the action, terminal names, and effective `pin_order`.

## Validation

- `pixi run pytest tests/test_skill_output.py tests/test_symbol_generator.py tests/test_symbol_reader.py tests/test_symbol_ops.py -q` — 74 passed
- `pixi run test` — 253 passed
- `pixi run python -m compileall -q src tests`
- `git diff --check`
- IC25.1 live validation covered create, replace, temporary-view cleanup, rollback after injected cleanup failure, close-failure reporting, and final OA residue checks.

No generated artifacts are included.
