### PR TITLE
fix: make recursive downloads Windows-safe

### DIFF
--- a/src/virtuoso_bridge/transport/ssh.py
+++ b/src/virtuoso_bridge/transport/ssh.py
@@ -926,8 +926,10 @@ class SSHRunner:
         # target only after both SSH and local tar have succeeded.  The archive
         # contains the remote directory itself rather than "." so BSD tar does
         # not try to restore metadata on the pre-created staging directory.
+        # A short sibling name and subprocess cwd keep local paths out of tar's
+        # narrow argv on Windows without giving up same-volume atomic renames.
         local_path.parent.mkdir(parents=True, exist_ok=True)
-        stage_path = local_path.with_name(f".{local_path.name}.tmp-{uuid.uuid4().hex}")
+        stage_path = local_path.parent / f".vbtmp-{uuid.uuid4().hex}"
         stage_path.mkdir(parents=True)
         remote_basename = PurePosixPath(remote_path.rstrip("/")).name
         if not remote_basename:
@@ -943,7 +945,7 @@ class SSHRunner:
         remote_cmd = f"sh -c {shlex.quote(inner_cmd)}"
 
         ssh_cmd = self._build_ssh_base() + [remote_cmd]
-        tar_cmd = [self._tar_cmd, "xzf", "-", "-C", str(stage_path).replace("\\", "/")]
+        tar_cmd = [self._tar_cmd, "xzf", "-"]
 
         if self._verbose:
             print(f"[cmd] {' '.join(ssh_cmd)} | {' '.join(tar_cmd)}  # download {remote_path} -> {local_path}", flush=True)
@@ -960,6 +962,7 @@ class SSHRunner:
             stdin=ssh_proc.stdout,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            cwd=stage_path,
             **_windows_no_window_kwargs(),
         )
         if ssh_proc.stdout:
@@ -967,7 +970,7 @@ class SSHRunner:
 
         try:
             tar_out, tar_err = tar_proc.communicate(timeout=timeout)
-            ssh_proc.wait(timeout=5)
+            ssh_proc.wait(timeout=timeout)
         except subprocess.TimeoutExpired:
             ssh_proc.kill()
             tar_proc.kill()
@@ -993,9 +996,7 @@ class SSHRunner:
             )
         try:
             if local_path.exists() or local_path.is_symlink():
-                backup_path = local_path.with_name(
-                    f".{local_path.name}.backup-{uuid.uuid4().hex}"
-                )
+                backup_path = local_path.parent / f".vbbak-{uuid.uuid4().hex}"
                 local_path.rename(backup_path)
             extracted_path.rename(local_path)
         except Exception:

--- a/tests/test_ssh_control_master.py
+++ b/tests/test_ssh_control_master.py
@@ -2,12 +2,82 @@ from __future__ import annotations
 
 import os
 import shlex
+import subprocess
 from pathlib import Path
+from typing import Callable
 
 import pytest
 
 from virtuoso_bridge.transport.ssh import CommandResult, SSHRunner
 from virtuoso_bridge.transport.tunnel import SSHClient
