### PR TITLE
Fix SymbolEditor checking for symbol cellviews

### DIFF
--- a/skills/virtuoso/references/symbol-python-api.md
+++ b/skills/virtuoso/references/symbol-python-api.md
@@ -60,5 +60,9 @@ separately for existing callers and manually authored symbols.
 ## Edit Symbol
 
 Use `client.symbol.edit()` as a context manager with the builders exported by
-`virtuoso_bridge.virtuoso.symbol.ops`. The editor runs `schCheck`, saves, and
-closes the symbol on context exit.
+`virtuoso_bridge.virtuoso.symbol.ops`. Before saving on context exit, the
+editor verifies that the open symbol can produce a pin list through Cadence's
+symbol-specific `schSymbolToPinList()` API. Cadence rejects non-symbol
+cellviews with `SCH-1004`, while unsuccessful pin-list generation also fails
+the edit. This validation does not run schematic connectivity, SRC, or VIC;
+`schCheck()` remains schematic-only.

--- a/src/virtuoso_bridge/virtuoso/symbol/ops.py
+++ b/src/virtuoso_bridge/virtuoso/symbol/ops.py
@@ -177,5 +177,14 @@ def symbol_set_term_order(term_names: Iterable[str], *, cv_expr: str = "cv") -> 
 
 
 def symbol_check(*, cv_expr: str = "cv") -> str:
-    """Build SKILL to run symbol/schematic checking."""
-    return f"schCheck({cv_expr})"
+    """Build SKILL to verify that a symbol can produce a pin list."""
+    # Cadence documents schSymbolToPinList as the symbol-specific converter:
+    # it returns the generated pin list on success and nil on failure.
+    return (
+        "let((rbCv rbPinList) "
+        f"rbCv = {cv_expr} "
+        'unless(rbCv error("symbol cellview not open")) '
+        "rbPinList = schSymbolToPinList(rbCv~>libName rbCv~>cellName rbCv~>viewName) "
+        'unless(rbPinList error("symbol pin-list generation failed")) '
+        "t)"
+    )

--- a/tests/test_symbol_ops.py
+++ b/tests/test_symbol_ops.py
@@ -115,10 +115,19 @@ def test_symbol_create_pin_escapes_repeated_pin_name_and_direction() -> None:
     assert '"A\\"\\\\B" "centerLeft"' in skill
 
 
-def test_symbol_set_term_order_and_check() -> None:
+def test_symbol_set_term_order() -> None:
     assert symbol_set_term_order(["A", "Y", "VDD", "VSS"]) == 'cv~>termOrder = list("A" "Y" "VDD" "VSS")'
     assert symbol_set_term_order(['A"\\B', "Y"]) == 'cv~>termOrder = list("A\\"\\\\B" "Y")'
-    assert symbol_check() == "schCheck(cv)"
+
+
+def test_symbol_check_uses_symbol_pin_list_api() -> None:
+    skill = symbol_check(cv_expr="myCv")
+
+    assert "rbCv = myCv" in skill
+    assert "schSymbolToPinList(rbCv~>libName rbCv~>cellName rbCv~>viewName)" in skill
+    assert 'unless(rbPinList error("symbol pin-list generation failed"))' in skill
+    assert "schCheck(" not in skill
+    assert skill.endswith("t)")
 
 
 def test_symbol_editor_opens_symbol_view_and_saves() -> None:
@@ -139,7 +148,7 @@ def test_symbol_editor_opens_symbol_view_and_saves() -> None:
     assert client.commands is not None
     assert client.commands[0] == 'cv = dbOpenCellViewByType("demoLib" "nand2" "symbol" "schematicSymbol" "w")'
     assert client.commands[1] == 'dbCreateRect(cv list("device" "drawing") list(list(-1 -1) list(1 1)))'
-    assert client.commands[2] == "schCheck(cv)"
+    assert client.commands[2] == symbol_check()
     assert "dbSave(rbCv)" in client.commands[3]
 
 


### PR DESCRIPTION
Fixes #124

## Summary

- replace the schematic-only `schCheck(cv)` call in `symbol_check()` with Cadence's symbol-specific `schSymbolToPinList(...)`
- fail when the symbol cellview is unavailable or pin-list generation returns `nil`
- return `t` on success so the existing `SymbolEditor` batch continues to `dbSave`
- update focused tests and Symbol Python API documentation without changing the public API

## Problem

`SymbolEditor` opens its target with cellview type `schematicSymbol`, but its exit path currently calls:

```skill
schCheck(cv)
```

Cadence restricts `schCheck` to schematic cellviews. On IC23.1, a normal `client.symbol.edit(...)` operation therefore fails with `SCH-1003` before reaching `dbSave`.

## Fix

`symbol_check()` now resolves the current cellview and calls:

```skill
schSymbolToPinList(
  rbCv~>libName
  rbCv~>cellName
  rbCv~>viewName
)
```

Cadence documents this API as the symbol-to-pin-list converter. It returns a pin list on success and `nil` when conversion is unsuccessful. IC23.1 also enforces the input type and raises `SCH-1004` for non-symbol cellviews.

The implementation preserves the existing Python signature and call site. No new public API or fallback behavior is introduced.

## Scope

Changed:

- `src/virtuoso_bridge/virtuoso/symbol/ops.py`
- `tests/test_symbol_ops.py`
- `skills/virtuoso/references/symbol-python-api.md`

Unchanged:

- `SymbolEditor` public behavior and signature
- symbol reader and generator
- schematic and layout editors
- cross-view checking

## Testing

Focused symbol tests on the branch rebased onto `upstream/main`:

```text
pytest tests/test_symbol_ops.py tests/test_symbol_reader.py tests/test_symbol_generator.py -q
70 passed
```

Live regression against Virtuoso IC23.1:

1. Created an isolated temporary symbol through `client.symbol.edit(...)` in a scratch test library.
2. Added a body, input/output pins, and `termOrder`.
3. Confirmed `schSymbolToPinList()` succeeds before the first `dbSave`.
4. Read back terminals `A` and `Y` and `termOrder = ("A" "Y")` after save.
5. Deleted the temporary test cell and confirmed it no longer exists.

The full Windows test run still has seven unrelated existing failures in documentation-search, runtime-path, and schematic-netlist tests. No symbol tests fail.

## Commits

```text
648f57b fix: use symbol-specific check API
7000ba8 docs: describe symbol-specific validation
```