+
+
+class _Pipe:
+    def close(self) -> None:
+        pass
+
+
+class _Stderr:
+    def __init__(self, data: bytes = b"") -> None:
+        self.data = data
+
+    def read(self) -> bytes:
+        return self.data
+
+
+def _tar_extract_root(cmd: list[str], cwd: Path | None) -> Path:
+    if "-C" not in cmd:
+        assert cwd is not None
+        return Path(cwd)
+    extract_arg = Path(cmd[cmd.index("-C") + 1])
+    if extract_arg.is_absolute():
+        return extract_arg
+    assert cwd is not None
+    return Path(cwd) / extract_arg
+
+
+def _install_download_pipeline(
+    monkeypatch,
+    *,
+    ssh_exit_seconds: int = 0,
+    reject_tar_path: Callable[[Path, bool], str | None] | None = None,
+) -> None:
+    class _FakeProcess:
+        def __init__(self, cmd, **kwargs):
+            self.cmd = cmd
+            self.cwd = kwargs.get("cwd")
+            self.is_tar = Path(cmd[0]).stem.lower() == "tar"
+            self.returncode = 0
+            self.stdout = _Pipe()
+            self.stderr = _Stderr()
+
+        def communicate(self, timeout=None):
+            if not self.is_tar:
+                return b"", b""
+            extract_root = _tar_extract_root(self.cmd, self.cwd)
+            rejection = (
+                reject_tar_path(extract_root, "-C" in self.cmd)
+                if reject_tar_path
+                else None
+            )
+            if rejection:
+                self.returncode = 2
+                return b"", rejection.encode("utf-8")
+            extracted = extract_root / "netlist"
+            extracted.mkdir()
+            (extracted / "input.scs").write_text("new netlist\n", encoding="utf-8")
+            return b"", b""
+
+        def wait(self, timeout=None):
+            if not self.is_tar and timeout is not None and timeout < ssh_exit_seconds:
+                raise subprocess.TimeoutExpired(self.cmd, timeout)
+            self.returncode = 0
+            return 0
+
+        def kill(self) -> None:
+            self.returncode = -9
+
+    monkeypatch.setattr("virtuoso_bridge.transport.ssh.subprocess.Popen", _FakeProcess)
 
 
 def test_control_path_is_bounded_for_long_remote_identity(monkeypatch) -> None:
@@ -61,11 +131,88 @@ def test_remote_python_detection_error_includes_ssh_stderr() -> None:
     assert "SSH return code: 255" in msg
 
 
+def test_recursive_download_allows_ssh_exit_within_caller_timeout(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setattr("virtuoso_bridge.transport.ssh.load_vb_env", lambda: None)
+    monkeypatch.setattr("virtuoso_bridge.transport.ssh._setup_command_log", lambda: None)
+    _install_download_pipeline(monkeypatch, ssh_exit_seconds=6)
+
+    local_path = tmp_path / "netlist"
+    runner = SSHRunner(host="eda-host", user="designer", ssh_cmd="ssh", timeout=30)
+
+    result = runner.download("/remote/netlist", local_path, recursive=True)
+
+    assert result.returncode == 0
+    assert (local_path / "input.scs").read_text(encoding="utf-8") == "new netlist\n"
+
+
+def test_recursive_download_supports_paths_outside_active_codepage(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setattr("virtuoso_bridge.transport.ssh.load_vb_env", lambda: None)
+    monkeypatch.setattr("virtuoso_bridge.transport.ssh._setup_command_log", lambda: None)
+
+    def reject_non_cp936(path: Path, path_from_argv: bool) -> str | None:
+        if not path_from_argv:
+            return None
+        try:
+            str(path).encode("cp936")
+        except UnicodeEncodeError:
+            return f"tar could not chdir to {path}"
+        return None
+
+    _install_download_pipeline(monkeypatch, reject_tar_path=reject_non_cp936)
+    local_path = (
+        tmp_path
+        / "Chinese_\U00020bb7_emoji_\U0001f600"
+        / "netlist_\U00020bb7_\U0001f600"
+    )
+    runner = SSHRunner(host="eda-host", user="designer", ssh_cmd="ssh", timeout=30)
+
+    result = runner.download("/remote/netlist", local_path, recursive=True)
+
+    assert result.returncode == 0
+    assert (local_path / "input.scs").read_text(encoding="utf-8") == "new netlist\n"
+
+
+def test_recursive_download_uses_bounded_staging_for_long_target_name(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setattr("virtuoso_bridge.transport.ssh.load_vb_env", lambda: None)
+    monkeypatch.setattr("virtuoso_bridge.transport.ssh._setup_command_log", lambda: None)
+
+    local_parent = tmp_path / "long_target"
+    target_name_length = 250 - len(str(local_parent)) - 1
+    assert 1 <= target_name_length <= 240
+    local_path = local_parent / ("n" * target_name_length)
+    legacy_stage = local_path.with_name(f".{local_path.name}.tmp-" + ("0" * 32))
+    assert len(str(local_path)) == 250
+    assert len(str(legacy_stage)) >= 260
+
+    def reject_legacy_long_path(path: Path, path_from_argv: bool) -> str | None:
+        if path_from_argv and len(str(path)) >= 260:
+            return f"tar could not chdir to {path}"
+        return None
+
+    _install_download_pipeline(monkeypatch, reject_tar_path=reject_legacy_long_path)
+    runner = SSHRunner(host="eda-host", user="designer", ssh_cmd="ssh", timeout=30)
+
+    result = runner.download("/remote/netlist", local_path, recursive=True)
+
+    assert result.returncode == 0
+    assert (local_path / "input.scs").read_text(encoding="utf-8") == "new netlist\n"
+
+
 def test_recursive_download_quotes_remote_path_components(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr("virtuoso_bridge.transport.ssh.load_vb_env", lambda: None)
     monkeypatch.setattr("virtuoso_bridge.transport.ssh._setup_command_log", lambda: None)
 
     commands: list[list[str]] = []
+    process_cwds: list[Path | None] = []
 
     class _Pipe:
         def close(self) -> None:
@@ -78,14 +225,16 @@ def test_recursive_download_quotes_remote_path_components(monkeypatch, tmp_path)
     class _FakeProcess:
         def __init__(self, cmd, **kwargs):
             commands.append(cmd)
+            process_cwds.append(kwargs.get("cwd"))
             self.cmd = cmd
+            self.cwd = kwargs.get("cwd")
             self.returncode = 0
             self.stdout = _Pipe()
             self.stderr = _Stderr()
 
         def communicate(self, timeout=None):
-            if self.cmd[0].endswith("tar"):
-                Path(self.cmd[4], "netlist dir").mkdir()
+            if Path(self.cmd[0]).stem.lower() == "tar":
+                (_tar_extract_root(self.cmd, self.cwd) / "netlist dir").mkdir()
             return b"", b""
 
         def wait(self, timeout=None):
@@ -113,10 +262,10 @@ def test_recursive_download_quotes_remote_path_components(monkeypatch, tmp_path)
     assert 'b=$(basename "$p")' in inner_cmd
     assert 'cd "$d"' in inner_cmd
     assert 'tar czf - "$b"' in inner_cmd
-    assert commands[1][:4] == [runner._tar_cmd, "xzf", "-", "-C"]
-    extract_dir = Path(commands[1][4])
+    assert commands[1] == [runner._tar_cmd, "xzf", "-"]
+    extract_dir = Path(process_cwds[1])
     assert extract_dir.parent == tmp_path
-    assert extract_dir.name.startswith(".netlist dir.tmp-")
+    assert extract_dir.name.startswith(".vbtmp-")
 
 
 def test_recursive_download_extracts_into_requested_directory(monkeypatch, tmp_path) -> None:
@@ -124,6 +273,7 @@ def test_recursive_download_extracts_into_requested_directory(monkeypatch, tmp_p
     monkeypatch.setattr("virtuoso_bridge.transport.ssh._setup_command_log", lambda: None)
 
     commands: list[list[str]] = []
+    process_cwds: list[Path | None] = []
 
     class _Pipe:
         def close(self) -> None:
@@ -136,14 +286,16 @@ def test_recursive_download_extracts_into_requested_directory(monkeypatch, tmp_p
     class _FakeProcess:
         def __init__(self, cmd, **kwargs):
             commands.append(cmd)
+            process_cwds.append(kwargs.get("cwd"))
             self.cmd = cmd
+            self.cwd = kwargs.get("cwd")
             self.returncode = 0
             self.stdout = _Pipe()
             self.stderr = _Stderr()
 
         def communicate(self, timeout=None):
-            if self.cmd[0].endswith("tar"):
-                extracted = Path(self.cmd[4], "netlist")
+            if Path(self.cmd[0]).stem.lower() == "tar":
+                extracted = _tar_extract_root(self.cmd, self.cwd) / "netlist"
                 extracted.mkdir()
                 (extracted / "input.scs").write_text("new netlist\n", encoding="utf-8")
             return b"", b""
@@ -170,10 +322,10 @@ def test_recursive_download_extracts_into_requested_directory(monkeypatch, tmp_p
     inner_cmd = shlex.split(remote_cmd)[2]
     assert 'cd "$d"' in inner_cmd
     assert 'tar czf - "$b"' in inner_cmd
-    assert commands[1][:4] == [runner._tar_cmd, "xzf", "-", "-C"]
-    extract_dir = Path(commands[1][4])
+    assert commands[1] == [runner._tar_cmd, "xzf", "-"]
+    extract_dir = Path(process_cwds[1])
     assert extract_dir.parent == tmp_path
-    assert extract_dir.name.startswith("..netlist.tmp-123.tmp-")
+    assert extract_dir.name.startswith(".vbtmp-")
     assert (local_path / "input.scs").read_text(encoding="utf-8") == "new netlist\n"
 
 
@@ -236,13 +388,14 @@ def test_recursive_download_restores_existing_target_when_install_rename_fails(
     class _FakeProcess:
         def __init__(self, cmd, **kwargs):
             self.cmd = cmd
+            self.cwd = kwargs.get("cwd")
             self.stdout = _Pipe()
             self.stderr = _Stderr()
             self.returncode = 0
 
         def communicate(self, timeout=None):
-            if self.cmd[0].endswith("tar"):
-                extracted = Path(self.cmd[4], "netlist")
+            if Path(self.cmd[0]).stem.lower() == "tar":
+                extracted = _tar_extract_root(self.cmd, self.cwd) / "netlist"
                 extracted.mkdir()
                 (extracted / "input.scs").write_text("new netlist\n", encoding="utf-8")
             return b"", b""
@@ -256,7 +409,7 @@ def test_recursive_download_restores_existing_target_when_install_rename_fails(
     original_rename = Path.rename
 
     def fail_temp_install(self: Path, target: Path):
-        if self.name == "netlist" and self.parent.name.startswith(".netlist.tmp-"):
+        if self.name == "netlist" and self.parent.name.startswith(".vbtmp-"):
             raise OSError("install failed")
         return original_rename(self, target)
 


### PR DESCRIPTION
Fixes #122.

## Summary

Make recursive directory downloads reliable on Windows when SSH cleanup is slow or the requested local path contains Unicode or a long basename.

## Root causes

- The tar stream used the caller's timeout, but SSH process exit was limited to a fixed five seconds. A completed transfer could therefore be reported as failed while the Windows OpenSSH wrapper was still exiting.
- The full local staging path was passed through tar's narrow `-C` argv. Characters outside the active Windows code page were replaced, so tar attempted to enter a different path.
- The staging name repeated the full target basename and added a UUID. A valid target near `MAX_PATH` could produce an overlong staging path.

## Fix

- Pass the caller-provided timeout to the SSH exit wait.
- Extract through a bounded ASCII sibling staging directory, `.vbtmp-<uuid>`.
- Start local tar with the staging directory as `cwd`, so no local path is passed through tar argv.
- Use a bounded `.vbbak-<uuid>` name while atomically replacing an existing target.

The staging directory remains beside the target, preserving same-volume atomic rename and the existing cleanup/restore behavior.

## Tests

Added scenario-level regressions that call `SSHRunner.download()` and verify downloaded content:

- SSH exits after six seconds while the caller allows 30 seconds.
- Both parent and target basename contain non-CP936 characters: `𠮷` and `😀`.
- A valid 250-character target would create a legacy staging path over 260 characters.

The exact tests fail against `b65b98f` and pass with this change.

Validation:

- `tests/test_ssh_control_master.py`: 10 passed.
- Related transfer, wrapper, and result-reader tests: 23 passed.
- Remaining suite passes after excluding six failures that reproduce unchanged on the base revision.
- Real jump-host SSH plus Windows `tar.exe` succeeds for common Chinese, non-code-page Unicode in both parent and basename, and a long target whose legacy staging path exceeds 260 characters.
- `git diff --check` passes.