### PR TITLE
Add robust XStream GDS export

### DIFF
--- a/examples/01_virtuoso/layout/15_export_gds.py
+++ b/examples/01_virtuoso/layout/15_export_gds.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Export a Virtuoso layout to GDS with XStream Out."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict
+from pathlib import Path
+
+from virtuoso_bridge import VirtuosoClient
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--library", required=True)
+    parser.add_argument("--cell", required=True)
+    parser.add_argument("--stream-map", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--view", default="layout")
+    parser.add_argument("--log", type=Path)
+    parser.add_argument("--timeout", type=float, default=300.0)
+    parser.add_argument("--poll-interval", type=float, default=0.5)
+    parser.add_argument("--skill-timeout", type=float, default=30.0)
+    parser.add_argument("--finalization-reserve", type=float, default=30.0)
+    parser.add_argument(
+        "--cleanup-policy",
+        choices=("success", "always", "never"),
+        default="success",
+    )
+    return parser
+
+
+def _print_json(payload: dict[str, object]) -> None:
+    print(json.dumps(payload, sort_keys=True))
+
+
+def main() -> int:
+    args = _parser().parse_args()
+
+    try:
+        client = VirtuosoClient.from_env()
+        probe = client.execute_skill(
+            "1+1",
+            timeout=min(10.0, args.skill_timeout),
+        )
+    except Exception as exc:
+        _print_json(
+            {
+                "status": "error",
+                "reason": "bridge_probe_failed",
+                "errors": [str(exc) or type(exc).__name__],
+            }
+        )
+        return 2
+
+    if not probe.ok:
+        _print_json(
+            {
+                "status": "error",
+                "reason": "bridge_probe_failed",
+                "errors": list(probe.errors)
+                or ["bridge probe returned a non-success status"],
+            }
+        )
+        return 2
+
+    try:
+        result = client.layout.export_gds(
+            args.library,
+            args.cell,
+            args.output,
+            stream_map=args.stream_map,
+            view=args.view,
+            log_path=args.log,
+            timeout=args.timeout,
+            poll_interval=args.poll_interval,
+            skill_timeout=args.skill_timeout,
+            finalization_reserve=args.finalization_reserve,
+            cleanup_policy=args.cleanup_policy,
+        )
+    except (ValueError, FileNotFoundError) as exc:
+        _print_json(
+            {
+                "status": "error",
+                "reason": "invalid_arguments",
+                "errors": [str(exc)],
+            }
+        )
+        return 2
+
+    log_result = result.log_result
+    _print_json(
+        {
+            "status": result.status.value,
+            "reason": result.reason.value,
+            "timed_out": result.timed_out,
+            "execution_time": result.execution_time,
+            "local_gds_path": (
+                str(result.local_gds_path)
+                if result.local_gds_path is not None
+                else None
+            ),
+            "local_log_path": (
+                str(result.local_log_path)
+                if result.local_log_path is not None
+                else None
+            ),
+            "error_count": (
+                log_result.error_count if log_result is not None else None
+            ),
+            "warning_count": (
+                log_result.warning_count if log_result is not None else None
+            ),
+            "warnings": list(result.warnings),
+            "errors": list(result.errors),
+            "translated_structures": (
+                [asdict(item) for item in log_result.translated_structures]
+                if log_result is not None
+                else []
+            ),
+            "local_run_dir": (
+                str(result.local_run_dir)
+                if result.local_run_dir is not None
+                else None
+            ),
+            "remote_run_dir": result.remote_run_dir,
+            "remote_files_retained": result.remote_files_retained,
+        }
+    )
+    return 0 if result.ok else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/virtuoso/references/layout-python-api.md
+++ b/skills/virtuoso/references/layout-python-api.md
@@ -10,6 +10,178 @@ client = VirtuosoClient.from_env()
 # LayoutOps is accessed via client.layout
 ```
 
+## Export GDS with XStream Out
+
+`client.layout.export_gds(...)` is the high-level XStream Out entry point. It
+stages each run separately, waits for the current run to finish, publishes a
+diagnostic log, and publishes the GDS only after the run is validated.
+
+```python
+from pathlib import Path
+
+from virtuoso_bridge import VirtuosoClient
+
+client = VirtuosoClient.from_env()
+result = client.layout.export_gds(
+    "worklib",
+    "top",
+    Path("artifacts/top.gds"),
+    stream_map=Path("pdk/stream.map"),
+    view="layout",
+    log_path=Path("artifacts/top.xstream.log"),
+    timeout=300.0,
+    poll_interval=0.5,
+    skill_timeout=30.0,
+    finalization_reserve=30.0,
+    cleanup_policy="success",
+)
+
+if result.ok:
+    print(f"GDS: {result.local_gds_path}")
+else:
+    print(f"{result.status.value}: {result.reason.value}")
+    for error in result.errors:
+        print(f"error: {error}")
+```
+
+The parameterized smoke example at
+`examples/01_virtuoso/layout/15_export_gds.py` exposes the same controls.
+
+### Paths, mode selection, and failures
+
+- `output_path`, `log_path`, and `stream_map` are **caller-host paths**. The
+  high-level API expands `~` and resolves them on the Python host. In remote
+  mode it uploads the stream map and downloads the validated artifacts; do not
+  pass compute-host-only paths for these arguments.
+- Mode selection is strict: only `client.ssh_runner is None` selects the local
+  path. Any non-`None` runner selects SSH mode. A missing or unreadable
+  `ssh_runner` does not silently fall back to local operation; it produces a
+  structured `TRANSPORT_ERROR` result.
+- Input preflight happens before operational result construction. Empty design
+  names, invalid timeout controls, aliased paths, an invalid cleanup policy, or
+  `finalization_reserve >= timeout` raise `ValueError`; a stream map that is not
+  an existing regular caller-host file raises `FileNotFoundError`.
+- Once preflight succeeds, launch, staging, transport, XStream, timeout, and
+  publication failures are returned as `GdsExportResult`. Inspect `result.ok`,
+  `result.reason`, `result.errors`, and `result.warnings` instead of expecting
+  those operational failures to raise.
+
+`result.ok` is true only for `ExecutionStatus.SUCCESS`. Success means the
+**current** XStream run has a parseable completion line with zero errors and a
+fresh, non-empty GDS from the same staged run has been validated and published.
+The parser ignores older concatenated runs by selecting the newest XStream
+product anchor when present, or otherwise the newest start anchor. A
+pre-existing destination GDS is never accepted as success evidence and is
+preserved when the new GDS cannot be validated.
+
+The log and GDS are each published through their own caller-host temporary file
+and replacement. They are not a cross-directory transaction: a diagnostic log
+may be available even when GDS publication fails, and the two destinations are
+not promised to change atomically together.
+
+### Result reason priority
+
+Operational errors are selected before the observation classifier. Within the
+classifier, the first matching row wins:
+
+| Priority | Reason | Meaning |
+|----------|--------|---------|
+| Operational | `STAGING_ERROR` | Local staging creation or local staged-artifact observation failed. |
+| Operational | `TRANSPORT_ERROR` | SSH command, upload/download, remote snapshot, digest, or remote integrity verification failed. |
+| Operational | `PUBLICATION_ERROR` | Caller-host destination preparation, validation, or replacement failed. |
+| 1 | `REQUEST_CLEANUP_ERROR` | The XStream request ran but restoring the prior XStream fields failed. |
+| 2 | `XSTREAM_FAILURE` | The current log contains a terminal failure marker. |
+| 3 | `MALFORMED_LOG` | A completion marker exists but its error/warning counts cannot be parsed. |
+| 4 | `XSTREAM_ERRORS` | Completion counts are valid and report one or more errors. |
+| 5 | `SKILL_ERROR` | The launch returned a definite, non-timeout SKILL/bridge error. |
+| 6 | `MISSING_GDS` | A valid zero-error completion exists but no staged GDS exists. |
+| 7 | `EMPTY_GDS` | A valid zero-error completion exists but the staged GDS is empty. |
+| 8 | `INCOMPLETE_LOG` | No valid current completion exists, and either launch was determinate or current-run evidence appeared. |
+| 9 | `LAUNCH_INDETERMINATE` | Launch timed out in an accepted indeterminate form and no run evidence appeared. |
+| 10 | `COMPLETED` | Valid zero-error completion plus a validated, published current-run GDS. |
+
+Explicit error lines remain available as diagnostics; completion counts and
+terminal failure markers determine the XStream reason priority.
+
+The three operational reasons identify the failed boundary: `STAGING_ERROR` is
+caller-host staging, `TRANSPORT_ERROR` is the remote/transfer integrity path,
+and `PUBLICATION_ERROR` is committing an artifact to its requested caller-host
+destination.
+
+### Cleanup and retention
+
+| `cleanup_policy` | Successful result | Non-success result |
+|------------------|-------------------|--------------------|
+| `"success"` | Remove the run directory after publication. | Retain it for diagnosis. |
+| `"always"` | Remove it when cleanup is safe. | Remove it only after a diagnostic log has been safely published locally (and, in SSH mode, downloaded from a stable remote snapshot). |
+| `"never"` | Retain the run directory. | Retain the run directory. |
+
+Cleanup is best effort and budgeted. A cleanup failure or exhausted cleanup
+budget adds a warning without replacing the export status/reason. `"never"`
+retains the run directory, but an unvalidated GDS inside it may still be removed
+so it cannot be mistaken for a publishable result.
+
+For SSH runs, `remote_files_retained` is deliberately three-state:
+
+| Value | Meaning |
+|-------|---------|
+| `False` | Remote run-directory removal was confirmed. |
+| `True` | The run directory is known to remain, including deliberate retention or a definitive cleanup failure. |
+| `None` | Retention could not be determined, such as an indeterminate SSH/staging/cleanup outcome. It is also not applicable to a local-only run. |
+
+An optional `recovery_hook` is considered only after an accepted indeterminate
+launch timeout produces current-run progress. It runs at most once. Hook
+exceptions become warnings and polling continues. The default is `None`, so the
+flow is headless and never performs implicit X11/dialog recovery; normal
+launches and timeouts with no artifact progress do not call the hook.
+
+### Remote integrity and private staging
+
+SSH mode creates and verifies an owner-only staging chain and run directory at
+mode `0700`, rejecting symlinks or unexpected ownership. During finalization it
+uses the first available remote SHA-256 command from `sha256sum`, `shasum`, or
+`openssl` to compare stable remote snapshots with downloaded bytes. These tools
+are runtime alternatives, not package installation dependencies. If none is
+available, the export returns a structured `TRANSPORT_ERROR`; the missing tool
+is not surfaced as a preflight exception.
+
+## Pure XStream helpers
+
+The request renderer and log parser are available without running a client:
+
+```python
+from virtuoso_bridge.virtuoso.layout import (
+    XStreamExportRequest,
+    parse_xstream_log,
+    xstream_export_gds_skill,
+)
+
+request = XStreamExportRequest(
+    library="worklib",
+    top_cell="top",
+    view="layout",
+    stream_file="/scratch/run/output.gds",
+    layer_map="/scratch/run/stream.map",
+    log_file="/scratch/run/xstream.log",
+    run_dir="/scratch/run",
+)
+skill_source = xstream_export_gds_skill(request)
+
+log_result = parse_xstream_log(
+    """Product : Virtuoso(R) XStream Out
+INFO: Translating cellview worklib/top/layout as STRUCTURE top.
+INFO (XSTRM-234): Translation completed. 0 error(s) and 0 warning(s) found.
+"""
+)
+print(log_result.completed, log_result.error_count)
+```
+
+Both helpers are deterministic and pure: they perform no filesystem, client,
+transport, clock, or sleep I/O. Request path strings are escaped into SKILL
+exactly as supplied; they are not expanded, resolved, normalized, or rewritten.
+`parse_xstream_log()` only inspects its text argument and scopes results to the
+latest run anchor.
+
 ## LayoutEditor (context manager)
 
 Collects SKILL commands, executes as a batch on `__exit__`, then saves automatically.

--- a/src/virtuoso_bridge/models.py
+++ b/src/virtuoso_bridge/models.py
@@ -88,7 +88,7 @@ class VirtuosoInterface(ABC):
         """Ensure bridge is ready (remote setup, tunnel, daemon reachable)."""
 
     @abstractmethod
-    def execute_skill(self, skill_code: str, timeout: int = 30) -> VirtuosoResult:
+    def execute_skill(self, skill_code: str, timeout: float = 30.0) -> VirtuosoResult:
         """Execute SKILL code in Virtuoso."""
 
     @abstractmethod

--- a/src/virtuoso_bridge/transport/ssh.py
+++ b/src/virtuoso_bridge/transport/ssh.py
@@ -18,8 +18,9 @@ import subprocess
 import threading
 import time
 import uuid
+from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
-from typing import Any, NamedTuple
+from typing import Any, Callable, NamedTuple
 
 from virtuoso_bridge.env import load_vb_env
 from virtuoso_bridge.profile import resolve_profile
@@ -117,6 +118,33 @@ class CommandResult(NamedTuple):
     returncode: int
     stdout: str
     stderr: str
+
+
+@dataclass(frozen=True)
+class _TimeoutBudget:
+    timeout: float
+    deadline: float
+
+    @classmethod
+    def start(
+        cls,
+        timeout: float | None,
+        default: float,
+    ) -> "_TimeoutBudget":
+        effective_timeout = float(default if timeout is None else timeout)
+        return cls(
+            timeout=effective_timeout,
+            deadline=time.monotonic() + effective_timeout,
+        )
+
+    def available(self) -> float:
+        return max(0.0, self.deadline - time.monotonic())
+
+    def remaining(self, command: object) -> float:
+        remaining = self.available()
+        if remaining <= 0.0:
+            raise subprocess.TimeoutExpired(command, self.timeout)
+        return remaining
 
 
 def _tool_override_from_env(var_name: str) -> str | None:
@@ -476,9 +504,9 @@ class SSHRunner:
 
     # -- connection test -------------------------------------------------------
 
-    def test_connection(self, timeout: int | None = None) -> bool:
+    def test_connection(self, timeout: float | None = None) -> bool:
         """Test SSH connectivity to the remote host."""
-        effective_timeout = timeout or self._connect_timeout
+        budget = _TimeoutBudget.start(timeout, self._connect_timeout)
         cmd = self._build_ssh_base() + ["-T", "exit", "0"]
         logger.debug("Testing SSH connection: %s", cmd)
         try:
@@ -486,7 +514,7 @@ class SSHRunner:
                 cmd,
                 capture_output=True,
                 text=True,
-                timeout=effective_timeout,
+                timeout=budget.remaining(cmd),
                 **_windows_no_window_kwargs(),
             )
             success = result.returncode == 0
@@ -502,7 +530,11 @@ class SSHRunner:
                 )
             return success
         except subprocess.TimeoutExpired:
-            logger.warning("SSH connection to %s timed out after %ds", self._host, effective_timeout)
+            logger.warning(
+                "SSH connection to %s timed out after %gs",
+                self._host,
+                budget.timeout,
+            )
             return False
         except FileNotFoundError:
             logger.error("SSH executable not found: %s", self._ssh_cmd)
@@ -511,17 +543,21 @@ class SSHRunner:
             logger.error("SSH connection error: %s", exc)
             return False
 
-    def run_command(self, command: str, timeout: int | None = None) -> CommandResult:
+    def run_command(self, command: str, timeout: float | None = None) -> CommandResult:
         """Execute a command on the remote host via SSH."""
+        budget = _TimeoutBudget.start(timeout, self._timeout)
         if self._persistent_shell_enabled:
             try:
-                return self._run_via_persistent_shell_with_retry(command, timeout=timeout)
+                return self._run_via_persistent_shell_with_retry(
+                    command,
+                    _budget=budget,
+                )
             except subprocess.TimeoutExpired:
                 raise
             except Exception as exc:  # noqa: BLE001
                 self._log_persistent_shell_fallback("Persistent SSH shell failed", exc)
 
-        return self._run_command_once(command, timeout=timeout)
+        return self._run_command_once(command, _budget=budget)
 
     def _print_cmd(self, cmd: list[str]) -> None:
         logger.info("[local] %s", " ".join(cmd))
@@ -591,8 +627,10 @@ class SSHRunner:
 
     def _attempt_with_cm_fallback(
         self,
-        run_one: "Callable[[], tuple[int, bytes, bytes]]",
+        run_one: Callable[[], tuple[int, bytes, bytes]],
         *,
+        budget: _TimeoutBudget,
+        command: object,
         max_attempts: int = 3,
     ) -> tuple[int, bytes, bytes]:
         """Repeatedly call ``run_one`` (which builds + runs one ssh/scp/tar
@@ -616,6 +654,7 @@ class SSHRunner:
         out: bytes = b""
         err: bytes = b""
         for attempt in range(max_attempts):
+            budget.remaining(command)
             rc, out, err = run_one()
             if rc == 0:
                 return rc, out, err
@@ -634,8 +673,14 @@ class SSHRunner:
             break
         return rc, out, err
 
-    def _run_command_once(self, command: str, timeout: int | None = None) -> CommandResult:
-        effective_timeout = timeout or self._timeout
+    def _run_command_once(
+        self,
+        command: str,
+        timeout: float | None = None,
+        *,
+        _budget: _TimeoutBudget | None = None,
+    ) -> CommandResult:
+        budget = _budget or _TimeoutBudget.start(timeout, self._timeout)
         # Pipe the command to `ssh host sh -l` via stdin so it always runs in
         # a POSIX login shell regardless of the remote user's login shell
         # (which may be csh).  Using -l (login) sources /etc/profile and
@@ -671,7 +716,7 @@ class SSHRunner:
                 input=command.encode("utf-8"),
                 capture_output=True,
                 text=False,
-                timeout=effective_timeout,
+                timeout=budget.remaining(cmd),
                 **_windows_no_window_kwargs(),
             )
             stderr_text = last.stderr.decode("utf-8", errors="replace")
@@ -707,14 +752,18 @@ class SSHRunner:
         local_path: Path,
         remote_path: str,
         recursive: bool = False,
-        timeout: int | None = None,
+        timeout: float | None = None,
     ) -> CommandResult:
         """Upload a file or directory to the remote host via tar pipe."""
+        budget = _TimeoutBudget.start(timeout, self._timeout)
         if not local_path.exists():
             raise FileNotFoundError(f"Local path not found: {local_path}")
 
-        effective_timeout = timeout or self._timeout
-        result = self._upload_via_tar(local_path, remote_path, timeout=effective_timeout)
+        result = self._upload_via_tar(
+            local_path,
+            remote_path,
+            _budget=budget,
+        )
         if result.returncode != 0:
             logger.warning("tar upload failed (rc=%d): %s", result.returncode, result.stderr.strip())
         else:
@@ -724,13 +773,13 @@ class SSHRunner:
     def upload_batch(
         self,
         files: list[tuple[Path, str]],
-        timeout: int | None = None,
+        timeout: float | None = None,
     ) -> CommandResult:
         """Upload multiple files in a single tar pipe (all to the same remote dir)."""
         if not files:
             return CommandResult(returncode=0, stdout="", stderr="")
 
-        effective_timeout = timeout or self._timeout
+        budget = _TimeoutBudget.start(timeout, self._timeout)
 
         # Group by remote directory (usually all the same)
         by_remote_dir: dict[str, list[tuple[Path, str]]] = {}
@@ -782,28 +831,36 @@ class SSHRunner:
                 tar_cmd += ["-C", str(local_path.resolve().parent).replace("\\", "/"), local_path.name]
 
             logger.debug("Batch tar upload: %d file(s) -> %s:%s", len(entries), self._host, remote_dir)
+            budget.remaining(tar_cmd)
             tar_proc = subprocess.Popen(
                 tar_cmd,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 **_windows_no_window_kwargs(),
             )
-            ssh_proc = subprocess.Popen(
-                ssh_cmd,
-                stdin=tar_proc.stdout,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                **_windows_no_window_kwargs(),
-            )
+            try:
+                budget.remaining(ssh_cmd)
+                ssh_proc = subprocess.Popen(
+                    ssh_cmd,
+                    stdin=tar_proc.stdout,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    **_windows_no_window_kwargs(),
+                )
+            except Exception:
+                tar_proc.kill()
+                raise
             if tar_proc.stdout:
                 tar_proc.stdout.close()
             try:
-                ssh_out, ssh_err = ssh_proc.communicate(timeout=effective_timeout)
+                ssh_out, ssh_err = ssh_proc.communicate(
+                    timeout=budget.remaining(ssh_cmd)
+                )
+                tar_proc.wait(timeout=budget.remaining(tar_cmd))
             except subprocess.TimeoutExpired:
                 ssh_proc.kill()
                 tar_proc.kill()
                 raise
-            tar_proc.wait()
 
             if ssh_proc.returncode != 0:
                 stderr_text = _as_text(ssh_err)
@@ -816,8 +873,9 @@ class SSHRunner:
 
         return CommandResult(returncode=0, stdout="", stderr="")
 
-    def upload_text(self, text: str, remote_path: str, timeout: int | None = None) -> CommandResult:
+    def upload_text(self, text: str, remote_path: str, timeout: float | None = None) -> CommandResult:
         """Upload a UTF-8 text string as a file to the remote host via SSH."""
+        budget = _TimeoutBudget.start(timeout, self._timeout)
         if self._persistent_shell_enabled:
             if not text.endswith("\n"):
                 text = text + "\n"
@@ -832,13 +890,15 @@ class SSHRunner:
                 f"{payload_token}\n"
             )
             try:
-                return self._run_via_persistent_shell_with_retry(command, timeout=timeout)
+                return self._run_via_persistent_shell_with_retry(
+                    command,
+                    _budget=budget,
+                )
             except subprocess.TimeoutExpired:
                 raise
             except Exception as exc:  # noqa: BLE001
                 self._log_persistent_shell_fallback("Persistent SSH text upload failed", exc)
 
-        effective_timeout = timeout or self._timeout
         remote_dir = str(Path(remote_path).parent).replace("\\", "/")
         quoted_dir = shlex.quote(remote_dir)
         quoted_path = shlex.quote(remote_path.replace("\\", "/"))
@@ -862,12 +922,16 @@ class SSHRunner:
                 input=text_bytes,
                 capture_output=True,
                 text=False,
-                timeout=effective_timeout,
+                timeout=budget.remaining(cmd),
                 **_windows_no_window_kwargs(),
             )
             return r.returncode, r.stdout or b"", r.stderr or b""
 
-        rc, out, err = self._attempt_with_cm_fallback(_attempt)
+        rc, out, err = self._attempt_with_cm_fallback(
+            _attempt,
+            budget=budget,
+            command=remote_cmd,
+        )
         if rc != 0:
             err_text = _as_text(err).strip()
             logger.warning("SSH text upload failed (rc=%d): %s", rc, err_text)
@@ -880,13 +944,17 @@ class SSHRunner:
         remote_path: str,
         local_path: Path,
         recursive: bool = False,
-        timeout: int | None = None,
+        timeout: float | None = None,
     ) -> CommandResult:
         """Download a file or directory from the remote host via tar pipe or scp."""
-        effective_timeout = timeout or self._timeout
+        budget = _TimeoutBudget.start(timeout, self._timeout)
 
         if recursive:
-            return self._download_via_tar(remote_path, local_path, timeout=effective_timeout)
+            return self._download_via_tar(
+                remote_path,
+                local_path,
+                _budget=budget,
+            )
 
         local_path.parent.mkdir(parents=True, exist_ok=True)
         logger.debug("Downloading via scp %s:%s -> %s", self._host, remote_path, local_path)
@@ -901,12 +969,16 @@ class SSHRunner:
                 cmd,
                 capture_output=True,
                 text=False,         # bytes for the helper
-                timeout=effective_timeout,
+                timeout=budget.remaining(cmd),
                 **_windows_no_window_kwargs(),
             )
             return r.returncode, r.stdout or b"", r.stderr or b""
 
-        rc, out, err = self._attempt_with_cm_fallback(_attempt)
+        rc, out, err = self._attempt_with_cm_fallback(
+            _attempt,
+            budget=budget,
+            command=remote_path,
+        )
         if rc != 0:
             err_text = _as_text(err).strip()
             logger.warning("download (scp) failed (rc=%d): %s", rc, err_text)
@@ -919,9 +991,11 @@ class SSHRunner:
         remote_path: str,
         local_path: Path,
         *,
-        timeout: int,
+        timeout: float | None = None,
+        _budget: _TimeoutBudget | None = None,
     ) -> CommandResult:
         """Download a directory recursively using tar czf piped over SSH."""
+        budget = _budget or _TimeoutBudget.start(timeout, self._timeout)
         # Extract into a sibling staging directory first; replace the requested
         # target only after both SSH and local tar have succeeded.  The archive
         # contains the remote directory itself rather than "." so BSD tar does
@@ -951,26 +1025,35 @@ class SSHRunner:
             print(f"[cmd] {' '.join(ssh_cmd)} | {' '.join(tar_cmd)}  # download {remote_path} -> {local_path}", flush=True)
         logger.debug("Downloading via tar pipe %s:%s -> %s", self._host, remote_path, local_path)
 
+        budget.remaining(ssh_cmd)
         ssh_proc = subprocess.Popen(
             ssh_cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             **_windows_no_window_kwargs(),
         )
-        tar_proc = subprocess.Popen(
-            tar_cmd,
-            stdin=ssh_proc.stdout,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            cwd=stage_path,
-            **_windows_no_window_kwargs(),
-        )
+        try:
+            budget.remaining(tar_cmd)
+            tar_proc = subprocess.Popen(
+                tar_cmd,
+                stdin=ssh_proc.stdout,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                cwd=stage_path,
+                **_windows_no_window_kwargs(),
+            )
+        except Exception:
+            ssh_proc.kill()
+            shutil.rmtree(stage_path, ignore_errors=True)
+            raise
         if ssh_proc.stdout:
             ssh_proc.stdout.close()
 
         try:
-            tar_out, tar_err = tar_proc.communicate(timeout=timeout)
-            ssh_proc.wait(timeout=timeout)
+            tar_out, tar_err = tar_proc.communicate(
+                timeout=budget.remaining(tar_cmd)
+            )
+            ssh_proc.wait(timeout=budget.remaining(ssh_cmd))
         except subprocess.TimeoutExpired:
             ssh_proc.kill()
             tar_proc.kill()
@@ -1023,8 +1106,10 @@ class SSHRunner:
         local_path: Path,
         remote_path: str,
         *,
-        timeout: int,
+        timeout: float | None = None,
+        _budget: _TimeoutBudget | None = None,
     ) -> CommandResult:
+        budget = _budget or _TimeoutBudget.start(timeout, self._timeout)
         remote_dir = str(Path(remote_path).parent).replace("\\", "/")
         remote_dir_q = shlex.quote(remote_dir)
         local_basename = local_path.name
@@ -1055,50 +1140,69 @@ class SSHRunner:
                     f"  # upload {local_path} -> {remote_path}",
                     flush=True,
                 )
+            budget.remaining(tar_cmd)
             tar_proc = subprocess.Popen(
                 tar_cmd,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 **_windows_no_window_kwargs(),
             )
-            ssh_proc = subprocess.Popen(
-                ssh_cmd,
-                stdin=tar_proc.stdout,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                **_windows_no_window_kwargs(),
-            )
+            try:
+                budget.remaining(ssh_cmd)
+                ssh_proc = subprocess.Popen(
+                    ssh_cmd,
+                    stdin=tar_proc.stdout,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    **_windows_no_window_kwargs(),
+                )
+            except Exception:
+                tar_proc.kill()
+                raise
             if tar_proc.stdout:
                 tar_proc.stdout.close()
             try:
-                ssh_out, ssh_err = ssh_proc.communicate(timeout=timeout)
+                ssh_out, ssh_err = ssh_proc.communicate(
+                    timeout=budget.remaining(ssh_cmd)
+                )
+                tar_proc.wait(timeout=budget.remaining(tar_cmd))
             except subprocess.TimeoutExpired:
                 ssh_proc.kill()
                 tar_proc.kill()
                 raise
-            tar_proc.wait()
             return ssh_proc.returncode, ssh_out or b"", ssh_err or b""
 
-        rc, out, err = self._attempt_with_cm_fallback(_attempt)
+        rc, out, err = self._attempt_with_cm_fallback(
+            _attempt,
+            budget=budget,
+            command=remote_path,
+        )
         return CommandResult(
             returncode=rc,
             stdout=_as_text(out),
             stderr=_as_text(err),
         )
 
-    def ensure_persistent_shell(self, timeout: int | None = None) -> None:
+    def ensure_persistent_shell(
+        self,
+        timeout: float | None = None,
+        *,
+        _budget: _TimeoutBudget | None = None,
+    ) -> None:
         """Start the reusable SSH shell on first use."""
         if not self._persistent_shell_enabled:
             return
 
+        budget = _budget or _TimeoutBudget.start(timeout, self._connect_timeout)
         with self._shell_lock:
             if self._shell_proc is not None and self._shell_proc.poll() is None:
                 return
 
-            self._close_persistent_shell_locked()
+            self._close_persistent_shell_locked(_budget=budget)
             cmd = self._build_ssh_base() + ["sh", "-l", "-s"]
             logger.info("Starting persistent SSH shell: %s", " ".join(cmd))
             self._print_cmd(cmd)
+            budget.remaining(cmd)
             proc = subprocess.Popen(
                 cmd,
                 stdin=subprocess.PIPE,
@@ -1122,15 +1226,17 @@ class SSHRunner:
             )
             self._shell_reader.start()
 
-            probe_timeout = timeout or self._connect_timeout
             try:
-                probe = self._run_command_via_persistent_shell_locked(":", probe_timeout)
+                probe = self._run_command_via_persistent_shell_locked(
+                    ":",
+                    _budget=budget,
+                )
             except Exception:
-                self._close_persistent_shell_locked()
+                self._close_persistent_shell_locked(_budget=budget)
                 raise
 
             if probe.returncode != 0:
-                self._close_persistent_shell_locked()
+                self._close_persistent_shell_locked(_budget=budget)
                 details = self._summarize_ssh_transport_error(probe.stderr.strip() or probe.stdout.strip())
                 raise RuntimeError(
                     f"Persistent SSH shell probe failed: {details}"
@@ -1215,20 +1321,27 @@ class SSHRunner:
     def _run_via_persistent_shell_with_retry(
         self,
         command: str,
-        timeout: int | None = None,
+        timeout: float | None = None,
+        *,
+        _budget: _TimeoutBudget | None = None,
     ) -> CommandResult:
+        budget = _budget or _TimeoutBudget.start(timeout, self._timeout)
         last_exc: Exception | None = None
         for attempt in range(2):
+            budget.remaining(command)
             try:
                 with self._shell_lock:
-                    self.ensure_persistent_shell(timeout=timeout)
-                    return self._run_command_via_persistent_shell_locked(command, timeout=timeout)
+                    self.ensure_persistent_shell(_budget=budget)
+                    return self._run_command_via_persistent_shell_locked(
+                        command,
+                        _budget=budget,
+                    )
             except subprocess.TimeoutExpired:
                 raise
             except Exception as exc:  # noqa: BLE001
                 last_exc = exc
                 with self._shell_lock:
-                    self._close_persistent_shell_locked()
+                    self._close_persistent_shell_locked(_budget=budget)
                 if attempt == 0 and self._is_retryable_persistent_shell_error(exc):
                     logger.info(
                         "Retrying persistent SSH shell for %s after recoverable protocol error: %s",
@@ -1251,8 +1364,13 @@ class SSHRunner:
             out_queue.put(None)
 
     def _run_command_via_persistent_shell_locked(
-        self, command: str, timeout: int | None = None
+        self,
+        command: str,
+        timeout: float | None = None,
+        *,
+        _budget: _TimeoutBudget | None = None,
     ) -> CommandResult:
+        budget = _budget or _TimeoutBudget.start(timeout, self._timeout)
         proc = self._shell_proc
         out_queue = self._shell_queue
         if proc is None or proc.stdin is None or proc.poll() is not None or out_queue is None:
@@ -1292,14 +1410,13 @@ class SSHRunner:
             "rm -f \"$__vb_stdout\" \"$__vb_stderr\"\n"
         )
 
+        budget.remaining(command)
         try:
             proc.stdin.write(script.encode("utf-8"))
             proc.stdin.flush()
         except OSError as exc:
             raise RuntimeError(f"Failed to write to persistent SSH shell: {exc}") from exc
 
-        effective_timeout = timeout or self._timeout
-        deadline = time.monotonic() + effective_timeout
         stdout_b64 = None
         stderr_b64 = None
         rc = None
@@ -1307,18 +1424,18 @@ class SSHRunner:
         preamble: list[str] = []
 
         while True:
-            remaining = deadline - time.monotonic()
+            remaining = budget.available()
             if remaining <= 0:
-                self._close_persistent_shell_locked()
-                raise subprocess.TimeoutExpired(cmd=command, timeout=effective_timeout)
+                self._close_persistent_shell_locked(_budget=budget)
+                raise subprocess.TimeoutExpired(cmd=command, timeout=budget.timeout)
             try:
                 line = out_queue.get(timeout=remaining)
             except queue.Empty as exc:
-                self._close_persistent_shell_locked()
-                raise subprocess.TimeoutExpired(cmd=command, timeout=effective_timeout) from exc
+                self._close_persistent_shell_locked(_budget=budget)
+                raise subprocess.TimeoutExpired(cmd=command, timeout=budget.timeout) from exc
 
             if line is None:
-                self._close_persistent_shell_locked()
+                self._close_persistent_shell_locked(_budget=budget)
                 raise RuntimeError("Persistent SSH shell exited unexpectedly.")
 
             stripped = line.rstrip("\r\n")
@@ -1369,7 +1486,11 @@ class SSHRunner:
         except (binascii.Error, ValueError) as exc:
             raise RuntimeError(f"Persistent SSH shell returned invalid base64 payload: {exc}") from exc
 
-    def _close_persistent_shell_locked(self) -> None:
+    def _close_persistent_shell_locked(
+        self,
+        *,
+        _budget: _TimeoutBudget | None = None,
+    ) -> None:
         proc = self._shell_proc
         reader = self._shell_reader
         if proc is not None and proc.poll() is None:
@@ -1380,9 +1501,13 @@ class SSHRunner:
             except OSError:
                 pass
             proc.terminate()
-            try:
-                proc.wait(timeout=5)
-            except subprocess.TimeoutExpired:
+            wait_timeout = 5.0 if _budget is None else min(5.0, _budget.available())
+            if wait_timeout > 0.0:
+                try:
+                    proc.wait(timeout=wait_timeout)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+            else:
                 proc.kill()
         if proc is not None and proc.stdout is not None:
             try:
@@ -1390,7 +1515,9 @@ class SSHRunner:
             except OSError:
                 pass
         if reader is not None and reader.is_alive():
-            reader.join(timeout=1)
+            join_timeout = 1.0 if _budget is None else min(1.0, _budget.available())
+            if join_timeout > 0.0:
+                reader.join(timeout=join_timeout)
         self._shell_proc = None
         self._shell_queue = None
         self._shell_reader = None
@@ -1443,9 +1570,20 @@ class SSHRunner:
         return cmd
 
     def _remote_scp_target(self, remote_path: str) -> str:
+        if any(
+            ord(character) < 32 or ord(character) == 127
+            for character in remote_path
+        ):
+            raise ValueError("remote SCP path contains unsupported control characters")
+        quoted_path = "".join(
+            character
+            if character.isalnum() or character in "/._-~"
+            else f"\\{character}"
+            for character in remote_path
+        )
         if self._user:
-            return f"{self._user}@{self._host}:{remote_path}"
-        return f"{self._host}:{remote_path}"
+            return f"{self._user}@{self._host}:{quoted_path}"
+        return f"{self._host}:{quoted_path}"
 
 class RemoteTaskResult(NamedTuple):
     """Result of a generic remote task (upload + run + optional cleanup)."""

--- a/src/virtuoso_bridge/virtuoso/basic/bridge.py
+++ b/src/virtuoso_bridge/virtuoso/basic/bridge.py
@@ -302,42 +302,62 @@ class VirtuosoClient(VirtuosoInterface):
 
     # -- SKILL execution ----------------------------------------------------
 
-    def execute_skill(self, skill_code: str, timeout: int | None = None) -> VirtuosoResult:
+    def execute_skill(
+        self,
+        skill_code: str,
+        timeout: float | None = None,
+    ) -> VirtuosoResult:
         """Execute SKILL code in Virtuoso via the RAMIC Bridge daemon."""
         effective_timeout = timeout if timeout is not None else self._timeout
 
         start_time = time.monotonic()
+        deadline = start_time + effective_timeout
         connect_deadline = start_time
         if self._has_jump_host:
-            connect_deadline = start_time + _TUNNEL_CONNECT_GRACE_SECONDS
+            connect_deadline = min(
+                deadline,
+                start_time + _TUNNEL_CONNECT_GRACE_SECONDS,
+            )
 
-        logger.debug("execute_skill %s:%d timeout=%d skill=%s",
+        logger.debug("execute_skill %s:%d timeout=%g skill=%s",
                       self._host, self._port, effective_timeout, skill_code[:120])
 
         try:
             while True:
+                if time.monotonic() >= deadline:
+                    raise socket.timeout
                 try:
-                    raw_response = self._execute_skill_once(skill_code, effective_timeout)
+                    raw_response = self._execute_skill_once(
+                        skill_code,
+                        effective_timeout,
+                        deadline,
+                    )
                     elapsed = time.monotonic() - start_time
                     result = self._parse_response(raw_response, elapsed)
                     logger.debug("execute_skill OK (%.3fs)", elapsed)
                     return result
                 except ConnectionRefusedError:
-                    if time.monotonic() >= connect_deadline:
+                    now = time.monotonic()
+                    if now >= deadline:
+                        raise socket.timeout
+                    if now >= connect_deadline:
                         raise
                     logger.debug("Connection refused, retrying (deadline in %.1fs)",
-                                 connect_deadline - time.monotonic())
-                    time.sleep(_TUNNEL_CONNECT_RETRY_DELAY)
+                                 connect_deadline - now)
+                    time.sleep(min(_TUNNEL_CONNECT_RETRY_DELAY, connect_deadline - now))
                 except OSError as exc:
-                    if not self._should_retry_tunnel_connect(exc, time.monotonic(), connect_deadline):
+                    now = time.monotonic()
+                    if now >= deadline:
+                        raise socket.timeout from exc
+                    if not self._should_retry_tunnel_connect(exc, now, connect_deadline):
                         raise
                     logger.debug("OSError %s, retrying (deadline in %.1fs)",
-                                 exc, connect_deadline - time.monotonic())
-                    time.sleep(_TUNNEL_CONNECT_RETRY_DELAY)
+                                 exc, connect_deadline - now)
+                    time.sleep(min(_TUNNEL_CONNECT_RETRY_DELAY, connect_deadline - now))
 
         except socket.timeout:
             elapsed = time.monotonic() - start_time
-            logger.warning("Socket timeout connecting to %s:%d after %ds",
+            logger.warning("Socket timeout connecting to %s:%d after %gs",
                            self._host, self._port, effective_timeout)
             return VirtuosoResult(
                 status=ExecutionStatus.ERROR,
@@ -1392,17 +1412,25 @@ let((result winName ciwNum)
             return remote_posix, True
         return _path_to_posix(p), False
 
-    def _execute_skill_once(self, skill_code: str, timeout: int) -> str:
+    def _execute_skill_once(
+        self,
+        skill_code: str,
+        timeout: float,
+        deadline: float,
+    ) -> str:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.settimeout(timeout)
+            s.settimeout(self._remaining_timeout(deadline))
             logger.debug("TCP connect %s:%d", self._host, self._port)
             s.connect((self._host, self._port))
             logger.debug("TCP connected, sending %d-byte payload", len(skill_code))
-            payload = json.dumps({"skill": skill_code, "timeout": timeout}).encode("utf-8")
+            request_timeout = min(timeout, self._remaining_timeout(deadline))
+            payload = json.dumps({"skill": skill_code, "timeout": request_timeout}).encode("utf-8")
+            s.settimeout(self._remaining_timeout(deadline))
             s.sendall(payload)
             s.shutdown(socket.SHUT_WR)
             chunks: list[bytes] = []
             while True:
+                s.settimeout(self._remaining_timeout(deadline))
                 chunk = s.recv(_RECV_BUF_SIZE)
                 if not chunk:
                     break
@@ -1410,6 +1438,13 @@ let((result winName ciwNum)
             raw = b"".join(chunks).decode("utf-8", errors="ignore")
             logger.debug("TCP received %d bytes", len(raw))
             return raw
+
+    @staticmethod
+    def _remaining_timeout(deadline: float) -> float:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0.0:
+            raise socket.timeout
+        return remaining
 
     @staticmethod
     def _should_retry_tunnel_connect(exc: OSError, now: float, connect_deadline: float) -> bool:

--- a/src/virtuoso_bridge/virtuoso/layout/__init__.py
+++ b/src/virtuoso_bridge/virtuoso/layout/__init__.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, TYPE_CHECKING
+from pathlib import Path
+from typing import Any, Callable, Literal, TYPE_CHECKING
 
 from virtuoso_bridge.virtuoso.layout.editor import LayoutEditor
 from virtuoso_bridge.virtuoso.layout.reader import parse_layout_geometry_output
@@ -35,6 +36,18 @@ from virtuoso_bridge.virtuoso.layout.ops import (
     layout_create_via,
     layout_via_def_expr_from_name,
 )
+from virtuoso_bridge.virtuoso.layout.streamout import (
+    GdsExportReason,
+    GdsExportResult,
+    export_gds,
+)
+from virtuoso_bridge.virtuoso.layout.xstream import (
+    XStreamExportRequest,
+    XStreamLogResult,
+    XStreamTranslatedStructure,
+    parse_xstream_log,
+    xstream_export_gds_skill,
+)
 
 if TYPE_CHECKING:
     from virtuoso_bridge import VirtuosoClient
@@ -51,10 +64,51 @@ class LayoutOps:
         """Return a LayoutEditor context manager."""
         return LayoutEditor(self._owner, lib, cell, view=view, mode=mode, timeout=timeout)
 
+    def export_gds(
+        self,
+        library: str,
+        cell: str,
+        output_path: str | Path,
+        *,
+        stream_map: str | Path,
+        view: str = "layout",
+        log_path: str | Path | None = None,
+        timeout: float = 300.0,
+        poll_interval: float = 0.5,
+        skill_timeout: float = 30.0,
+        finalization_reserve: float = 30.0,
+        cleanup_policy: Literal["success", "always", "never"] = "success",
+        recovery_hook: Callable[[], object] | None = None,
+    ) -> GdsExportResult:
+        """Export one layout to GDS using XStream Out."""
+        return export_gds(
+            self._owner,
+            library,
+            cell,
+            output_path,
+            stream_map=stream_map,
+            view=view,
+            log_path=log_path,
+            timeout=timeout,
+            poll_interval=poll_interval,
+            skill_timeout=skill_timeout,
+            finalization_reserve=finalization_reserve,
+            cleanup_policy=cleanup_policy,
+            recovery_hook=recovery_hook,
+        )
+
 
 __all__ = [
     "LayoutOps",
     "LayoutEditor",
+    "XStreamExportRequest",
+    "XStreamTranslatedStructure",
+    "XStreamLogResult",
+    "GdsExportReason",
+    "GdsExportResult",
+    "xstream_export_gds_skill",
+    "parse_xstream_log",
+    "export_gds",
     "parse_layout_geometry_output",
     "layout_bind_current_or_open_cell_view",
     "close_current_cellview",

--- a/src/virtuoso_bridge/virtuoso/layout/streamout.py
+++ b/src/virtuoso_bridge/virtuoso/layout/streamout.py
@@ -195,8 +195,8 @@ def _remote_security_prelude() -> str:
     return r"""umask 077
 vb_uid=$(id -u) || exit $?
 vb_read_meta() {
-    vb_meta=$(stat -c '%u %a' -- "$1" 2>/dev/null) ||
-        vb_meta=$(stat -f '%u %Lp' -- "$1" 2>/dev/null) || return 74
+    vb_meta=$(stat -c '%u %a' "$1" 2>/dev/null) ||
+        vb_meta=$(stat -f '%u %Lp' "$1" 2>/dev/null) || return 74
     set -- $vb_meta
     vb_owner=$1
     vb_mode=$2
@@ -213,7 +213,7 @@ vb_verify_dir() {
         return 75
     fi
     if [ "$vb_mode" != 700 ]; then
-        chmod 700 -- "$vb_path" || return $?
+        chmod 700 "$vb_path" || return $?
         if [ -L "$vb_path" ] || [ ! -d "$vb_path" ]; then
             printf 'unsafe remote XStream directory after chmod: %s\n' "$vb_path" >&2
             return 73
@@ -232,7 +232,7 @@ vb_ensure_dir() {
         return 73
     fi
     if [ ! -e "$vb_path" ]; then
-        mkdir -m 700 -- "$vb_path" || return $?
+        mkdir -m 700 "$vb_path" || return $?
     fi
     vb_verify_dir "$vb_path"
 }
@@ -258,7 +258,7 @@ def _remote_stage_command(paths: _RemoteExportPaths) -> str:
             f"    printf 'remote XStream run already exists: %s\\n' {quoted_run} >&2\n",
             "    exit 77\n",
             "fi\n",
-            f"mkdir -m 700 -- {quoted_run} || exit $?\n",
+            f"mkdir -m 700 {quoted_run} || exit $?\n",
             f"printf '%s\\n' {_REMOTE_STAGE_CREATED}\n",
             f"vb_verify_dir {quoted_run} || exit $?\n",
             f"printf '%s\\n' {_REMOTE_STAGE_READY}\n",
@@ -288,7 +288,7 @@ def _remote_delete_command(
         )
     target = paths.run_dir if remove_run else paths.gds
     flags = "-rf" if remove_run else "-f"
-    commands.append(f"rm {flags} -- {shlex.quote(target.as_posix())}\n")
+    commands.append(f"rm {flags} {shlex.quote(target.as_posix())}\n")
     return "".join(commands)
 
 
@@ -316,10 +316,10 @@ def _remote_poll_command(
     if include_digests:
         digest_function = r"""vb_sha256() {
     if command -v sha256sum >/dev/null 2>&1; then
-        vb_digest_line=$(sha256sum -- "$1") || return $?
+        vb_digest_line=$(sha256sum "$1") || return $?
         vb_digest=${vb_digest_line%% *}
     elif command -v shasum >/dev/null 2>&1; then
-        vb_digest_line=$(shasum -a 256 -- "$1") || return $?
+        vb_digest_line=$(shasum -a 256 "$1") || return $?
         vb_digest=${vb_digest_line%% *}
     elif command -v openssl >/dev/null 2>&1; then
         vb_digest_line=$(openssl dgst -sha256 "$1") || return $?
@@ -348,12 +348,12 @@ def _remote_poll_command(
         "umask 077; "
         f"vb_tail_probe={quoted_tail_probe}; "
         f"vb_tail_lines={quoted_tail_lines}; "
-        'rm -f -- "$vb_tail_probe" "$vb_tail_lines" || exit $?; '
-        "trap 'rm -f -- \"$vb_tail_probe\" \"$vb_tail_lines\"' 0; "
-        f"tail -c {tail_probe_bytes} -- {quoted_log} "
+        'rm -f "$vb_tail_probe" "$vb_tail_lines" || exit $?; '
+        "trap 'rm -f \"$vb_tail_probe\" \"$vb_tail_lines\"' 0; "
+        f"tail -c {tail_probe_bytes} {quoted_log} "
         '> "$vb_tail_probe"; vb_tail_rc=$?; '
         '[ "$vb_tail_rc" -eq 0 ] || exit "$vb_tail_rc"; '
-        'tail -n 200 -- "$vb_tail_probe" > "$vb_tail_lines"; '
+        'tail -n 200 "$vb_tail_probe" > "$vb_tail_lines"; '
         "vb_tail_rc=$?; "
         '[ "$vb_tail_rc" -eq 0 ] || exit "$vb_tail_rc"; '
         'vb_tail_size=$(wc -c < "$vb_tail_lines"); vb_tail_rc=$?; '
@@ -363,10 +363,10 @@ def _remote_poll_command(
         f"printf '%s LOG_TRUNCATED %s\\n' {token} "
         '"$vb_tail_truncated"; '
         f"printf '%s LOG_BEGIN\\n' {token}; "
-        f'tail -c {_REMOTE_LOG_TAIL_BYTES} -- "$vb_tail_lines"; '
+        f'tail -c {_REMOTE_LOG_TAIL_BYTES} "$vb_tail_lines"; '
         "vb_tail_rc=$?; printf '\\n'; "
         f"[ \"$vb_tail_rc\" -eq 0 ] || exit \"$vb_tail_rc\"; "
-        'rm -f -- "$vb_tail_probe" "$vb_tail_lines"; '
+        'rm -f "$vb_tail_probe" "$vb_tail_lines"; '
         "vb_tail_rc=$?; trap - 0; "
         '[ "$vb_tail_rc" -eq 0 ] || exit "$vb_tail_rc"; '
         f"printf '%s LOG_END\\n' {token}; "

--- a/src/virtuoso_bridge/virtuoso/layout/streamout.py
+++ b/src/virtuoso_bridge/virtuoso/layout/streamout.py
@@ -1,0 +1,2955 @@
+"""Result helpers and local orchestration for XStream GDS export."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import os
+import re
+import shlex
+import shutil
+import stat
+import subprocess
+import time
+import uuid
+from dataclasses import dataclass
+from enum import Enum
+from numbers import Real
+from pathlib import Path, PurePosixPath
+from typing import Callable, Literal, cast
+
+from virtuoso_bridge.models import ExecutionStatus
+from virtuoso_bridge.transport.remote_paths import (
+    default_virtuoso_bridge_dir,
+    resolve_client_id,
+    sanitize_username_for_path,
+)
+from virtuoso_bridge.virtuoso.layout.xstream import (
+    XStreamExportRequest,
+    XStreamLogResult,
+    _parse_xstream_request_response,
+    parse_xstream_log,
+    xstream_export_gds_skill,
+)
+from virtuoso_bridge.virtuoso.response import response_fields
+
+
+CleanupPolicy = Literal["success", "always", "never"]
+
+_MONOTONIC = time.monotonic
+_SLEEP = time.sleep
+_CLEANUP_POLICIES = ("success", "always", "never")
+_MAX_FINAL_LOG_REFRESHES = 3
+_SOCKET_TIMEOUT_RE = re.compile(
+    r"Socket timeout after \d+(?:\.\d+)?(?:[eE][+-]?\d+)?s"
+)
+_REMOTE_SENTINEL_TOKEN_RE = re.compile(r"VBXSTREAM_[A-Za-z0-9]+")
+_REMOTE_SHA256_RE = re.compile(r"[0-9A-Fa-f]{64}")
+_REMOTE_LOG_TAIL_BYTES = 128 * 1024
+_REMOTE_POLL_OUTPUT_LIMIT = _REMOTE_LOG_TAIL_BYTES + 4096
+_REMOTE_HASH_CHUNK_BYTES = 1024 * 1024
+_REMOTE_STAGE_CREATED = "VBXSTREAM_STAGE_CREATED"
+_REMOTE_STAGE_READY = "VBXSTREAM_STAGE_READY"
+
+
+class GdsExportReason(str, Enum):
+    """Final reason for a GDS export result."""
+
+    COMPLETED = "completed"
+    XSTREAM_FAILURE = "xstream_failure"
+    XSTREAM_ERRORS = "xstream_errors"
+    REQUEST_CLEANUP_ERROR = "request_cleanup_error"
+    SKILL_ERROR = "skill_error"
+    LAUNCH_INDETERMINATE = "launch_indeterminate"
+    INCOMPLETE_LOG = "incomplete_log"
+    MISSING_GDS = "missing_gds"
+    EMPTY_GDS = "empty_gds"
+    MALFORMED_LOG = "malformed_log"
+    STAGING_ERROR = "staging_error"
+    TRANSPORT_ERROR = "transport_error"
+    PUBLICATION_ERROR = "publication_error"
+
+
+@dataclass(frozen=True)
+class GdsExportResult:
+    """Immutable outcome of one GDS export attempt."""
+
+    status: ExecutionStatus
+    reason: GdsExportReason
+    timed_out: bool
+    library: str
+    cell: str
+    view: str
+    execution_time: float
+    local_gds_path: Path | None = None
+    local_log_path: Path | None = None
+    log_result: XStreamLogResult | None = None
+    errors: tuple[str, ...] = ()
+    warnings: tuple[str, ...] = ()
+    remote_run_dir: str | None = None
+    local_run_dir: Path | None = None
+    remote_files_retained: bool | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "errors", tuple(self.errors))
+        object.__setattr__(self, "warnings", tuple(self.warnings))
+
+    @property
+    def ok(self) -> bool:
+        """Return whether the export completed successfully."""
+        return self.status == ExecutionStatus.SUCCESS
+
+
+@dataclass(frozen=True)
+class _ExportInputs:
+    library: str
+    cell: str
+    view: str
+    output_path: Path
+    log_path: Path
+    stream_map: Path
+    timeout: float
+    poll_interval: float
+    skill_timeout: float
+    finalization_reserve: float
+    cleanup_policy: CleanupPolicy
+
+
+@dataclass(frozen=True)
+class _ExportPaths:
+    run_dir: Path
+    gds: Path
+    log: Path
+    snapshot_log: Path
+    diagnostic_log: Path
+
+
+@dataclass(frozen=True)
+class _RemoteExportPaths:
+    owned_root: PurePosixPath
+    run_dir: PurePosixPath
+    gds: PurePosixPath
+    log: PurePosixPath
+    stream_map: PurePosixPath
+
+
+@dataclass(frozen=True)
+class _RemoteLogFinalization:
+    observation: _ArtifactObservation
+    log: XStreamLogResult | None
+    local_path: Path | None
+    stable: bool
+    error: str | None = None
+    reason: GdsExportReason | None = None
+    timed_out: bool = False
+
+
+@dataclass(frozen=True)
+class _ArtifactObservation:
+    log_present: bool = False
+    log_size: int = 0
+    log_bytes: bytes = b""
+    log_text: str = ""
+    log_tail_truncated: bool = False
+    log_digest: str | None = None
+    gds_present: bool = False
+    gds_size: int = 0
+    gds_digest: str | None = None
+
+
+@dataclass(frozen=True)
+class _PollOutcome:
+    observation: _ArtifactObservation
+    log: XStreamLogResult | None
+    saw_evidence: bool
+    deadline_expired: bool
+    staging_error: str | None = None
+
+
+class _LogSnapshotChanged(RuntimeError):
+    def __init__(self, outcome: _PollOutcome) -> None:
+        super().__init__("XStream log changed before GDS commit")
+        self.outcome = outcome
+
+
+class _RemoteSnapshotChanged(RuntimeError):
+    def __init__(self, observation: _ArtifactObservation) -> None:
+        super().__init__("remote XStream artifacts changed before publication")
+        self.observation = observation
+
+
+class _RemoteFinalizationFailure(RuntimeError):
+    def __init__(
+        self,
+        message: str,
+        reason: GdsExportReason,
+        *,
+        timed_out: bool = False,
+    ) -> None:
+        super().__init__(message)
+        self.reason = reason
+        self.timed_out = timed_out
+
+
+def _remote_security_prelude() -> str:
+    return r"""umask 077
+vb_uid=$(id -u) || exit $?
+vb_read_meta() {
+    vb_meta=$(stat -c '%u %a' -- "$1" 2>/dev/null) ||
+        vb_meta=$(stat -f '%u %Lp' -- "$1" 2>/dev/null) || return 74
+    set -- $vb_meta
+    vb_owner=$1
+    vb_mode=$2
+}
+vb_verify_dir() {
+    vb_path=$1
+    if [ -L "$vb_path" ] || [ ! -d "$vb_path" ]; then
+        printf 'unsafe remote XStream directory: %s\n' "$vb_path" >&2
+        return 73
+    fi
+    vb_read_meta "$vb_path" || return $?
+    if [ "$vb_owner" != "$vb_uid" ]; then
+        printf 'remote XStream directory has wrong owner: %s\n' "$vb_path" >&2
+        return 75
+    fi
+    if [ "$vb_mode" != 700 ]; then
+        chmod 700 -- "$vb_path" || return $?
+        if [ -L "$vb_path" ] || [ ! -d "$vb_path" ]; then
+            printf 'unsafe remote XStream directory after chmod: %s\n' "$vb_path" >&2
+            return 73
+        fi
+        vb_read_meta "$vb_path" || return $?
+        if [ "$vb_owner" != "$vb_uid" ] || [ "$vb_mode" != 700 ]; then
+            printf 'remote XStream directory is not private: %s\n' "$vb_path" >&2
+            return 76
+        fi
+    fi
+}
+vb_ensure_dir() {
+    vb_path=$1
+    if [ -L "$vb_path" ]; then
+        printf 'remote XStream directory is a symlink: %s\n' "$vb_path" >&2
+        return 73
+    fi
+    if [ ! -e "$vb_path" ]; then
+        mkdir -m 700 -- "$vb_path" || return $?
+    fi
+    vb_verify_dir "$vb_path"
+}
+"""
+
+
+def _remote_private_chain(
+    paths: _RemoteExportPaths,
+) -> tuple[PurePosixPath, PurePosixPath, PurePosixPath]:
+    return paths.owned_root.parent.parent, paths.owned_root.parent, paths.owned_root
+
+
+def _remote_stage_command(paths: _RemoteExportPaths) -> str:
+    commands = [_remote_security_prelude()]
+    for directory in _remote_private_chain(paths):
+        commands.append(
+            f"vb_ensure_dir {shlex.quote(directory.as_posix())} || exit $?\n"
+        )
+    quoted_run = shlex.quote(paths.run_dir.as_posix())
+    commands.extend(
+        [
+            f"if [ -L {quoted_run} ] || [ -e {quoted_run} ]; then\n",
+            f"    printf 'remote XStream run already exists: %s\\n' {quoted_run} >&2\n",
+            "    exit 77\n",
+            "fi\n",
+            f"mkdir -m 700 -- {quoted_run} || exit $?\n",
+            f"printf '%s\\n' {_REMOTE_STAGE_CREATED}\n",
+            f"vb_verify_dir {quoted_run} || exit $?\n",
+            f"printf '%s\\n' {_REMOTE_STAGE_READY}\n",
+        ]
+    )
+    return "".join(commands)
+
+
+def _remote_stage_markers(output: str) -> tuple[bool, bool]:
+    lines = output.splitlines()
+    created_count = lines.count(_REMOTE_STAGE_CREATED)
+    ready_count = lines.count(_REMOTE_STAGE_READY)
+    if created_count > 1 or ready_count > 1 or ready_count > created_count:
+        raise ValueError("malformed remote XStream staging markers")
+    return created_count == 1, ready_count == 1
+
+
+def _remote_delete_command(
+    paths: _RemoteExportPaths,
+    *,
+    remove_run: bool,
+) -> str:
+    commands = [_remote_security_prelude()]
+    for directory in (*_remote_private_chain(paths), paths.run_dir):
+        commands.append(
+            f"vb_verify_dir {shlex.quote(directory.as_posix())} || exit $?\n"
+        )
+    target = paths.run_dir if remove_run else paths.gds
+    flags = "-rf" if remove_run else "-f"
+    commands.append(f"rm {flags} -- {shlex.quote(target.as_posix())}\n")
+    return "".join(commands)
+
+
+def _remote_poll_command(
+    log_path: PurePosixPath,
+    gds_path: PurePosixPath,
+    token: str,
+    *,
+    include_digests: bool = False,
+) -> str:
+    if _REMOTE_SENTINEL_TOKEN_RE.fullmatch(token) is None:
+        raise ValueError("invalid remote XStream sentinel token")
+    quoted_log = shlex.quote(log_path.as_posix())
+    quoted_gds = shlex.quote(gds_path.as_posix())
+    tail_probe_bytes = _REMOTE_LOG_TAIL_BYTES + 1
+    quoted_tail_probe = shlex.quote(
+        (log_path.parent / f".{token}.tail-probe").as_posix()
+    )
+    quoted_tail_lines = shlex.quote(
+        (log_path.parent / f".{token}.tail-lines").as_posix()
+    )
+    digest_function = ""
+    log_digest = ""
+    gds_digest = ""
+    if include_digests:
+        digest_function = r"""vb_sha256() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        vb_digest_line=$(sha256sum -- "$1") || return $?
+        vb_digest=${vb_digest_line%% *}
+    elif command -v shasum >/dev/null 2>&1; then
+        vb_digest_line=$(shasum -a 256 -- "$1") || return $?
+        vb_digest=${vb_digest_line%% *}
+    elif command -v openssl >/dev/null 2>&1; then
+        vb_digest_line=$(openssl dgst -sha256 "$1") || return $?
+        vb_digest=${vb_digest_line##* }
+    else
+        printf 'no SHA-256 tool available\n' >&2
+        return 78
+    fi
+    printf '%s\n' "$vb_digest"
+}
+"""
+        log_digest = (
+            f"vb_log_digest=$(vb_sha256 {quoted_log}) || exit $?; "
+            f"printf '%s LOG_SHA256 %s\\n' {token} \"$vb_log_digest\"; "
+        )
+        gds_digest = (
+            f"vb_gds_digest=$(vb_sha256 {quoted_gds}) || exit $?; "
+            f"printf '%s GDS_SHA256 %s\\n' {token} \"$vb_gds_digest\"; "
+        )
+    return (
+        digest_function
+        + f"if [ -f {quoted_log} ]; then "
+        f"vb_log_size=$(wc -c < {quoted_log}) || exit $?; "
+        f"printf '%s LOG_SIZE %s\\n' {token} \"$vb_log_size\"; "
+        f"{log_digest}"
+        "umask 077; "
+        f"vb_tail_probe={quoted_tail_probe}; "
+        f"vb_tail_lines={quoted_tail_lines}; "
+        'rm -f -- "$vb_tail_probe" "$vb_tail_lines" || exit $?; '
+        "trap 'rm -f -- \"$vb_tail_probe\" \"$vb_tail_lines\"' 0; "
+        f"tail -c {tail_probe_bytes} -- {quoted_log} "
+        '> "$vb_tail_probe"; vb_tail_rc=$?; '
+        '[ "$vb_tail_rc" -eq 0 ] || exit "$vb_tail_rc"; '
+        'tail -n 200 -- "$vb_tail_probe" > "$vb_tail_lines"; '
+        "vb_tail_rc=$?; "
+        '[ "$vb_tail_rc" -eq 0 ] || exit "$vb_tail_rc"; '
+        'vb_tail_size=$(wc -c < "$vb_tail_lines"); vb_tail_rc=$?; '
+        '[ "$vb_tail_rc" -eq 0 ] || exit "$vb_tail_rc"; '
+        f"if [ \"$vb_tail_size\" -gt {_REMOTE_LOG_TAIL_BYTES} ]; then "
+        "vb_tail_truncated=1; else vb_tail_truncated=0; fi; "
+        f"printf '%s LOG_TRUNCATED %s\\n' {token} "
+        '"$vb_tail_truncated"; '
+        f"printf '%s LOG_BEGIN\\n' {token}; "
+        f'tail -c {_REMOTE_LOG_TAIL_BYTES} -- "$vb_tail_lines"; '
+        "vb_tail_rc=$?; printf '\\n'; "
+        f"[ \"$vb_tail_rc\" -eq 0 ] || exit \"$vb_tail_rc\"; "
+        'rm -f -- "$vb_tail_probe" "$vb_tail_lines"; '
+        "vb_tail_rc=$?; trap - 0; "
+        '[ "$vb_tail_rc" -eq 0 ] || exit "$vb_tail_rc"; '
+        f"printf '%s LOG_END\\n' {token}; "
+        f"else printf '%s LOG_MISSING\\n' {token}; fi; "
+        f"if [ -f {quoted_gds} ]; then "
+        f"vb_gds_size=$(wc -c < {quoted_gds}) || exit $?; "
+        f"printf '%s GDS_SIZE %s\\n' {token} \"$vb_gds_size\"; "
+        f"{gds_digest}"
+        f"else printf '%s GDS_MISSING\\n' {token}; fi"
+    )
+
+
+def _parse_remote_poll_output(
+    output: str,
+    token: str,
+    *,
+    require_digests: bool = False,
+) -> _ArtifactObservation:
+    if not isinstance(output, str):
+        raise TypeError("remote XStream sentinel output must be text")
+    if _REMOTE_SENTINEL_TOKEN_RE.fullmatch(token) is None:
+        raise ValueError("invalid remote XStream sentinel token")
+    if len(output) > _REMOTE_POLL_OUTPUT_LIMIT:
+        raise ValueError(
+            "remote XStream sentinel output exceeds remote XStream "
+            "sentinel limit"
+        )
+
+    prefix = f"{token} "
+    log_missing = False
+    log_size: int | None = None
+    log_digest: str | None = None
+    log_started = False
+    log_finished = False
+    log_tail_truncated: bool | None = None
+    gds_missing = False
+    gds_size: int | None = None
+    gds_digest: str | None = None
+    frame_lines: list[str] = []
+
+    for line in output.splitlines():
+        if log_started and not log_finished:
+            if line == f"{token} LOG_END":
+                log_finished = True
+            else:
+                frame_lines.append(line)
+            continue
+        if not line.startswith(prefix):
+            raise ValueError(
+                f"malformed remote XStream sentinel output: {line!r}"
+            )
+        fields = line[len(prefix) :].split()
+        if fields == ["LOG_MISSING"]:
+            if log_missing or log_size is not None or log_started:
+                raise ValueError("malformed remote XStream sentinel log status")
+            log_missing = True
+        elif len(fields) == 2 and fields[0] == "LOG_SIZE":
+            if log_missing or log_size is not None or log_started:
+                raise ValueError("malformed remote XStream sentinel log size")
+            if not fields[1].isdigit():
+                raise ValueError("malformed remote XStream sentinel log size")
+            log_size = int(fields[1])
+        elif len(fields) == 2 and fields[0] == "LOG_SHA256":
+            if (
+                log_missing
+                or log_size is None
+                or log_started
+                or log_digest is not None
+                or _REMOTE_SHA256_RE.fullmatch(fields[1]) is None
+            ):
+                raise ValueError(
+                    "malformed remote XStream sentinel log digest"
+                )
+            log_digest = fields[1].lower()
+        elif fields == ["LOG_BEGIN"]:
+            if log_missing or log_size is None or log_started:
+                raise ValueError("malformed remote XStream sentinel log frame")
+            log_started = True
+        elif len(fields) == 2 and fields[0] == "LOG_TRUNCATED":
+            if (
+                log_missing
+                or log_size is None
+                or log_started
+                or log_tail_truncated is not None
+                or fields[1] not in {"0", "1"}
+            ):
+                raise ValueError(
+                    "malformed remote XStream sentinel truncation marker"
+                )
+            log_tail_truncated = fields[1] == "1"
+        elif fields == ["GDS_MISSING"]:
+            if gds_missing or gds_size is not None:
+                raise ValueError("malformed remote XStream sentinel GDS status")
+            gds_missing = True
+        elif len(fields) == 2 and fields[0] == "GDS_SIZE":
+            if gds_missing or gds_size is not None:
+                raise ValueError("malformed remote XStream sentinel GDS size")
+            if not fields[1].isdigit():
+                raise ValueError("malformed remote XStream sentinel GDS size")
+            gds_size = int(fields[1])
+        elif len(fields) == 2 and fields[0] == "GDS_SHA256":
+            if (
+                gds_missing
+                or gds_size is None
+                or gds_digest is not None
+                or _REMOTE_SHA256_RE.fullmatch(fields[1]) is None
+            ):
+                raise ValueError(
+                    "malformed remote XStream sentinel GDS digest"
+                )
+            gds_digest = fields[1].lower()
+        else:
+            raise ValueError(
+                f"malformed remote XStream sentinel control line: {line!r}"
+            )
+
+    log_present = log_size is not None
+    if log_missing == log_present:
+        raise ValueError("malformed remote XStream sentinel log status")
+    if log_present and not (log_started and log_finished):
+        raise ValueError("malformed remote XStream sentinel log frame")
+    if log_missing and (log_started or log_finished):
+        raise ValueError("malformed remote XStream sentinel log frame")
+    if log_missing and log_tail_truncated is not None:
+        raise ValueError("malformed remote XStream sentinel truncation marker")
+    if require_digests and log_present and log_digest is None:
+        raise ValueError("missing remote XStream sentinel log digest")
+
+    gds_present = gds_size is not None
+    if gds_missing == gds_present:
+        raise ValueError("malformed remote XStream sentinel GDS status")
+    if require_digests and gds_present and gds_digest is None:
+        raise ValueError("missing remote XStream sentinel GDS digest")
+
+    log_text = "\n".join(frame_lines) if log_present else ""
+    log_bytes = log_text.encode("utf-8")
+    return _ArtifactObservation(
+        log_present=log_present,
+        log_size=log_size or 0,
+        log_bytes=log_bytes,
+        log_text=log_text,
+        log_tail_truncated=bool(log_tail_truncated),
+        log_digest=log_digest,
+        gds_present=gds_present,
+        gds_size=gds_size or 0,
+        gds_digest=gds_digest,
+    )
+
+
+def _validate_export_inputs(
+    library: str,
+    cell: str,
+    output_path: str | Path,
+    *,
+    stream_map: str | Path,
+    view: str,
+    log_path: str | Path | None,
+    timeout: float,
+    poll_interval: float,
+    skill_timeout: float,
+    finalization_reserve: float,
+    cleanup_policy: CleanupPolicy,
+) -> _ExportInputs:
+    normalized_library = _require_nonempty_string("library", library)
+    normalized_cell = _require_nonempty_string("cell", cell)
+    normalized_view = _require_nonempty_string("view", view)
+
+    normalized_output = Path(output_path).expanduser().resolve()
+    normalized_log = (
+        Path(log_path).expanduser().resolve()
+        if log_path is not None
+        else normalized_output.with_name(
+            f"{normalized_output.stem}.xstream.log"
+        )
+    )
+    normalized_stream_map = Path(stream_map).expanduser().resolve()
+    if not normalized_stream_map.is_file():
+        raise FileNotFoundError(
+            f"stream_map is not an existing regular file: {normalized_stream_map}"
+        )
+    if (
+        _paths_alias(normalized_output, normalized_log)
+        or _paths_alias(normalized_output, normalized_stream_map)
+        or _paths_alias(normalized_log, normalized_stream_map)
+    ):
+        raise ValueError("output_path, log_path, and stream_map must be distinct")
+
+    normalized_timeout = _positive_finite_float("timeout", timeout)
+    normalized_poll_interval = _positive_finite_float(
+        "poll_interval", poll_interval
+    )
+    normalized_skill_timeout = _positive_finite_float(
+        "skill_timeout", skill_timeout
+    )
+    normalized_finalization_reserve = _positive_finite_float(
+        "finalization_reserve", finalization_reserve
+    )
+    if normalized_finalization_reserve >= normalized_timeout:
+        raise ValueError("finalization_reserve must be smaller than timeout")
+    if cleanup_policy not in _CLEANUP_POLICIES:
+        raise ValueError(
+            "cleanup_policy must be one of: success, always, never"
+        )
+
+    return _ExportInputs(
+        library=normalized_library,
+        cell=normalized_cell,
+        view=normalized_view,
+        output_path=normalized_output,
+        log_path=normalized_log,
+        stream_map=normalized_stream_map,
+        timeout=normalized_timeout,
+        poll_interval=normalized_poll_interval,
+        skill_timeout=normalized_skill_timeout,
+        finalization_reserve=normalized_finalization_reserve,
+        cleanup_policy=cast(CleanupPolicy, cleanup_policy),
+    )
+
+
+def _require_nonempty_string(name: str, value: object) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{name} must be a nonempty string")
+    return value
+
+
+def _paths_alias(first: Path, second: Path) -> bool:
+    if first == second:
+        return True
+    if not first.exists() or not second.exists():
+        return False
+    try:
+        return first.samefile(second)
+    except OSError:
+        return False
+
+
+def _positive_finite_float(name: str, value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a finite positive real number")
+    normalized = float(value)
+    if not math.isfinite(normalized) or normalized <= 0.0:
+        raise ValueError(f"{name} must be a finite positive real number")
+    return normalized
+
+
+class _BudgetExpired(TimeoutError):
+    """Raised when an export operation has exhausted its time budget."""
+
+
+@dataclass(frozen=True)
+class _Budget:
+    started_at: float
+    deadline: float
+    prefinalization_deadline: float
+    clock: Callable[[], float]
+
+    @classmethod
+    def start(
+        cls,
+        timeout: float,
+        finalization_reserve: float,
+        clock: Callable[[], float] = _MONOTONIC,
+    ) -> _Budget:
+        started_at = float(clock())
+        deadline = started_at + float(timeout)
+        return cls(
+            started_at=started_at,
+            deadline=deadline,
+            prefinalization_deadline=deadline - float(finalization_reserve),
+            clock=clock,
+        )
+
+    def remaining(self, finalizing: bool) -> float:
+        deadline = self.deadline if finalizing else self.prefinalization_deadline
+        return max(0.0, deadline - float(self.clock()))
+
+    def timeout(self, finalizing: bool, cap: float | None = None) -> float:
+        remaining = self.remaining(finalizing)
+        timeout = remaining if cap is None else min(remaining, cap)
+        if timeout <= 0.0:
+            raise _BudgetExpired("export time budget exhausted")
+        return float(timeout)
+
+    def elapsed(self) -> float:
+        return max(0.0, float(self.clock()) - self.started_at)
+
+
+def _is_indeterminate_skill_timeout(errors: tuple[str, ...]) -> bool:
+    """Return whether every error is one exact transport timeout form."""
+    return bool(errors) and all(
+        error == "SKILL execution timeout in Virtuoso"
+        or _SOCKET_TIMEOUT_RE.fullmatch(error) is not None
+        for error in errors
+    )
+
+
+def _classify_export(
+    *,
+    cleanup_failures: tuple[str, ...],
+    log: XStreamLogResult | None,
+    skill_errors: tuple[str, ...],
+    launch_indeterminate: bool,
+    saw_evidence: bool,
+    gds_present: bool,
+    gds_size: int,
+    gds_published: bool,
+    deadline_expired: bool,
+) -> tuple[ExecutionStatus, GdsExportReason, bool]:
+    if cleanup_failures:
+        return (
+            ExecutionStatus.ERROR,
+            GdsExportReason.REQUEST_CLEANUP_ERROR,
+            deadline_expired,
+        )
+    if log is not None and log.terminal_failures:
+        return (
+            ExecutionStatus.FAILURE,
+            GdsExportReason.XSTREAM_FAILURE,
+            deadline_expired,
+        )
+
+    completed = log is not None and log.completed
+    if completed and (log.error_count is None or log.warning_count is None):
+        return (
+            ExecutionStatus.ERROR,
+            GdsExportReason.MALFORMED_LOG,
+            deadline_expired,
+        )
+    if completed and log.error_count != 0:
+        return (
+            ExecutionStatus.FAILURE,
+            GdsExportReason.XSTREAM_ERRORS,
+            deadline_expired,
+        )
+    if skill_errors and not _is_indeterminate_skill_timeout(skill_errors):
+        return ExecutionStatus.ERROR, GdsExportReason.SKILL_ERROR, False
+    valid_completion = (
+        completed and log.error_count == 0 and log.warning_count is not None
+    )
+    if valid_completion and not gds_present:
+        return ExecutionStatus.PARTIAL, GdsExportReason.MISSING_GDS, True
+    if valid_completion and gds_size <= 0:
+        return ExecutionStatus.PARTIAL, GdsExportReason.EMPTY_GDS, True
+    if not valid_completion and (not launch_indeterminate or saw_evidence):
+        return ExecutionStatus.PARTIAL, GdsExportReason.INCOMPLETE_LOG, True
+    if not valid_completion and launch_indeterminate and not saw_evidence:
+        return (
+            ExecutionStatus.PARTIAL,
+            GdsExportReason.LAUNCH_INDETERMINATE,
+            True,
+        )
+    if valid_completion and gds_present and gds_size > 0 and gds_published:
+        return ExecutionStatus.SUCCESS, GdsExportReason.COMPLETED, False
+    raise ValueError("unclassifiable GDS export observations")
+
+
+def export_gds(
+    client: object,
+    library: str,
+    cell: str,
+    output_path: str | Path,
+    *,
+    stream_map: str | Path,
+    view: str = "layout",
+    log_path: str | Path | None = None,
+    timeout: float = 300.0,
+    poll_interval: float = 0.5,
+    skill_timeout: float = 30.0,
+    finalization_reserve: float = 30.0,
+    cleanup_policy: CleanupPolicy = "success",
+    recovery_hook: Callable[[], object] | None = None,
+) -> GdsExportResult:
+    """Export one layout to GDS using a fresh XStream staging directory."""
+    inputs = _validate_export_inputs(
+        library,
+        cell,
+        output_path,
+        stream_map=stream_map,
+        view=view,
+        log_path=log_path,
+        timeout=timeout,
+        poll_interval=poll_interval,
+        skill_timeout=skill_timeout,
+        finalization_reserve=finalization_reserve,
+        cleanup_policy=cleanup_policy,
+    )
+    budget = _Budget.start(
+        inputs.timeout,
+        inputs.finalization_reserve,
+        clock=_MONOTONIC,
+    )
+    try:
+        ssh_runner = getattr(client, "ssh_runner")
+    except Exception as exc:
+        return GdsExportResult(
+            status=ExecutionStatus.ERROR,
+            reason=GdsExportReason.TRANSPORT_ERROR,
+            timed_out=budget.remaining(finalizing=True) <= 0.0,
+            library=inputs.library,
+            cell=inputs.cell,
+            view=inputs.view,
+            execution_time=budget.elapsed(),
+            errors=(f"failed to inspect client ssh_runner: {exc}",),
+        )
+    if ssh_runner is None:
+        return _export_gds_local(client, inputs, budget, recovery_hook)
+    return _export_gds_remote(client, inputs, budget, recovery_hook)
+
+
+def _export_gds_remote(
+    client: object,
+    inputs: _ExportInputs,
+    budget: _Budget,
+    recovery_hook: Callable[[], object] | None,
+) -> GdsExportResult:
+    try:
+        runner = getattr(client, "ssh_runner")
+        configured_user = getattr(runner, "user", None)
+    except Exception as exc:
+        return _remote_error_result(
+            inputs,
+            budget,
+            f"failed to inspect remote XStream runner: {exc}",
+        )
+
+    if isinstance(configured_user, str) and configured_user.strip():
+        username = sanitize_username_for_path(configured_user)
+    else:
+        try:
+            whoami = runner.run_command(
+                "whoami",
+                timeout=budget.timeout(finalizing=False),
+            )
+            returncode, stdout, stderr = _command_result_fields(whoami)
+        except Exception as exc:
+            return _remote_error_result(
+                inputs,
+                budget,
+                f"failed to resolve remote XStream username: {exc}",
+                timed_out=_exception_timed_out(exc),
+            )
+        if returncode != 0 or not stdout.strip():
+            detail = stderr.strip() or stdout.strip() or (
+                f"whoami returned exit status {returncode}"
+            )
+            return _remote_error_result(
+                inputs,
+                budget,
+                f"failed to resolve remote XStream username: {detail}",
+            )
+        username = sanitize_username_for_path(stdout)
+
+    try:
+        client_id = resolve_client_id()
+        owned_root = PurePosixPath(
+            default_virtuoso_bridge_dir(
+                username,
+                "xstream",
+                client_id,
+            ).replace("\\", "/")
+        )
+        if not owned_root.is_absolute() or ".." in owned_root.parts:
+            raise ValueError("remote XStream scratch root must be absolute")
+        run_dir = owned_root / uuid.uuid4().hex
+        paths = _RemoteExportPaths(
+            owned_root=owned_root,
+            run_dir=run_dir,
+            gds=run_dir / "output.gds",
+            log=run_dir / "xstream.log",
+            stream_map=run_dir / "stream.map",
+        )
+    except Exception as exc:
+        return _remote_error_result(
+            inputs,
+            budget,
+            f"failed to allocate remote XStream staging path: {exc}",
+        )
+
+    remote_run_dir = paths.run_dir.as_posix()
+    try:
+        mkdir_result = runner.run_command(
+            _remote_stage_command(paths),
+            timeout=budget.timeout(finalizing=False),
+        )
+        returncode, stdout, stderr = _command_result_fields(mkdir_result)
+        run_created, run_ready = _remote_stage_markers(stdout)
+    except Exception as exc:
+        return _remote_error_result(
+            inputs,
+            budget,
+            f"failed to create remote XStream staging: {exc}",
+            remote_run_dir=remote_run_dir,
+            remote_files_retained=None,
+            timed_out=_exception_timed_out(exc),
+        )
+    if returncode != 0 or not run_ready:
+        detail = stderr.strip() or stdout.strip() or (
+            f"secure staging returned exit status {returncode}"
+        )
+        return _remote_error_result(
+            inputs,
+            budget,
+            f"failed to create remote XStream staging: {detail}",
+            remote_run_dir=remote_run_dir,
+            remote_files_retained=True if run_created else None,
+        )
+
+    warnings: list[str] = []
+    try:
+        upload_response = getattr(client, "upload_file")(
+            inputs.stream_map,
+            paths.stream_map.as_posix(),
+            timeout=budget.timeout(finalizing=False),
+        )
+        warnings.extend(_response_warnings(upload_response))
+        upload_errors, upload_status, _upload_output = response_fields(
+            upload_response
+        )
+    except Exception as exc:
+        return _remote_error_result(
+            inputs,
+            budget,
+            f"failed to upload remote XStream stream map: {exc}",
+            warnings=warnings,
+            remote_run_dir=remote_run_dir,
+            remote_files_retained=True,
+            timed_out=_exception_timed_out(exc),
+        )
+    if not _response_succeeded(upload_status):
+        detail = "; ".join(upload_errors) or (
+            "upload returned non-success status without errors: "
+            f"{upload_status!r}"
+        )
+        return _remote_error_result(
+            inputs,
+            budget,
+            f"failed to upload remote XStream stream map: {detail}",
+            warnings=warnings,
+            remote_run_dir=remote_run_dir,
+            remote_files_retained=True,
+        )
+
+    request = XStreamExportRequest(
+        library=inputs.library,
+        top_cell=inputs.cell,
+        view=inputs.view,
+        stream_file=paths.gds.as_posix(),
+        layer_map=paths.stream_map.as_posix(),
+        log_file=paths.log.as_posix(),
+        run_dir=remote_run_dir,
+    )
+    skill_errors: tuple[str, ...] = ()
+    cleanup_failures: tuple[str, ...] = ()
+    launch_indeterminate = False
+    should_poll = False
+    try:
+        skill_code = xstream_export_gds_skill(request)
+        response = getattr(client, "execute_skill")(
+            skill_code,
+            timeout=budget.timeout(
+                finalizing=False,
+                cap=inputs.skill_timeout,
+            ),
+        )
+        warnings.extend(_response_warnings(response))
+    except _BudgetExpired as exc:
+        return _remote_error_result(
+            inputs,
+            budget,
+            f"remote XStream launch skipped: {exc}",
+            warnings=warnings,
+            remote_run_dir=remote_run_dir,
+            remote_files_retained=True,
+            timed_out=True,
+        )
+    except Exception as exc:
+        if _exception_timed_out(exc):
+            skill_errors = ("SKILL execution timeout in Virtuoso",)
+            launch_indeterminate = True
+            should_poll = True
+        else:
+            skill_errors = (f"SKILL execution failed: {exc}",)
+    else:
+        try:
+            response_errors, response_status, response_output = response_fields(
+                response
+            )
+        except Exception as exc:
+            skill_errors = (f"failed to normalize SKILL response: {exc}",)
+        else:
+            skill_errors = tuple(response_errors)
+            response_succeeded = _response_succeeded(response_status)
+            if not response_succeeded and not skill_errors:
+                skill_errors = (
+                    "SKILL request returned non-success status without errors: "
+                    f"{response_status!r}",
+                )
+            if not response_succeeded or skill_errors:
+                launch_indeterminate = _is_indeterminate_skill_timeout(
+                    skill_errors
+                )
+                should_poll = launch_indeterminate
+            else:
+                try:
+                    request_response = _parse_xstream_request_response(
+                        response_output
+                    )
+                except ValueError as exc:
+                    skill_errors = (str(exc),)
+                else:
+                    cleanup_failures = request_response.cleanup_failures
+                    if request_response.state == "failed":
+                        skill_errors = (
+                            request_response.body_error
+                            or "XStream request body failed",
+                        )
+                    elif not cleanup_failures:
+                        should_poll = True
+
+    outcome = _poll_remote_artifacts(
+        runner,
+        paths,
+        budget,
+        inputs.poll_interval,
+        should_poll=should_poll,
+        launch_indeterminate=launch_indeterminate,
+        recovery_hook=recovery_hook,
+        warnings=warnings,
+    )
+    return _finalize_remote_export(
+        client,
+        runner,
+        inputs,
+        paths,
+        budget,
+        outcome,
+        skill_errors=skill_errors,
+        cleanup_failures=cleanup_failures,
+        launch_indeterminate=launch_indeterminate,
+        warnings=warnings,
+    )
+
+
+def _command_result_fields(result: object) -> tuple[int, str, str]:
+    if isinstance(result, dict):
+        returncode = result.get("returncode")
+        stdout = result.get("stdout", "")
+        stderr = result.get("stderr", "")
+    else:
+        returncode = getattr(result, "returncode")
+        stdout = getattr(result, "stdout", "")
+        stderr = getattr(result, "stderr", "")
+    if isinstance(returncode, bool) or not isinstance(returncode, int):
+        raise TypeError("remote command returncode must be an integer")
+    return returncode, str(stdout or ""), str(stderr or "")
+
+
+def _exception_timed_out(exc: BaseException) -> bool:
+    return isinstance(exc, (_BudgetExpired, subprocess.TimeoutExpired))
+
+
+def _remote_error_result(
+    inputs: _ExportInputs,
+    budget: _Budget,
+    error: str,
+    *,
+    warnings: list[str] | tuple[str, ...] = (),
+    remote_run_dir: str | None = None,
+    remote_files_retained: bool | None = None,
+    timed_out: bool = False,
+    reason: GdsExportReason = GdsExportReason.TRANSPORT_ERROR,
+) -> GdsExportResult:
+    return GdsExportResult(
+        status=ExecutionStatus.ERROR,
+        reason=reason,
+        timed_out=(
+            timed_out or budget.remaining(finalizing=True) <= 0.0
+        ),
+        library=inputs.library,
+        cell=inputs.cell,
+        view=inputs.view,
+        execution_time=budget.elapsed(),
+        errors=(error,),
+        warnings=tuple(warnings),
+        remote_run_dir=remote_run_dir,
+        remote_files_retained=remote_files_retained,
+    )
+
+
+def _poll_remote_artifacts(
+    runner: object,
+    paths: _RemoteExportPaths,
+    budget: _Budget,
+    poll_interval: float,
+    *,
+    should_poll: bool,
+    launch_indeterminate: bool,
+    recovery_hook: Callable[[], object] | None,
+    warnings: list[str],
+) -> _PollOutcome:
+    observation = _ArtifactObservation()
+    log: XStreamLogResult | None = None
+    saw_evidence = False
+    recovery_attempted = False
+
+    while True:
+        if budget.remaining(finalizing=False) <= 0.0:
+            return _PollOutcome(
+                observation=observation,
+                log=log,
+                saw_evidence=saw_evidence,
+                deadline_expired=True,
+            )
+        try:
+            observation = _observe_remote_artifacts(
+                runner,
+                paths,
+                budget,
+                finalizing=False,
+            )
+            log = (
+                parse_xstream_log(observation.log_text)
+                if observation.log_present
+                else None
+            )
+        except Exception as exc:
+            return _PollOutcome(
+                observation=observation,
+                log=log,
+                saw_evidence=saw_evidence,
+                deadline_expired=(
+                    _exception_timed_out(exc)
+                    or budget.remaining(finalizing=False) <= 0.0
+                ),
+                staging_error=f"failed to poll remote XStream artifacts: {exc}",
+            )
+
+        progress = _observation_has_evidence(observation, log)
+        saw_evidence = saw_evidence or progress
+        if (
+            launch_indeterminate
+            and progress
+            and not recovery_attempted
+            and recovery_hook is not None
+            and budget.remaining(finalizing=False) > 0.0
+        ):
+            recovery_attempted = True
+            try:
+                recovery_hook()
+            except Exception as exc:
+                warnings.append(f"recovery hook failed: {exc}")
+
+        if _observation_is_terminal(observation, log) or not should_poll:
+            return _PollOutcome(
+                observation=observation,
+                log=log,
+                saw_evidence=saw_evidence,
+                deadline_expired=False,
+            )
+        remaining = budget.remaining(finalizing=False)
+        if remaining <= 0.0:
+            return _PollOutcome(
+                observation=observation,
+                log=log,
+                saw_evidence=saw_evidence,
+                deadline_expired=True,
+            )
+        delay = min(poll_interval, remaining)
+        try:
+            _SLEEP(delay)
+        except (OSError, OverflowError) as exc:
+            return _PollOutcome(
+                observation=observation,
+                log=log,
+                saw_evidence=saw_evidence,
+                deadline_expired=budget.remaining(finalizing=False) <= 0.0,
+                staging_error=f"failed while polling remote artifacts: {exc}",
+            )
+
+
+def _observe_remote_artifacts(
+    runner: object,
+    paths: _RemoteExportPaths,
+    budget: _Budget,
+    *,
+    finalizing: bool,
+) -> _ArtifactObservation:
+    token = f"VBXSTREAM_{uuid.uuid4().hex}"
+    command = _remote_poll_command(
+        paths.log,
+        paths.gds,
+        token,
+        include_digests=finalizing,
+    )
+    result = getattr(runner, "run_command")(
+        command,
+        timeout=budget.timeout(finalizing=finalizing),
+    )
+    returncode, stdout, stderr = _command_result_fields(result)
+    if returncode != 0:
+        detail = stderr.strip() or stdout.strip() or (
+            f"remote sentinel returned exit status {returncode}"
+        )
+        raise OSError(detail)
+    return _parse_remote_poll_output(
+        stdout,
+        token,
+        require_digests=finalizing,
+    )
+
+
+def _remote_log_fingerprint(
+    observation: _ArtifactObservation,
+) -> tuple[bool, int, bytes, str | None]:
+    return (
+        observation.log_present,
+        observation.log_size,
+        observation.log_bytes,
+        observation.log_digest,
+    )
+
+
+def _remote_gds_fingerprint(
+    observation: _ArtifactObservation,
+) -> tuple[bool, int, str | None]:
+    return (
+        observation.gds_present,
+        observation.gds_size,
+        observation.gds_digest,
+    )
+
+
+def _remote_download_temp_path(destination: Path) -> Path:
+    return destination.parent / f".vbd-{uuid.uuid4().hex}.tmp"
+
+
+def _download_remote_file(
+    client: object,
+    remote_path: PurePosixPath,
+    local_path: Path,
+    budget: _Budget,
+    warnings: list[str],
+    *,
+    label: str,
+) -> None:
+    try:
+        budget.timeout(finalizing=True)
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+    except _BudgetExpired as exc:
+        raise _RemoteFinalizationFailure(
+            str(exc),
+            GdsExportReason.PUBLICATION_ERROR,
+            timed_out=True,
+        ) from exc
+    except OSError as exc:
+        raise _RemoteFinalizationFailure(
+            f"failed to prepare local {label} download staging: {exc}",
+            GdsExportReason.PUBLICATION_ERROR,
+        ) from exc
+
+    try:
+        response = getattr(client, "download_file")(
+            remote_path.as_posix(),
+            local_path,
+            timeout=budget.timeout(finalizing=True),
+        )
+        warnings.extend(_response_warnings(response))
+        response_errors, response_status, _response_output = response_fields(
+            response
+        )
+    except Exception as exc:
+        raise _RemoteFinalizationFailure(
+            f"failed to download remote XStream {label}: {exc}",
+            GdsExportReason.TRANSPORT_ERROR,
+            timed_out=_exception_timed_out(exc),
+        ) from exc
+    if not _response_succeeded(response_status):
+        detail = "; ".join(response_errors) or (
+            "download returned non-success status without errors: "
+            f"{response_status!r}"
+        )
+        raise _RemoteFinalizationFailure(
+            f"failed to download remote XStream {label}: {detail}",
+            GdsExportReason.TRANSPORT_ERROR,
+        )
+    if budget.remaining(finalizing=True) <= 0.0:
+        raise _RemoteFinalizationFailure(
+            f"export time budget exhausted after remote XStream {label} download",
+            GdsExportReason.TRANSPORT_ERROR,
+            timed_out=True,
+        )
+
+
+def _read_downloaded_file(path: Path, *, label: str) -> bytes:
+    try:
+        metadata = path.stat()
+        if not stat.S_ISREG(metadata.st_mode):
+            raise OSError(f"downloaded {label} is not a regular file: {path}")
+        return path.read_bytes()
+    except OSError as exc:
+        raise _RemoteFinalizationFailure(
+            f"failed to validate downloaded remote XStream {label}: {exc}",
+            GdsExportReason.TRANSPORT_ERROR,
+        ) from exc
+
+
+def _stream_file_sha256(path: Path, budget: _Budget) -> tuple[int, str]:
+    digest = hashlib.sha256()
+    size = 0
+    with path.open("rb") as artifact:
+        metadata = os.fstat(artifact.fileno())
+        if not stat.S_ISREG(metadata.st_mode):
+            raise OSError(f"downloaded GDS is not a regular file: {path}")
+        while True:
+            budget.timeout(finalizing=True)
+            chunk = artifact.read(_REMOTE_HASH_CHUNK_BYTES)
+            if not chunk:
+                break
+            digest.update(chunk)
+            size += len(chunk)
+    return size, digest.hexdigest()
+
+
+def _cleanup_local_download_temp(
+    path: Path,
+    budget: _Budget,
+    warnings: list[str],
+) -> None:
+    after_deadline = budget.remaining(finalizing=True) <= 0.0
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        warnings.append(f"local download temp retained: {path}: {exc}")
+    else:
+        if after_deadline:
+            warnings.append(
+                f"local download temp removed after export deadline: {path}"
+            )
+
+
+def _stabilize_remote_log(
+    client: object,
+    runner: object,
+    inputs: _ExportInputs,
+    paths: _RemoteExportPaths,
+    budget: _Budget,
+    initial_observation: _ArtifactObservation,
+    warnings: list[str],
+) -> _RemoteLogFinalization:
+    observation = initial_observation
+    local_path: Path | None = None
+    changed_before_publication = False
+
+    if observation.log_present and observation.log_digest is None:
+        try:
+            observation = _observe_remote_artifacts(
+                runner,
+                paths,
+                budget,
+                finalizing=True,
+            )
+        except Exception as exc:
+            return _RemoteLogFinalization(
+                observation=observation,
+                log=None,
+                local_path=None,
+                stable=False,
+                error=f"failed to fingerprint remote XStream log: {exc}",
+                reason=GdsExportReason.TRANSPORT_ERROR,
+                timed_out=_exception_timed_out(exc),
+            )
+
+    for _ in range(_MAX_FINAL_LOG_REFRESHES):
+        if not observation.log_present:
+            return _RemoteLogFinalization(
+                observation=observation,
+                log=None,
+                local_path=local_path,
+                stable=True,
+            )
+
+        temporary = _remote_download_temp_path(inputs.log_path)
+        try:
+            _download_remote_file(
+                client,
+                paths.log,
+                temporary,
+                budget,
+                warnings,
+                label="log",
+            )
+            log_bytes = _read_downloaded_file(temporary, label="log")
+            budget.timeout(finalizing=True)
+            downloaded_log_digest = hashlib.sha256(log_bytes).hexdigest()
+            refreshed = _observe_remote_artifacts(
+                runner,
+                paths,
+                budget,
+                finalizing=True,
+            )
+        except _RemoteFinalizationFailure as exc:
+            _cleanup_local_download_temp(temporary, budget, warnings)
+            return _RemoteLogFinalization(
+                observation=observation,
+                log=None,
+                local_path=local_path,
+                stable=False,
+                error=str(exc),
+                reason=exc.reason,
+                timed_out=exc.timed_out,
+            )
+        except Exception as exc:
+            _cleanup_local_download_temp(temporary, budget, warnings)
+            return _RemoteLogFinalization(
+                observation=observation,
+                log=None,
+                local_path=local_path,
+                stable=False,
+                error=f"failed to recheck remote XStream log: {exc}",
+                reason=GdsExportReason.TRANSPORT_ERROR,
+                timed_out=_exception_timed_out(exc),
+            )
+
+        if (
+            len(log_bytes) != observation.log_size
+            or downloaded_log_digest != observation.log_digest
+            or _remote_log_fingerprint(refreshed)
+            != _remote_log_fingerprint(observation)
+        ):
+            if (
+                _remote_log_fingerprint(refreshed)
+                != _remote_log_fingerprint(observation)
+            ):
+                local_path = None
+            observation = refreshed
+            _cleanup_local_download_temp(temporary, budget, warnings)
+            continue
+
+        log_text = log_bytes.decode("utf-8", errors="replace")
+        parsed_log: XStreamLogResult | None = None
+        validated_observation = refreshed
+
+        def validate_remote_log_snapshot() -> None:
+            nonlocal validated_observation
+            try:
+                latest = _observe_remote_artifacts(
+                    runner,
+                    paths,
+                    budget,
+                    finalizing=True,
+                )
+                budget.timeout(finalizing=True)
+            except Exception as exc:
+                raise _RemoteFinalizationFailure(
+                    "failed to validate remote XStream log before "
+                    f"publication: {exc}",
+                    GdsExportReason.TRANSPORT_ERROR,
+                    timed_out=_exception_timed_out(exc),
+                ) from exc
+            validated_observation = latest
+            if (
+                _remote_log_fingerprint(latest)
+                != _remote_log_fingerprint(observation)
+            ):
+                raise _RemoteSnapshotChanged(latest)
+
+        try:
+            parsed_log = parse_xstream_log(log_text)
+            budget.timeout(finalizing=True)
+            _publish_file(
+                temporary,
+                inputs.log_path,
+                validator=validate_remote_log_snapshot,
+            )
+            local_path = inputs.log_path
+        except _RemoteSnapshotChanged as exc:
+            changed_before_publication = True
+            local_path = None
+            observation = exc.observation
+            _cleanup_local_download_temp(temporary, budget, warnings)
+            continue
+        except _RemoteFinalizationFailure as exc:
+            _cleanup_local_download_temp(temporary, budget, warnings)
+            return _RemoteLogFinalization(
+                observation=observation,
+                log=parsed_log,
+                local_path=None,
+                stable=False,
+                error=str(exc),
+                reason=exc.reason,
+                timed_out=exc.timed_out,
+            )
+        except _BudgetExpired as exc:
+            _cleanup_local_download_temp(temporary, budget, warnings)
+            return _RemoteLogFinalization(
+                observation=observation,
+                log=parsed_log,
+                local_path=None,
+                stable=False,
+                error=str(exc),
+                reason=GdsExportReason.PUBLICATION_ERROR,
+                timed_out=True,
+            )
+        except (OSError, ValueError, TypeError) as exc:
+            _cleanup_local_download_temp(temporary, budget, warnings)
+            return _RemoteLogFinalization(
+                observation=observation,
+                log=parsed_log,
+                local_path=None,
+                stable=False,
+                error=f"failed to publish remote XStream log: {exc}",
+                reason=GdsExportReason.PUBLICATION_ERROR,
+            )
+
+        _cleanup_local_download_temp(temporary, budget, warnings)
+        if budget.remaining(finalizing=True) <= 0.0:
+            return _RemoteLogFinalization(
+                observation=validated_observation,
+                log=parsed_log,
+                local_path=local_path,
+                stable=False,
+                error=(
+                    "export time budget exhausted after remote XStream "
+                    "log publication"
+                ),
+                reason=GdsExportReason.PUBLICATION_ERROR,
+                timed_out=True,
+            )
+        return _RemoteLogFinalization(
+            observation=validated_observation,
+            log=parsed_log,
+            local_path=local_path,
+            stable=True,
+        )
+
+    if changed_before_publication:
+        error = "remote XStream log did not stabilize before publication"
+        reason = GdsExportReason.PUBLICATION_ERROR
+    else:
+        error = "remote XStream log did not stabilize during download"
+        reason = GdsExportReason.TRANSPORT_ERROR
+    return _RemoteLogFinalization(
+        observation=observation,
+        log=None,
+        local_path=local_path,
+        stable=False,
+        error=error,
+        reason=reason,
+    )
+
+
+def _finalize_remote_export(
+    client: object,
+    runner: object,
+    inputs: _ExportInputs,
+    paths: _RemoteExportPaths,
+    budget: _Budget,
+    outcome: _PollOutcome,
+    *,
+    skill_errors: tuple[str, ...],
+    cleanup_failures: tuple[str, ...],
+    launch_indeterminate: bool,
+    warnings: list[str],
+) -> GdsExportResult:
+    result_warnings = list(warnings)
+    final_observation = outcome.observation
+    final_log: XStreamLogResult | None = None
+    local_log_path: Path | None = None
+    local_gds_path: Path | None = None
+    operational_error = outcome.staging_error
+    operational_reason = (
+        GdsExportReason.TRANSPORT_ERROR
+        if operational_error is not None
+        else None
+    )
+    operational_timed_out = (
+        outcome.deadline_expired and operational_error is not None
+    )
+    diagnostic_log_ready = False
+
+    launch_is_blocked = bool(cleanup_failures) or bool(
+        skill_errors and not _is_indeterminate_skill_timeout(skill_errors)
+    )
+    if operational_error is None and not launch_is_blocked:
+        try:
+            final_observation = _observe_remote_artifacts(
+                runner,
+                paths,
+                budget,
+                finalizing=True,
+            )
+        except Exception as exc:
+            operational_error = (
+                f"failed to refresh remote XStream artifacts: {exc}"
+            )
+            operational_reason = GdsExportReason.TRANSPORT_ERROR
+            operational_timed_out = _exception_timed_out(exc)
+
+    if operational_error is None:
+        log_finalization = _stabilize_remote_log(
+            client,
+            runner,
+            inputs,
+            paths,
+            budget,
+            final_observation,
+            result_warnings,
+        )
+        final_observation = log_finalization.observation
+        final_log = log_finalization.log
+        local_log_path = log_finalization.local_path
+        diagnostic_log_ready = bool(
+            log_finalization.stable
+            and final_log is not None
+            and local_log_path is not None
+        )
+        if log_finalization.error is not None:
+            operational_error = log_finalization.error
+            operational_reason = log_finalization.reason
+            operational_timed_out = log_finalization.timed_out
+
+    gds_allowed = (
+        operational_error is None
+        and diagnostic_log_ready
+        and not cleanup_failures
+        and (not skill_errors or _is_indeterminate_skill_timeout(skill_errors))
+        and _has_valid_zero_error_completion(final_log)
+    )
+    gds_download_mismatch = False
+    if gds_allowed:
+        for _ in range(_MAX_FINAL_LOG_REFRESHES):
+            if (
+                not final_observation.gds_present
+                or final_observation.gds_size <= 0
+            ):
+                break
+            expected = final_observation
+            temporary = _remote_download_temp_path(inputs.output_path)
+            try:
+                _download_remote_file(
+                    client,
+                    paths.gds,
+                    temporary,
+                    budget,
+                    result_warnings,
+                    label="GDS",
+                )
+                downloaded_gds_size, downloaded_gds_digest = (
+                    _stream_file_sha256(temporary, budget)
+                )
+                refreshed = _observe_remote_artifacts(
+                    runner,
+                    paths,
+                    budget,
+                    finalizing=True,
+                )
+            except _RemoteFinalizationFailure as exc:
+                _cleanup_local_download_temp(temporary, budget, result_warnings)
+                operational_error = str(exc)
+                operational_reason = exc.reason
+                operational_timed_out = exc.timed_out
+                break
+            except Exception as exc:
+                _cleanup_local_download_temp(temporary, budget, result_warnings)
+                operational_error = (
+                    f"failed to verify downloaded remote XStream GDS: {exc}"
+                )
+                operational_reason = GdsExportReason.TRANSPORT_ERROR
+                operational_timed_out = _exception_timed_out(exc)
+                break
+
+            if (
+                _remote_log_fingerprint(refreshed)
+                != _remote_log_fingerprint(expected)
+            ):
+                _cleanup_local_download_temp(temporary, budget, result_warnings)
+                log_finalization = _stabilize_remote_log(
+                    client,
+                    runner,
+                    inputs,
+                    paths,
+                    budget,
+                    refreshed,
+                    result_warnings,
+                )
+                final_observation = log_finalization.observation
+                final_log = log_finalization.log
+                local_log_path = log_finalization.local_path
+                diagnostic_log_ready = bool(
+                    log_finalization.stable
+                    and final_log is not None
+                    and local_log_path is not None
+                )
+                if log_finalization.error is not None:
+                    operational_error = log_finalization.error
+                    operational_reason = log_finalization.reason
+                    operational_timed_out = log_finalization.timed_out
+                    break
+                if not _has_valid_zero_error_completion(final_log):
+                    break
+                continue
+
+            if (
+                downloaded_gds_size != expected.gds_size
+                or downloaded_gds_digest != expected.gds_digest
+            ):
+                gds_download_mismatch = True
+                final_observation = refreshed
+                _cleanup_local_download_temp(temporary, budget, result_warnings)
+                continue
+
+            if _remote_gds_fingerprint(refreshed) != _remote_gds_fingerprint(
+                expected
+            ):
+                final_observation = refreshed
+                _cleanup_local_download_temp(temporary, budget, result_warnings)
+                continue
+
+            validated_observation = refreshed
+
+            def validate_remote_snapshot() -> None:
+                nonlocal validated_observation
+                try:
+                    latest = _observe_remote_artifacts(
+                        runner,
+                        paths,
+                        budget,
+                        finalizing=True,
+                    )
+                    budget.timeout(finalizing=True)
+                except Exception as exc:
+                    raise _RemoteFinalizationFailure(
+                        "failed to validate remote XStream artifacts before "
+                        f"GDS publication: {exc}",
+                        GdsExportReason.TRANSPORT_ERROR,
+                        timed_out=_exception_timed_out(exc),
+                    ) from exc
+                validated_observation = latest
+                if (
+                    _remote_log_fingerprint(latest)
+                    != _remote_log_fingerprint(expected)
+                    or _remote_gds_fingerprint(latest)
+                    != _remote_gds_fingerprint(expected)
+                ):
+                    raise _RemoteSnapshotChanged(latest)
+
+            try:
+                budget.timeout(finalizing=True)
+                _publish_file(
+                    temporary,
+                    inputs.output_path,
+                    validator=validate_remote_snapshot,
+                )
+                local_gds_path = inputs.output_path
+                final_observation = validated_observation
+                if budget.remaining(finalizing=True) <= 0.0:
+                    result_warnings.append(
+                        "GDS publication completed after the export deadline; "
+                        "remote staging retained"
+                    )
+            except _RemoteSnapshotChanged as exc:
+                final_observation = exc.observation
+                _cleanup_local_download_temp(temporary, budget, result_warnings)
+                if (
+                    _remote_log_fingerprint(final_observation)
+                    != _remote_log_fingerprint(expected)
+                ):
+                    log_finalization = _stabilize_remote_log(
+                        client,
+                        runner,
+                        inputs,
+                        paths,
+                        budget,
+                        final_observation,
+                        result_warnings,
+                    )
+                    final_observation = log_finalization.observation
+                    final_log = log_finalization.log
+                    local_log_path = log_finalization.local_path
+                    diagnostic_log_ready = bool(
+                        log_finalization.stable
+                        and final_log is not None
+                        and local_log_path is not None
+                    )
+                    if log_finalization.error is not None:
+                        operational_error = log_finalization.error
+                        operational_reason = log_finalization.reason
+                        operational_timed_out = log_finalization.timed_out
+                        break
+                    if not _has_valid_zero_error_completion(final_log):
+                        break
+                continue
+            except _RemoteFinalizationFailure as exc:
+                operational_error = str(exc)
+                operational_reason = exc.reason
+                operational_timed_out = exc.timed_out
+            except _BudgetExpired as exc:
+                operational_error = str(exc)
+                operational_reason = GdsExportReason.PUBLICATION_ERROR
+                operational_timed_out = True
+            except (OSError, ValueError, TypeError) as exc:
+                operational_error = f"failed to publish remote XStream GDS: {exc}"
+                operational_reason = GdsExportReason.PUBLICATION_ERROR
+            finally:
+                _cleanup_local_download_temp(
+                    temporary,
+                    budget,
+                    result_warnings,
+                )
+            break
+        else:
+            if gds_download_mismatch:
+                operational_error = (
+                    "downloaded remote XStream GDS content did not stabilize"
+                )
+                operational_reason = GdsExportReason.TRANSPORT_ERROR
+            else:
+                operational_error = (
+                    "remote XStream artifacts did not stabilize before GDS "
+                    "publication"
+                )
+                operational_reason = GdsExportReason.PUBLICATION_ERROR
+
+    final_outcome = _PollOutcome(
+        observation=final_observation,
+        log=final_log,
+        saw_evidence=(
+            outcome.saw_evidence
+            or _observation_has_evidence(final_observation, final_log)
+        ),
+        deadline_expired=outcome.deadline_expired,
+    )
+    errors = _result_errors(
+        final_outcome,
+        skill_errors=skill_errors,
+        cleanup_failures=cleanup_failures,
+    )
+    if final_log is not None:
+        result_warnings.extend(final_log.warnings)
+
+    if operational_error is not None:
+        errors.append(operational_error)
+        status = ExecutionStatus.ERROR
+        reason = operational_reason or GdsExportReason.TRANSPORT_ERROR
+        timed_out = (
+            operational_timed_out
+            or budget.remaining(finalizing=True) <= 0.0
+        )
+    else:
+        status, reason, timed_out = _classify_export(
+            cleanup_failures=cleanup_failures,
+            log=final_log,
+            skill_errors=skill_errors,
+            launch_indeterminate=launch_indeterminate,
+            saw_evidence=final_outcome.saw_evidence,
+            gds_present=final_observation.gds_present,
+            gds_size=final_observation.gds_size,
+            gds_published=local_gds_path is not None,
+            deadline_expired=outcome.deadline_expired,
+        )
+
+    if final_observation.gds_present and local_gds_path is None:
+        _discard_remote_gds(runner, paths, budget, result_warnings)
+
+    remote_files_retained: bool | None = True
+    should_cleanup = (
+        inputs.cleanup_policy == "success" and status == ExecutionStatus.SUCCESS
+    ) or (
+        inputs.cleanup_policy == "always" and diagnostic_log_ready
+    )
+    if should_cleanup:
+        remote_files_retained = _cleanup_remote_run(
+            runner,
+            paths,
+            budget,
+            result_warnings,
+        )
+
+    return GdsExportResult(
+        status=status,
+        reason=reason,
+        timed_out=timed_out,
+        library=inputs.library,
+        cell=inputs.cell,
+        view=inputs.view,
+        execution_time=budget.elapsed(),
+        local_gds_path=local_gds_path,
+        local_log_path=local_log_path,
+        log_result=final_log,
+        errors=tuple(errors),
+        warnings=tuple(result_warnings),
+        remote_run_dir=paths.run_dir.as_posix(),
+        remote_files_retained=remote_files_retained,
+    )
+
+
+def _remote_paths_are_owned(paths: _RemoteExportPaths) -> bool:
+    return bool(
+        paths.owned_root.is_absolute()
+        and ".." not in paths.owned_root.parts
+        and paths.run_dir.parent == paths.owned_root
+        and re.fullmatch(r"[0-9a-f]{32}", paths.run_dir.name)
+        and paths.gds == paths.run_dir / "output.gds"
+        and paths.log == paths.run_dir / "xstream.log"
+        and paths.stream_map == paths.run_dir / "stream.map"
+        and "\\" not in paths.run_dir.as_posix()
+    )
+
+
+def _discard_remote_gds(
+    runner: object,
+    paths: _RemoteExportPaths,
+    budget: _Budget,
+    warnings: list[str],
+) -> None:
+    if not _remote_paths_are_owned(paths):
+        warnings.append("refused to discard GDS outside owned XStream run")
+        return
+    if budget.remaining(finalizing=True) <= 0.0:
+        warnings.append(
+            "remote GDS discard skipped because the export deadline expired"
+        )
+        return
+    try:
+        result = getattr(runner, "run_command")(
+            _remote_delete_command(paths, remove_run=False),
+            timeout=budget.timeout(finalizing=True),
+        )
+        returncode, stdout, stderr = _command_result_fields(result)
+    except Exception as exc:
+        warnings.append(f"failed to discard unvalidated remote GDS: {exc}")
+        return
+    if returncode != 0:
+        detail = stderr.strip() or stdout.strip() or (
+            f"exit status {returncode}"
+        )
+        warnings.append(f"failed to discard unvalidated remote GDS: {detail}")
+
+
+_REMOTE_DISCONNECT_FRAGMENTS = (
+    "connection reset",
+    "connection closed",
+    "broken pipe",
+    "connection timed out",
+    "no route to host",
+    "could not resolve hostname",
+    "kex_exchange_identification",
+)
+
+
+def _cleanup_remote_run(
+    runner: object,
+    paths: _RemoteExportPaths,
+    budget: _Budget,
+    warnings: list[str],
+) -> bool | None:
+    if not _remote_paths_are_owned(paths):
+        warnings.append("refused to clean unowned remote XStream path")
+        return True
+    if budget.remaining(finalizing=True) <= 0.0:
+        warnings.append(
+            "remote cleanup skipped because the export deadline expired"
+        )
+        return True
+    try:
+        result = getattr(runner, "run_command")(
+            _remote_delete_command(paths, remove_run=True),
+            timeout=budget.timeout(finalizing=True),
+        )
+        returncode, stdout, stderr = _command_result_fields(result)
+    except _BudgetExpired:
+        warnings.append(
+            "remote cleanup skipped because the export deadline expired"
+        )
+        return True
+    except PermissionError as exc:
+        warnings.append(f"remote XStream cleanup failed: {exc}")
+        return True
+    except Exception as exc:
+        warnings.append(f"remote XStream cleanup could not be verified: {exc}")
+        return None
+    if returncode == 0:
+        if budget.remaining(finalizing=True) <= 0.0:
+            warnings.append(
+                "remote XStream cleanup completed after the export deadline"
+            )
+        return False
+
+    detail = stderr.strip() or stdout.strip() or f"exit status {returncode}"
+    if returncode == 255 or any(
+        fragment in detail.lower()
+        for fragment in _REMOTE_DISCONNECT_FRAGMENTS
+    ):
+        warnings.append(f"remote XStream cleanup could not be verified: {detail}")
+        return None
+    warnings.append(f"remote XStream cleanup failed: {detail}")
+    return True
+
+
+def _export_gds_local(
+    client: object,
+    inputs: _ExportInputs,
+    budget: _Budget,
+    recovery_hook: Callable[[], object] | None,
+) -> GdsExportResult:
+    run_dir = inputs.output_path.parent / (
+        f".{inputs.output_path.name}.xstream-{uuid.uuid4().hex}"
+    )
+    paths = _ExportPaths(
+        run_dir=run_dir,
+        gds=run_dir / "output.gds",
+        log=run_dir / "xstream.log",
+        snapshot_log=run_dir / "xstream-snapshot.log",
+        diagnostic_log=run_dir / "bridge-diagnostic.log",
+    )
+    run_created = False
+    try:
+        parents = tuple(
+            dict.fromkeys((inputs.output_path.parent, inputs.log_path.parent))
+        )
+        for parent in parents:
+            budget.timeout(finalizing=False)
+            parent.mkdir(parents=True, exist_ok=True)
+        budget.timeout(finalizing=False)
+        paths.run_dir.mkdir(parents=False, exist_ok=False)
+        run_created = True
+    except (_BudgetExpired, OSError) as exc:
+        return _staging_error_result(
+            inputs,
+            budget,
+            f"failed to create local XStream staging: {exc}",
+            local_run_dir=paths.run_dir if run_created else None,
+            timed_out=isinstance(exc, _BudgetExpired),
+        )
+
+    request = XStreamExportRequest(
+        library=inputs.library,
+        top_cell=inputs.cell,
+        view=inputs.view,
+        stream_file=str(paths.gds),
+        layer_map=str(inputs.stream_map),
+        log_file=str(paths.log),
+        run_dir=str(paths.run_dir),
+    )
+    skill_errors: tuple[str, ...] = ()
+    cleanup_failures: tuple[str, ...] = ()
+    launch_indeterminate = False
+    should_poll = False
+    warnings: list[str] = []
+    try:
+        skill_code = xstream_export_gds_skill(request)
+        effective_skill_timeout = budget.timeout(
+            finalizing=False,
+            cap=inputs.skill_timeout,
+        )
+        response = getattr(client, "execute_skill")(
+            skill_code,
+            timeout=effective_skill_timeout,
+        )
+        warnings.extend(_response_warnings(response))
+    except _BudgetExpired as exc:
+        outcome = _PollOutcome(
+            observation=_ArtifactObservation(),
+            log=None,
+            saw_evidence=False,
+            deadline_expired=True,
+            staging_error=str(exc),
+        )
+        return _finalize_local_export(
+            inputs,
+            paths,
+            budget,
+            outcome,
+            skill_errors=(),
+            cleanup_failures=(),
+            launch_indeterminate=False,
+            warnings=warnings,
+        )
+    except Exception as exc:
+        skill_errors = (f"SKILL execution failed: {exc}",)
+    else:
+        try:
+            response_errors, response_status, response_output = response_fields(
+                response
+            )
+        except Exception as exc:
+            skill_errors = (f"failed to normalize SKILL response: {exc}",)
+        else:
+            skill_errors = tuple(response_errors)
+            response_succeeded = _response_succeeded(response_status)
+            if not response_succeeded and not skill_errors:
+                skill_errors = (
+                    "SKILL request returned non-success status without errors: "
+                    f"{response_status!r}",
+                )
+
+            if not response_succeeded or skill_errors:
+                launch_indeterminate = _is_indeterminate_skill_timeout(
+                    skill_errors
+                )
+                should_poll = launch_indeterminate
+            else:
+                try:
+                    request_response = _parse_xstream_request_response(
+                        response_output
+                    )
+                except ValueError as exc:
+                    skill_errors = (str(exc),)
+                else:
+                    cleanup_failures = request_response.cleanup_failures
+                    if request_response.state == "failed":
+                        skill_errors = (
+                            request_response.body_error
+                            or "XStream request body failed",
+                        )
+                    elif not cleanup_failures:
+                        should_poll = True
+
+    outcome = _poll_local_artifacts(
+        paths,
+        budget,
+        inputs.poll_interval,
+        should_poll=should_poll,
+        launch_indeterminate=launch_indeterminate,
+        recovery_hook=recovery_hook,
+        warnings=warnings,
+    )
+    return _finalize_local_export(
+        inputs,
+        paths,
+        budget,
+        outcome,
+        skill_errors=skill_errors,
+        cleanup_failures=cleanup_failures,
+        launch_indeterminate=launch_indeterminate,
+        warnings=warnings,
+    )
+
+
+def _response_succeeded(status: object) -> bool:
+    return status in (ExecutionStatus.SUCCESS, ExecutionStatus.SUCCESS.value)
+
+
+def _response_warnings(response: object) -> tuple[str, ...]:
+    if isinstance(response, dict):
+        nested = (
+            response.get("result")
+            if isinstance(response.get("result"), dict)
+            else {}
+        )
+        value = response.get("warnings") or nested.get("warnings")
+    else:
+        value = getattr(response, "warnings", None)
+    if value is None or value == "":
+        return ()
+    if isinstance(value, str):
+        return (value,)
+    if isinstance(value, (list, tuple)):
+        return tuple(str(warning) for warning in value)
+    return (str(value),)
+
+
+def _poll_local_artifacts(
+    paths: _ExportPaths,
+    budget: _Budget,
+    poll_interval: float,
+    *,
+    should_poll: bool,
+    launch_indeterminate: bool,
+    recovery_hook: Callable[[], object] | None,
+    warnings: list[str],
+) -> _PollOutcome:
+    observation = _ArtifactObservation()
+    log: XStreamLogResult | None = None
+    saw_evidence = False
+    deadline_expired = False
+    recovery_attempted = False
+
+    while True:
+        if budget.remaining(finalizing=True) <= 0.0:
+            deadline_expired = True
+            break
+        try:
+            observation = _observe_local_artifacts(paths)
+            log = (
+                parse_xstream_log(observation.log_text)
+                if observation.log_present
+                else None
+            )
+        except (OSError, ValueError, TypeError) as exc:
+            return _PollOutcome(
+                observation=observation,
+                log=log,
+                saw_evidence=saw_evidence,
+                deadline_expired=budget.remaining(finalizing=False) <= 0.0,
+                staging_error=f"failed to observe local XStream artifacts: {exc}",
+            )
+
+        progress = _observation_has_evidence(observation, log)
+        saw_evidence = saw_evidence or progress
+        if (
+            launch_indeterminate
+            and progress
+            and not recovery_attempted
+            and recovery_hook is not None
+            and budget.remaining(finalizing=False) > 0.0
+        ):
+            recovery_attempted = True
+            try:
+                recovery_hook()
+            except Exception as exc:
+                warnings.append(f"recovery hook failed: {exc}")
+
+        if _observation_is_terminal(observation, log):
+            deadline_expired = budget.remaining(finalizing=False) <= 0.0
+            break
+        if not should_poll:
+            deadline_expired = budget.remaining(finalizing=False) <= 0.0
+            break
+
+        remaining = budget.remaining(finalizing=False)
+        if remaining <= 0.0:
+            deadline_expired = True
+            break
+        delay = min(poll_interval, remaining)
+        if delay <= 0.0:
+            deadline_expired = True
+            break
+        try:
+            _SLEEP(delay)
+        except (OSError, OverflowError) as exc:
+            return _PollOutcome(
+                observation=observation,
+                log=log,
+                saw_evidence=saw_evidence,
+                deadline_expired=budget.remaining(finalizing=False) <= 0.0,
+                staging_error=f"failed while polling local artifacts: {exc}",
+            )
+
+    return _PollOutcome(
+        observation=observation,
+        log=log,
+        saw_evidence=saw_evidence,
+        deadline_expired=deadline_expired,
+    )
+
+
+def _observe_local_artifacts(paths: _ExportPaths) -> _ArtifactObservation:
+    log_present, log_bytes, log_text = _read_local_log_snapshot(paths.log)
+    gds_present, gds_size = _local_file_size(paths.gds)
+    return _ArtifactObservation(
+        log_present=log_present,
+        log_size=len(log_bytes),
+        log_bytes=log_bytes,
+        log_text=log_text,
+        gds_present=gds_present,
+        gds_size=gds_size,
+    )
+
+
+def _read_local_log_snapshot(path: Path) -> tuple[bool, bytes, str]:
+    try:
+        data = path.read_bytes()
+    except FileNotFoundError:
+        return False, b"", ""
+    except OSError as exc:
+        raise OSError(f"failed to read {path}: {exc}") from exc
+    return True, data, data.decode("utf-8", errors="replace")
+
+
+def _local_file_size(path: Path) -> tuple[bool, int]:
+    try:
+        metadata = path.stat()
+    except FileNotFoundError:
+        return False, 0
+    except OSError as exc:
+        raise OSError(f"failed to stat {path}: {exc}") from exc
+    if not stat.S_ISREG(metadata.st_mode):
+        raise OSError(f"staged artifact is not a regular file: {path}")
+    return True, metadata.st_size
+
+
+def _observation_has_evidence(
+    observation: _ArtifactObservation,
+    log: XStreamLogResult | None,
+) -> bool:
+    return (
+        observation.log_size > 0
+        or observation.gds_size > 0
+        or (log is not None and (log.completed or bool(log.terminal_failures)))
+    )
+
+
+def _observation_is_terminal(
+    observation: _ArtifactObservation,
+    log: XStreamLogResult | None,
+) -> bool:
+    if log is None:
+        return False
+    if log.terminal_failures:
+        return True
+    if log.completed and (
+        log.parse_errors
+        or log.error_count is None
+        or log.warning_count is None
+    ):
+        return True
+    if log.completed and log.error_count != 0:
+        return True
+    return (
+        _has_valid_zero_error_completion(log)
+        and observation.gds_present
+        and observation.gds_size > 0
+    )
+
+
+def _has_valid_zero_error_completion(log: XStreamLogResult | None) -> bool:
+    return bool(
+        log is not None
+        and log.completed
+        and log.error_count == 0
+        and log.warning_count is not None
+        and not log.terminal_failures
+        and not log.parse_errors
+    )
+
+
+def _refresh_local_log_outcome(
+    paths: _ExportPaths,
+    outcome: _PollOutcome,
+) -> _PollOutcome:
+    log_present, log_bytes, log_text = _read_local_log_snapshot(paths.log)
+    observation = _ArtifactObservation(
+        log_present=log_present,
+        log_size=len(log_bytes),
+        log_bytes=log_bytes,
+        log_text=log_text,
+        gds_present=outcome.observation.gds_present,
+        gds_size=outcome.observation.gds_size,
+    )
+    log = parse_xstream_log(log_text) if log_present else None
+    return _PollOutcome(
+        observation=observation,
+        log=log,
+        saw_evidence=(
+            outcome.saw_evidence
+            or _observation_has_evidence(observation, log)
+        ),
+        deadline_expired=outcome.deadline_expired,
+        staging_error=outcome.staging_error,
+    )
+
+
+def _publish_local_log_snapshot(
+    inputs: _ExportInputs,
+    paths: _ExportPaths,
+    budget: _Budget,
+    outcome: _PollOutcome,
+    errors: list[str],
+) -> tuple[Path | None, str | None, bool]:
+    log_source: Path | None = None
+    if outcome.observation.log_present and outcome.observation.log_size > 0:
+        try:
+            budget.timeout(finalizing=True)
+            paths.snapshot_log.write_bytes(outcome.observation.log_bytes)
+            log_source = paths.snapshot_log
+        except _BudgetExpired as exc:
+            return None, str(exc), True
+        except OSError as exc:
+            return None, f"failed to stage XStream log snapshot: {exc}", False
+    else:
+        try:
+            budget.timeout(finalizing=True)
+            paths.diagnostic_log.write_text(
+                _diagnostic_log_text(inputs, errors),
+                encoding="utf-8",
+            )
+            log_source = paths.diagnostic_log
+        except _BudgetExpired as exc:
+            return None, str(exc), True
+        except (OSError, UnicodeError) as exc:
+            return None, f"failed to recover diagnostic log: {exc}", False
+
+    try:
+        budget.timeout(finalizing=True)
+        _publish_file(log_source, inputs.log_path)
+        if budget.remaining(finalizing=True) <= 0.0:
+            return (
+                inputs.log_path,
+                "export time budget exhausted after XStream log publication",
+                True,
+            )
+    except _BudgetExpired as exc:
+        return None, str(exc), True
+    except OSError as exc:
+        return None, f"failed to publish XStream log: {exc}", False
+    return inputs.log_path, None, False
+
+
+def _finalize_local_export(
+    inputs: _ExportInputs,
+    paths: _ExportPaths,
+    budget: _Budget,
+    outcome: _PollOutcome,
+    *,
+    skill_errors: tuple[str, ...],
+    cleanup_failures: tuple[str, ...],
+    launch_indeterminate: bool,
+    warnings: list[str],
+) -> GdsExportResult:
+    final_outcome = outcome
+    publication_error: str | None = None
+    publication_timed_out = False
+    should_refresh_log = outcome.staging_error is None
+    if should_refresh_log:
+        try:
+            budget.timeout(finalizing=True)
+            final_outcome = _refresh_local_log_outcome(paths, outcome)
+            if budget.remaining(finalizing=True) <= 0.0:
+                publication_error = (
+                    "export time budget exhausted while snapshotting XStream log"
+                )
+                publication_timed_out = True
+        except _BudgetExpired as exc:
+            publication_error = str(exc)
+            publication_timed_out = True
+        except (OSError, ValueError, TypeError) as exc:
+            publication_error = f"failed to snapshot XStream log: {exc}"
+
+    errors = _result_errors(
+        final_outcome,
+        skill_errors=skill_errors,
+        cleanup_failures=cleanup_failures,
+    )
+    result_warnings = list(warnings)
+    if final_outcome.log is not None:
+        result_warnings.extend(final_outcome.log.warnings)
+
+    local_log_path: Path | None = None
+    local_gds_path: Path | None = None
+    final_gds_present = final_outcome.observation.gds_present
+    final_gds_size = final_outcome.observation.gds_size
+
+    if publication_error is None:
+        (
+            local_log_path,
+            publication_error,
+            publication_timed_out,
+        ) = _publish_local_log_snapshot(
+            inputs,
+            paths,
+            budget,
+            final_outcome,
+            errors,
+        )
+
+    if publication_error is None and local_log_path is not None:
+        for _ in range(_MAX_FINAL_LOG_REFRESHES):
+            try:
+                budget.timeout(finalizing=True)
+                refreshed_outcome = _refresh_local_log_outcome(
+                    paths,
+                    final_outcome,
+                )
+            except _BudgetExpired as exc:
+                publication_error = str(exc)
+                publication_timed_out = True
+                break
+            except (OSError, ValueError, TypeError) as exc:
+                publication_error = (
+                    "failed to stabilize XStream log before final "
+                    f"publication: {exc}"
+                )
+                break
+
+            previous_snapshot = (
+                final_outcome.observation.log_present,
+                final_outcome.observation.log_bytes,
+            )
+            refreshed_snapshot = (
+                refreshed_outcome.observation.log_present,
+                refreshed_outcome.observation.log_bytes,
+            )
+            if refreshed_snapshot == previous_snapshot:
+                break
+
+            final_outcome = refreshed_outcome
+            errors = _result_errors(
+                final_outcome,
+                skill_errors=skill_errors,
+                cleanup_failures=cleanup_failures,
+            )
+            result_warnings = list(warnings)
+            if final_outcome.log is not None:
+                result_warnings.extend(final_outcome.log.warnings)
+            (
+                local_log_path,
+                publication_error,
+                refresh_timed_out,
+            ) = _publish_local_log_snapshot(
+                inputs,
+                paths,
+                budget,
+                final_outcome,
+                errors,
+            )
+            publication_timed_out = (
+                publication_timed_out or refresh_timed_out
+            )
+            if publication_error is not None:
+                break
+        else:
+            publication_error = (
+                "XStream log did not stabilize before final publication"
+            )
+
+    gds_publication_allowed = (
+        final_outcome.staging_error is None
+        and publication_error is None
+        and local_log_path is not None
+        and not cleanup_failures
+        and (not skill_errors or _is_indeterminate_skill_timeout(skill_errors))
+        and _has_valid_zero_error_completion(final_outcome.log)
+    )
+    gds_revalidated = False
+    if gds_publication_allowed:
+        source_snapshot_error: str | None = None
+        for _ in range(_MAX_FINAL_LOG_REFRESHES):
+            source_snapshot_error = None
+            try:
+                budget.timeout(finalizing=True)
+                refreshed_outcome = _refresh_local_log_outcome(
+                    paths,
+                    final_outcome,
+                )
+            except _BudgetExpired as exc:
+                publication_error = str(exc)
+                publication_timed_out = True
+                break
+            except (OSError, ValueError, TypeError) as exc:
+                publication_error = (
+                    "failed to recheck XStream log before GDS publication: "
+                    f"{exc}"
+                )
+                break
+
+            previous_snapshot = (
+                final_outcome.observation.log_present,
+                final_outcome.observation.log_bytes,
+            )
+            refreshed_snapshot = (
+                refreshed_outcome.observation.log_present,
+                refreshed_outcome.observation.log_bytes,
+            )
+            if refreshed_snapshot == previous_snapshot:
+                try:
+                    budget.timeout(finalizing=True)
+                    final_gds_present, final_gds_size = _local_file_size(
+                        paths.gds
+                    )
+                except _BudgetExpired as exc:
+                    publication_error = str(exc)
+                    publication_timed_out = True
+                    break
+                except OSError as exc:
+                    publication_error = (
+                        f"failed to revalidate staged GDS: {exc}"
+                    )
+                    break
+
+                try:
+                    budget.timeout(finalizing=True)
+                    refreshed_outcome = _refresh_local_log_outcome(
+                        paths,
+                        final_outcome,
+                    )
+                except _BudgetExpired as exc:
+                    publication_error = str(exc)
+                    publication_timed_out = True
+                    break
+                except (OSError, ValueError, TypeError) as exc:
+                    publication_error = (
+                        "failed to recheck XStream log after GDS "
+                        f"revalidation: {exc}"
+                    )
+                    break
+
+                refreshed_snapshot = (
+                    refreshed_outcome.observation.log_present,
+                    refreshed_outcome.observation.log_bytes,
+                )
+                if refreshed_snapshot == previous_snapshot:
+                    if not final_gds_present or final_gds_size <= 0:
+                        gds_revalidated = True
+                        break
+
+                    def validate_log_before_replace() -> None:
+                        budget.timeout(finalizing=True)
+                        latest_outcome = _refresh_local_log_outcome(
+                            paths,
+                            final_outcome,
+                        )
+                        budget.timeout(finalizing=True)
+                        latest_snapshot = (
+                            latest_outcome.observation.log_present,
+                            latest_outcome.observation.log_bytes,
+                        )
+                        if latest_snapshot != previous_snapshot:
+                            raise _LogSnapshotChanged(latest_outcome)
+
+                    try:
+                        budget.timeout(finalizing=True)
+                        _publish_file(
+                            paths.gds,
+                            inputs.output_path,
+                            validator=validate_log_before_replace,
+                        )
+                        local_gds_path = inputs.output_path
+                        gds_revalidated = True
+                        if budget.remaining(finalizing=True) <= 0.0:
+                            result_warnings.append(
+                                "GDS publication completed after the export "
+                                "deadline; local staging retained"
+                            )
+                        break
+                    except _SourceSnapshotChanged as exc:
+                        source_snapshot_error = str(exc)
+                        continue
+                    except _LogSnapshotChanged as exc:
+                        refreshed_outcome = exc.outcome
+                    except _EmptyPublicationFileError:
+                        final_gds_present = True
+                        final_gds_size = 0
+                        gds_revalidated = True
+                        break
+                    except _BudgetExpired as exc:
+                        publication_error = str(exc)
+                        publication_timed_out = True
+                        break
+                    except (OSError, ValueError, TypeError) as exc:
+                        publication_error = f"failed to publish GDS: {exc}"
+                        break
+
+            final_outcome = refreshed_outcome
+            errors = _result_errors(
+                final_outcome,
+                skill_errors=skill_errors,
+                cleanup_failures=cleanup_failures,
+            )
+            result_warnings = list(warnings)
+            if final_outcome.log is not None:
+                result_warnings.extend(final_outcome.log.warnings)
+            (
+                local_log_path,
+                publication_error,
+                refresh_timed_out,
+            ) = _publish_local_log_snapshot(
+                inputs,
+                paths,
+                budget,
+                final_outcome,
+                errors,
+            )
+            publication_timed_out = (
+                publication_timed_out or refresh_timed_out
+            )
+            if (
+                publication_error is not None
+                or not _has_valid_zero_error_completion(final_outcome.log)
+            ):
+                break
+        else:
+            if source_snapshot_error is None:
+                publication_error = (
+                    "XStream log did not stabilize before GDS publication"
+                )
+            else:
+                publication_error = (
+                    "staged GDS did not stabilize before publication: "
+                    f"{source_snapshot_error}"
+                )
+
+    gds_publication_allowed = (
+        final_outcome.staging_error is None
+        and publication_error is None
+        and local_log_path is not None
+        and not cleanup_failures
+        and (not skill_errors or _is_indeterminate_skill_timeout(skill_errors))
+        and _has_valid_zero_error_completion(final_outcome.log)
+    )
+
+    can_publish_gds = (
+        gds_publication_allowed
+        and publication_error is None
+        and gds_revalidated
+        and final_gds_present
+        and final_gds_size > 0
+    )
+
+    if final_gds_present and not can_publish_gds:
+        _remove_unvalidated_gds(paths, budget, result_warnings)
+
+    if final_outcome.staging_error is not None:
+        if publication_error is not None:
+            errors.append(publication_error)
+        status = ExecutionStatus.ERROR
+        reason = GdsExportReason.STAGING_ERROR
+        timed_out = (
+            final_outcome.deadline_expired
+            or budget.remaining(finalizing=True) <= 0.0
+        )
+    elif publication_error is not None:
+        errors.append(publication_error)
+        status = ExecutionStatus.ERROR
+        reason = GdsExportReason.PUBLICATION_ERROR
+        timed_out = (
+            publication_timed_out
+            or budget.remaining(finalizing=True) <= 0.0
+        )
+    else:
+        status, reason, timed_out = _classify_export(
+            cleanup_failures=cleanup_failures,
+            log=final_outcome.log,
+            skill_errors=skill_errors,
+            launch_indeterminate=launch_indeterminate,
+            saw_evidence=final_outcome.saw_evidence,
+            gds_present=final_gds_present,
+            gds_size=final_gds_size,
+            gds_published=local_gds_path is not None,
+            deadline_expired=final_outcome.deadline_expired,
+        )
+
+    local_run_dir: Path | None = paths.run_dir
+    should_cleanup = (
+        inputs.cleanup_policy == "success" and status == ExecutionStatus.SUCCESS
+    ) or inputs.cleanup_policy == "always"
+    if inputs.cleanup_policy == "always" and local_log_path is None:
+        should_cleanup = False
+    if should_cleanup:
+        if budget.remaining(finalizing=True) <= 0.0:
+            result_warnings.append(
+                "cleanup skipped because the export deadline expired"
+            )
+        else:
+            try:
+                shutil.rmtree(paths.run_dir)
+            except FileNotFoundError:
+                local_run_dir = None
+            except OSError as exc:
+                result_warnings.append(
+                    f"local XStream cleanup failed: {exc}"
+                )
+            else:
+                local_run_dir = None
+                if budget.remaining(finalizing=True) <= 0.0:
+                    result_warnings.append(
+                        "local XStream cleanup completed after the export "
+                        "deadline"
+                    )
+
+    return GdsExportResult(
+        status=status,
+        reason=reason,
+        timed_out=timed_out,
+        library=inputs.library,
+        cell=inputs.cell,
+        view=inputs.view,
+        execution_time=budget.elapsed(),
+        local_gds_path=local_gds_path,
+        local_log_path=local_log_path,
+        log_result=final_outcome.log,
+        errors=tuple(errors),
+        warnings=tuple(result_warnings),
+        local_run_dir=local_run_dir,
+    )
+
+
+def _remove_unvalidated_gds(
+    paths: _ExportPaths,
+    budget: _Budget,
+    warnings: list[str],
+) -> None:
+    try:
+        budget.timeout(finalizing=True)
+        paths.gds.unlink()
+    except _BudgetExpired:
+        warnings.append(
+            "export time budget exhausted before unvalidated GDS cleanup"
+        )
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        warnings.append(f"failed to remove unvalidated GDS: {exc}")
+
+
+def _result_errors(
+    outcome: _PollOutcome,
+    *,
+    skill_errors: tuple[str, ...],
+    cleanup_failures: tuple[str, ...],
+) -> list[str]:
+    errors = list(cleanup_failures)
+    errors.extend(skill_errors)
+    if outcome.staging_error is not None:
+        errors.append(outcome.staging_error)
+    if outcome.log is not None:
+        errors.extend(outcome.log.terminal_failures)
+        errors.extend(outcome.log.parse_errors)
+        errors.extend(outcome.log.errors)
+        if outcome.log.error_count not in (None, 0):
+            errors.append(
+                f"XStream reported {outcome.log.error_count} error(s)"
+            )
+    return errors
+
+
+def _diagnostic_log_text(
+    inputs: _ExportInputs,
+    errors: list[str],
+) -> str:
+    lines = [
+        "Virtuoso Bridge XStream export diagnostics",
+        f"library: {inputs.library}",
+        f"cell: {inputs.cell}",
+        f"view: {inputs.view}",
+    ]
+    if errors:
+        lines.extend(f"error: {error}" for error in errors)
+    else:
+        lines.append("error: no XStream log was produced for this run")
+    return "\n".join(lines) + "\n"
+
+
+class _EmptyPublicationFileError(OSError):
+    """Raised before replacement when a copied publication file is empty."""
+
+
+class _SourceSnapshotChanged(OSError):
+    """Raised when a publication source changes before replacement."""
+
+
+def _publication_temp_path(destination: Path) -> Path:
+    return destination.parent / f".vbp-{uuid.uuid4().hex}.tmp"
+
+
+def _publication_source_snapshot(
+    metadata: os.stat_result,
+) -> tuple[int, int, int, int, int]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+    )
+
+
+def _publish_file(
+    source: Path,
+    destination: Path,
+    *,
+    validator: Callable[[], None] | None = None,
+) -> None:
+    temporary = _publication_temp_path(destination)
+    try:
+        with source.open("rb", buffering=0) as source_file:
+            source_metadata_before = os.fstat(source_file.fileno())
+            source_snapshot_before = _publication_source_snapshot(
+                source_metadata_before
+            )
+            try:
+                destination_metadata = destination.stat()
+            except FileNotFoundError:
+                destination_metadata = None
+                publication_mode = stat.S_IMODE(source_metadata_before.st_mode)
+            else:
+                publication_mode = stat.S_IMODE(destination_metadata.st_mode)
+
+            with temporary.open("wb") as temporary_file:
+                shutil.copyfileobj(source_file, temporary_file)
+                temporary_file.flush()
+                source_metadata_after = os.fstat(source_file.fileno())
+                temporary_size = os.fstat(temporary_file.fileno()).st_size
+
+            source_snapshot_after = _publication_source_snapshot(
+                source_metadata_after
+            )
+            if source_snapshot_after != source_snapshot_before:
+                raise _SourceSnapshotChanged(
+                    f"source changed while copying {source}"
+                )
+            if temporary_size != source_metadata_before.st_size:
+                raise _SourceSnapshotChanged(
+                    "copied publication size does not match source snapshot "
+                    f"for {source}"
+                )
+            if temporary_size <= 0:
+                raise _EmptyPublicationFileError(
+                    f"refusing to publish empty file copied from {source}"
+                )
+
+            temporary.chmod(publication_mode)
+            temporary_metadata = temporary.stat()
+            if (
+                os.name == "posix"
+                and destination_metadata is not None
+                and temporary_metadata.st_uid != destination_metadata.st_uid
+            ):
+                raise PermissionError(
+                    "refusing to replace destination with a different owner"
+                )
+
+            try:
+                current_source_metadata = source.stat()
+            except FileNotFoundError as exc:
+                raise _SourceSnapshotChanged(
+                    f"source path disappeared before publication: {source}"
+                ) from exc
+            if (
+                _publication_source_snapshot(current_source_metadata)
+                != source_snapshot_after
+            ):
+                raise _SourceSnapshotChanged(
+                    f"source path changed before publication: {source}"
+                )
+
+            if validator is not None:
+                validator()
+                source_metadata_after_validator = os.fstat(
+                    source_file.fileno()
+                )
+                try:
+                    current_source_metadata = source.stat()
+                except FileNotFoundError as exc:
+                    raise _SourceSnapshotChanged(
+                        "source path disappeared during publication validation: "
+                        f"{source}"
+                    ) from exc
+                if (
+                    _publication_source_snapshot(
+                        source_metadata_after_validator
+                    )
+                    != source_snapshot_after
+                    or _publication_source_snapshot(current_source_metadata)
+                    != source_snapshot_after
+                ):
+                    raise _SourceSnapshotChanged(
+                        "source changed during publication validation: "
+                        f"{source}"
+                    )
+            os.replace(temporary, destination)
+    finally:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+def _staging_error_result(
+    inputs: _ExportInputs,
+    budget: _Budget,
+    error: str,
+    *,
+    local_run_dir: Path | None,
+    timed_out: bool,
+) -> GdsExportResult:
+    return GdsExportResult(
+        status=ExecutionStatus.ERROR,
+        reason=GdsExportReason.STAGING_ERROR,
+        timed_out=(
+            timed_out
+            or budget.remaining(finalizing=False) <= 0.0
+            or budget.remaining(finalizing=True) <= 0.0
+        ),
+        library=inputs.library,
+        cell=inputs.cell,
+        view=inputs.view,
+        execution_time=budget.elapsed(),
+        errors=(error,),
+        local_run_dir=local_run_dir,
+    )
+
+
+__all__ = ["GdsExportReason", "GdsExportResult", "export_gds"]

--- a/src/virtuoso_bridge/virtuoso/layout/xstream.py
+++ b/src/virtuoso_bridge/virtuoso/layout/xstream.py
@@ -1,0 +1,347 @@
+"""Pure helpers for requesting and inspecting XStream GDS export."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Literal, cast
+
+from virtuoso_bridge.virtuoso.ops import escape_skill_string
+from virtuoso_bridge.virtuoso.skill_output import (
+    is_single_complete_skill_list,
+    parse_sexpr,
+    tokenize_top_level,
+)
+
+
+_XSTREAM_FIELDS = (
+    ("library", "library", "vbOldLibrary"),
+    ("top_cell", "topCell", "vbOldTopCell"),
+    ("view", "view", "vbOldView"),
+    ("stream_file", "strmFile", "vbOldStreamFile"),
+    ("layer_map", "layerMap", "vbOldLayerMap"),
+    ("log_file", "logFile", "vbOldLogFile"),
+    ("run_dir", "runDir", "vbOldRunDir"),
+)
+_PRODUCT_ANCHOR_RE = re.compile(
+    r"^Product[ \t]*:[ \t]*Virtuoso\(R\)[ \t]+XStream[ \t]+Out",
+    re.MULTILINE,
+)
+_STARTED_ANCHOR_RE = re.compile(
+    r"^[ \t]*Started[ \t]+at[ \t]*:",
+    re.IGNORECASE | re.MULTILINE,
+)
+_WARNING_LINE_RE = re.compile(r"^(?:WARNING(?:\s|:|\()|\*WARNING\*)")
+_ERROR_LINE_RE = re.compile(r"^(?:ERROR(?:\s|:|\()|\*ERROR\*)")
+_TRANSLATED_STRUCTURE_RE = re.compile(
+    r"\bTranslating\s+cellview\s+"
+    r"(?P<library>[^/\s]+)/(?P<cell>[^/\s]+)/(?P<view>[^/\s]+)\s+"
+    r"as\s+STRUCTURE\s+(?P<structure>\S+?)\.\s*$"
+)
+_COMPLETION_PREFIX_PATTERN = (
+    r"(?:INFO(?:[ \t]*\([ \t]*XSTRM-234[ \t]*\))?|XSTRM-234)"
+    r"[ \t]*:[ \t]*"
+)
+_COMPLETION_LINE_RE = re.compile(
+    rf"^{_COMPLETION_PREFIX_PATTERN}"
+    r"Translation completed\.(?:[ \t]+.*)?[ \t]*$"
+)
+_COMPLETION_COUNTS_RE = re.compile(
+    rf"^{_COMPLETION_PREFIX_PATTERN}"
+    r"Translation completed\.\s*"
+    r"(?P<error_quote>['\"]?)(?P<errors>\d+)(?P=error_quote)\s+"
+    r"error\(s\)\s+and\s+"
+    r"(?P<warning_quote>['\"]?)(?P<warnings>\d+)(?P=warning_quote)\s+"
+    r"warning\(s\)\s+found\.[ \t]*$"
+)
+_MAX_COMPLETION_COUNT_DIGITS = 18
+_TERMINAL_MARKERS = (
+    re.compile(
+        r"(?<![A-Za-z0-9_-])XSTRM-273(?![A-Za-z0-9_-])",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"(?<![A-Za-z0-9_])Translation[ \t]+failed(?![A-Za-z0-9_])",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"(?<![A-Za-z0-9_-])OPEN_FAILED(?![A-Za-z0-9_-])",
+        re.IGNORECASE,
+    ),
+)
+
+
+@dataclass(frozen=True)
+class XStreamExportRequest:
+    """Execution-host XStream parameters for one GDS export request."""
+
+    library: str
+    top_cell: str
+    view: str
+    stream_file: str
+    layer_map: str
+    log_file: str
+    run_dir: str
+
+
+@dataclass(frozen=True)
+class XStreamTranslatedStructure:
+    """One XStream cellview-to-GDS structure translation."""
+
+    library: str
+    cell: str
+    view: str
+    structure: str
+
+
+@dataclass(frozen=True)
+class XStreamLogResult:
+    """Parsed status and diagnostics from the current XStream log run."""
+
+    completed: bool
+    completion_line: str | None
+    error_count: int | None
+    warning_count: int | None
+    translated_structures: tuple[XStreamTranslatedStructure, ...]
+    warnings: tuple[str, ...]
+    errors: tuple[str, ...]
+    terminal_failures: tuple[str, ...]
+    parse_errors: tuple[str, ...]
+    current_run_text: str
+
+
+@dataclass(frozen=True)
+class _XStreamRequestResponse:
+    state: Literal["started", "failed"]
+    body_error: str | None
+    cleanup_failures: tuple[str, ...]
+
+
+def xstream_export_gds_skill(request: XStreamExportRequest) -> str:
+    """Render SKILL that submits an XStream export and restores its fields."""
+    escaped_values: dict[str, str] = {}
+    for request_field, _xstream_field, _old_variable in _XSTREAM_FIELDS:
+        value = getattr(request, request_field)
+        if not isinstance(value, str) or not value:
+            raise ValueError(f"{request_field} must be a nonempty string")
+        escaped_values[request_field] = escape_skill_string(value)
+
+    old_variables = " ".join(old_variable for _, _, old_variable in _XSTREAM_FIELDS)
+    captures = "".join(
+        f'{old_variable} = xstGetField("{xstream_field}") '
+        for _request_field, xstream_field, old_variable in _XSTREAM_FIELDS
+    )
+    setters = "".join(
+        f'xstSetField("{xstream_field}" "{escaped_values[request_field]}") '
+        for request_field, xstream_field, _old_variable in _XSTREAM_FIELDS
+    )
+    restorations = "".join(
+        (
+            f'vbCleanup = errset(xstSetField("{xstream_field}" '
+            f"{old_variable}) nil) "
+            "unless(vbCleanup "
+            f'vbCleanupFailures = cons("failed to restore XStream field '
+            f'{xstream_field}" vbCleanupFailures)) '
+        )
+        for _request_field, xstream_field, old_variable in _XSTREAM_FIELDS
+    )
+
+    return (
+        f"let(({old_variables} vbCaptured vbBodyAttempt vbBodyError "
+        "vbCleanup vbCleanupFailures) "
+        'vbBodyError = "XStream export request failed" '
+        "unwindProtect("
+        "progn("
+        "vbBodyAttempt = errset(progn("
+        "unless(and(isCallable('xstGetField) isCallable('xstSetField) "
+        "isCallable('xstOutDoTranslate)) "
+        'error("XStream APIs unavailable")) '
+        f"{captures}"
+        "vbCaptured = t "
+        f"{setters}"
+        "xstOutDoTranslate()) nil) "
+        'unless(vbBodyAttempt vbBodyError = sprintf(nil "%L" errset.errset)) '
+        "vbBodyAttempt) "
+        "progn("
+        "when(vbCaptured "
+        f"{restorations}"
+        ")) "
+        ") "
+        "if(vbBodyAttempt "
+        'then list("xstreamRequest" "started" nil reverse(vbCleanupFailures)) '
+        'else list("xstreamRequest" "failed" '
+        "vbBodyError reverse(vbCleanupFailures))))"
+    )
+
+
+def parse_xstream_log(text: str) -> XStreamLogResult:
+    """Parse the newest XStream Out run from log text."""
+    if not isinstance(text, str):
+        raise TypeError("text must be a string")
+
+    current_run_text = _select_current_run_text(text)
+    lines = tuple(
+        line.strip() for line in current_run_text.splitlines() if line.strip()
+    )
+
+    warnings = tuple(line for line in lines if _WARNING_LINE_RE.match(line))
+    errors = tuple(line for line in lines if _ERROR_LINE_RE.match(line))
+
+    translated_structures: list[XStreamTranslatedStructure] = []
+    terminal_failures: list[str] = []
+    for line in lines:
+        match = _TRANSLATED_STRUCTURE_RE.search(line)
+        if match is not None:
+            translated_structures.append(
+                XStreamTranslatedStructure(
+                    library=match.group("library"),
+                    cell=match.group("cell"),
+                    view=match.group("view"),
+                    structure=match.group("structure"),
+                )
+            )
+            continue
+        if any(marker.search(line) for marker in _TERMINAL_MARKERS):
+            terminal_failures.append(line)
+
+    completion_lines = tuple(
+        line for line in lines if _COMPLETION_LINE_RE.fullmatch(line)
+    )
+    completion_line = completion_lines[-1] if completion_lines else None
+    error_count = None
+    warning_count = None
+    parse_errors: tuple[str, ...] = ()
+    if completion_line is not None:
+        malformed_counts = (
+            f"malformed XStream completion counts: {completion_line}",
+        )
+        match = _COMPLETION_COUNTS_RE.fullmatch(completion_line)
+        if match is None:
+            parse_errors = malformed_counts
+        else:
+            error_digits = match.group("errors")
+            warning_digits = match.group("warnings")
+            if max(len(error_digits), len(warning_digits)) > (
+                _MAX_COMPLETION_COUNT_DIGITS
+            ):
+                parse_errors = malformed_counts
+            else:
+                try:
+                    error_count, warning_count = (
+                        int(error_digits),
+                        int(warning_digits),
+                    )
+                except ValueError:
+                    parse_errors = malformed_counts
+
+    return XStreamLogResult(
+        completed=completion_line is not None,
+        completion_line=completion_line,
+        error_count=error_count,
+        warning_count=warning_count,
+        translated_structures=tuple(translated_structures),
+        warnings=warnings,
+        errors=errors,
+        terminal_failures=tuple(terminal_failures),
+        parse_errors=parse_errors,
+        current_run_text=current_run_text,
+    )
+
+
+def _select_current_run_text(text: str) -> str:
+    product_matches = tuple(_PRODUCT_ANCHOR_RE.finditer(text))
+    if product_matches:
+        return text[product_matches[-1].start() :]
+
+    started_matches = tuple(_STARTED_ANCHOR_RE.finditer(text))
+    if started_matches:
+        return text[started_matches[-1].start() :]
+    return text
+
+
+def _parse_xstream_request_response(output: str) -> _XStreamRequestResponse:
+    text = output.strip() if isinstance(output, str) else ""
+    if not is_single_complete_skill_list(text):
+        _raise_malformed_response(output)
+
+    tokens = tokenize_top_level(
+        text[1:-1],
+        include_groups=True,
+        include_strings=True,
+        include_atoms=True,
+    )
+    if not _is_canonical_xstream_response_tokens(tokens):
+        _raise_malformed_response(output)
+
+    parsed = parse_sexpr(text)
+    if not isinstance(parsed, list) or len(parsed) != 4:
+        _raise_malformed_response(output)
+
+    tag, state, body_error, cleanup_failures = parsed
+    if (
+        tag != "xstreamRequest"
+        or not isinstance(state, str)
+        or state not in {"started", "failed"}
+    ):
+        _raise_malformed_response(output)
+    if body_error is not None and not isinstance(body_error, str):
+        _raise_malformed_response(output)
+
+    if cleanup_failures is None:
+        cleanup = ()
+    elif isinstance(cleanup_failures, list) and all(
+        isinstance(item, str) for item in cleanup_failures
+    ):
+        cleanup = tuple(cleanup_failures)
+    else:
+        _raise_malformed_response(output)
+
+    if state == "started":
+        if body_error is not None:
+            _raise_malformed_response(output)
+    elif body_error is None:
+        _raise_malformed_response(output)
+
+    return _XStreamRequestResponse(
+        state=cast(Literal["started", "failed"], state),
+        body_error=body_error,
+        cleanup_failures=cleanup,
+    )
+
+
+def _is_canonical_xstream_response_tokens(tokens: list[str]) -> bool:
+    if len(tokens) != 4:
+        return False
+    tag, state, body_error, cleanup_failures = tokens
+    if not _is_quoted_skill_string(tag) or not _is_quoted_skill_string(state):
+        return False
+    if body_error != "nil" and not _is_quoted_skill_string(body_error):
+        return False
+    if cleanup_failures == "nil":
+        return True
+    if not cleanup_failures.startswith("(") or not cleanup_failures.endswith(")"):
+        return False
+    cleanup_tokens = tokenize_top_level(
+        cleanup_failures[1:-1],
+        include_groups=True,
+        include_strings=True,
+        include_atoms=True,
+    )
+    return all(_is_quoted_skill_string(token) for token in cleanup_tokens)
+
+
+def _is_quoted_skill_string(token: str) -> bool:
+    return len(token) >= 2 and token.startswith('"') and token.endswith('"')
+
+
+def _raise_malformed_response(output: object) -> None:
+    raise ValueError(f"malformed XStream request response: {output!r}")
+
+
+__all__ = [
+    "XStreamExportRequest",
+    "xstream_export_gds_skill",
+    "XStreamTranslatedStructure",
+    "XStreamLogResult",
+    "parse_xstream_log",
+]

--- a/src/virtuoso_bridge/virtuoso/layout/xstream.py
+++ b/src/virtuoso_bridge/virtuoso/layout/xstream.py
@@ -23,6 +23,8 @@ _XSTREAM_FIELDS = (
     ("log_file", "logFile", "vbOldLogFile"),
     ("run_dir", "runDir", "vbOldRunDir"),
 )
+_COMPLETION_MESSAGE_FIELD = "showCompletionMsgBox"
+_COMPLETION_MESSAGE_OLD_VARIABLE = "vbOldShowCompletionMsgBox"
 _PRODUCT_ANCHOR_RE = re.compile(
     r"^Product[ \t]*:[ \t]*Virtuoso\(R\)[ \t]+XStream[ \t]+Out",
     re.MULTILINE,
@@ -126,14 +128,33 @@ def xstream_export_gds_skill(request: XStreamExportRequest) -> str:
             raise ValueError(f"{request_field} must be a nonempty string")
         escaped_values[request_field] = escape_skill_string(value)
 
-    old_variables = " ".join(old_variable for _, _, old_variable in _XSTREAM_FIELDS)
+    old_variables = " ".join(
+        (
+            *(old_variable for _, _, old_variable in _XSTREAM_FIELDS),
+            _COMPLETION_MESSAGE_OLD_VARIABLE,
+        )
+    )
     captures = "".join(
         f'{old_variable} = xstGetField("{xstream_field}") '
         for _request_field, xstream_field, old_variable in _XSTREAM_FIELDS
     )
+    captures += (
+        f'{_COMPLETION_MESSAGE_OLD_VARIABLE} = '
+        f'xstGetField("{_COMPLETION_MESSAGE_FIELD}") '
+    )
     setters = "".join(
         f'xstSetField("{xstream_field}" "{escaped_values[request_field]}") '
         for request_field, xstream_field, _old_variable in _XSTREAM_FIELDS
+    )
+    setters += f'xstSetField("{_COMPLETION_MESSAGE_FIELD}" "false") '
+    restored_fields = tuple(
+        (xstream_field, old_variable)
+        for _request_field, xstream_field, old_variable in _XSTREAM_FIELDS
+    ) + (
+        (
+            _COMPLETION_MESSAGE_FIELD,
+            _COMPLETION_MESSAGE_OLD_VARIABLE,
+        ),
     )
     restorations = "".join(
         (
@@ -143,7 +164,7 @@ def xstream_export_gds_skill(request: XStreamExportRequest) -> str:
             f'vbCleanupFailures = cons("failed to restore XStream field '
             f'{xstream_field}" vbCleanupFailures)) '
         )
-        for _request_field, xstream_field, old_variable in _XSTREAM_FIELDS
+        for xstream_field, old_variable in restored_fields
     )
 
     return (

--- a/tests/test_bridge_timeout.py
+++ b/tests/test_bridge_timeout.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import errno
+import socket
+from collections.abc import Iterator
+from typing import get_type_hints
+
+import pytest
+
+from virtuoso_bridge import VirtuosoClient
+from virtuoso_bridge.models import ExecutionStatus
+from virtuoso_bridge.virtuoso.basic import bridge
+
+
+class _FakeClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.sleeps: list[float] = []
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+    def sleep(self, seconds: float) -> None:
+        assert seconds > 0.0
+        self.sleeps.append(seconds)
+        self.advance(seconds)
+
+
+class _FakeSocket:
+    def __init__(
+        self,
+        clock: _FakeClock,
+        *,
+        connect_duration: float = 0.0,
+        connect_error: OSError | None = None,
+        send_duration: float = 0.0,
+        recv_results: tuple[tuple[float, bytes], ...] = ((0.0, b""),),
+    ) -> None:
+        self._clock = clock
+        self._connect_duration = connect_duration
+        self._connect_error = connect_error
+        self._send_duration = send_duration
+        self._recv_results: Iterator[tuple[float, bytes]] = iter(recv_results)
+        self._timeout: float | None = None
+        self.phase_timeouts: list[tuple[str, float]] = []
+
+    def __enter__(self) -> "_FakeSocket":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def settimeout(self, timeout: float) -> None:
+        self._timeout = timeout
+
+    def connect(self, _address: tuple[str, int]) -> None:
+        self._run_phase("connect", self._connect_duration)
+        if self._connect_error is not None:
+            raise self._connect_error
+
+    def sendall(self, _payload: bytes) -> None:
+        self._run_phase("send", self._send_duration)
+
+    def shutdown(self, _how: int) -> None:
+        return None
+
+    def recv(self, _size: int) -> bytes:
+        duration, result = next(self._recv_results)
+        self._run_phase("recv", duration)
+        return result
+
+    def _run_phase(self, phase: str, duration: float) -> None:
+        assert self._timeout is not None
+        self.phase_timeouts.append((phase, self._timeout))
+        if duration > self._timeout:
+            self._clock.advance(self._timeout)
+            raise socket.timeout
+        self._clock.advance(duration)
+
+
+class _SocketFactory:
+    def __init__(self, sockets: list[_FakeSocket]) -> None:
+        self._remaining = iter(sockets)
+        self.created: list[_FakeSocket] = []
+
+    def __call__(self, *_args: object) -> _FakeSocket:
+        fake_socket = next(self._remaining)
+        self.created.append(fake_socket)
+        return fake_socket
+
+
+def _use_fake_network(
+    monkeypatch: pytest.MonkeyPatch,
+    clock: _FakeClock,
+    factory: _SocketFactory,
+) -> None:
+    monkeypatch.setattr(bridge.time, "monotonic", clock)
+    monkeypatch.setattr(bridge.time, "sleep", clock.sleep)
+    monkeypatch.setattr(bridge.socket, "socket", factory)
+    monkeypatch.setenv("VB_JUMP_HOST", "jump.example.com")
+
+
+def test_execute_skill_uses_one_deadline_across_retry_and_socket_phases(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock()
+    refused = _FakeSocket(
+        clock,
+        connect_duration=0.1,
+        connect_error=ConnectionRefusedError(errno.ECONNREFUSED, "refused"),
+    )
+    connected = _FakeSocket(
+        clock,
+        connect_duration=0.1,
+        send_duration=0.2,
+        recv_results=((0.2, b"\x02partial"), (0.3, b"")),
+    )
+    factory = _SocketFactory([refused, connected])
+    _use_fake_network(monkeypatch, clock, factory)
+
+    result = VirtuosoClient().execute_skill("1+1", timeout=1.0)
+
+    assert result.status == ExecutionStatus.ERROR
+    assert result.errors == ["Socket timeout after 1.0s"]
+    assert result.execution_time == pytest.approx(1.0)
+    assert clock.sleeps == [0.2]
+    assert refused.phase_timeouts == [("connect", pytest.approx(1.0))]
+    assert connected.phase_timeouts == [
+        ("connect", pytest.approx(0.7)),
+        ("send", pytest.approx(0.6)),
+        ("recv", pytest.approx(0.4)),
+        ("recv", pytest.approx(0.2)),
+    ]
+
+
+def test_execute_skill_timeout_caps_jump_host_retry_grace(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    clock = _FakeClock()
+    refused_sockets = [
+        _FakeSocket(
+            clock,
+            connect_error=ConnectionRefusedError(errno.ECONNREFUSED, "refused"),
+        )
+        for _ in range(20)
+    ]
+    factory = _SocketFactory(refused_sockets)
+    _use_fake_network(monkeypatch, clock, factory)
+
+    result = VirtuosoClient().execute_skill("1+1", timeout=0.1)
+
+    assert result.status == ExecutionStatus.ERROR
+    assert result.errors == ["Socket timeout after 0.1s"]
+    assert result.execution_time == pytest.approx(0.1)
+    assert clock.sleeps == [pytest.approx(0.1)]
+    assert factory.created[0].phase_timeouts == [("connect", pytest.approx(0.1))]
+    assert sum(
+        phase == "connect"
+        for fake_socket in factory.created
+        for phase, _timeout in fake_socket.phase_timeouts
+    ) == 1
+    assert any("after 0.1s" in message for message in caplog.messages)
+
+
+def test_execute_skill_timeout_annotation_accepts_float() -> None:
+    annotations = get_type_hints(VirtuosoClient.execute_skill)
+
+    assert annotations["timeout"] == float | None
+
+
+def test_execute_skill_preserves_successful_jump_host_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock()
+    refused = _FakeSocket(
+        clock,
+        connect_duration=0.05,
+        connect_error=ConnectionRefusedError(errno.ECONNREFUSED, "refused"),
+    )
+    connected = _FakeSocket(
+        clock,
+        connect_duration=0.05,
+        send_duration=0.05,
+        recv_results=((0.05, b"\x023"), (0.0, b"")),
+    )
+    factory = _SocketFactory([refused, connected])
+    _use_fake_network(monkeypatch, clock, factory)
+
+    result = VirtuosoClient().execute_skill("1+2", timeout=1.0)
+
+    assert result.status == ExecutionStatus.SUCCESS
+    assert result.output == "3"
+    assert result.execution_time == pytest.approx(0.4)
+    assert clock.sleeps == [0.2]
+    assert len(factory.created) == 2

--- a/tests/test_export_gds_example.py
+++ b/tests/test_export_gds_example.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from virtuoso_bridge.models import ExecutionStatus, VirtuosoResult
+
+
+_EXAMPLE_PATH = (
+    Path(__file__).parents[1]
+    / "examples"
+    / "01_virtuoso"
+    / "layout"
+    / "15_export_gds.py"
+)
+
+
+def _load_example() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "test_export_gds_example_module",
+        _EXAMPLE_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise AssertionError(f"failed to load example: {_EXAMPLE_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_export_gds_example_reports_preflight_error_as_json(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    example = _load_example()
+    export_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    error = "stream_map is not an existing regular file: /missing/stream.map"
+
+    class FakeLayout:
+        def export_gds(self, *args: object, **kwargs: object) -> object:
+            export_calls.append((args, kwargs))
+            raise FileNotFoundError(error)
+
+    class FakeClient:
+        layout = FakeLayout()
+
+        def execute_skill(self, code: str, *, timeout: float) -> VirtuosoResult:
+            assert code == "1+1"
+            assert timeout == 10.0
+            return VirtuosoResult(
+                status=ExecutionStatus.SUCCESS,
+                output="2",
+            )
+
+    fake_client = FakeClient()
+
+    class FakeVirtuosoClient:
+        @classmethod
+        def from_env(cls) -> FakeClient:
+            return fake_client
+
+    monkeypatch.setattr(example, "VirtuosoClient", FakeVirtuosoClient)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "15_export_gds.py",
+            "--library",
+            "worklib",
+            "--cell",
+            "top",
+            "--stream-map",
+            "/missing/stream.map",
+            "--output",
+            "top.gds",
+        ],
+    )
+
+    exit_code = example.main()
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert json.loads(captured.out) == {
+        "status": "error",
+        "reason": "invalid_arguments",
+        "errors": [error],
+    }
+    assert captured.err == ""
+    assert len(export_calls) == 1

--- a/tests/test_layout_streamout.py
+++ b/tests/test_layout_streamout.py
@@ -7,6 +7,7 @@ import shlex
 import shutil
 import subprocess
 import stat
+import sys
 from dataclasses import FrozenInstanceError, fields
 from pathlib import Path, PurePosixPath
 from typing import Any, Callable
@@ -199,12 +200,12 @@ class _FakeRemoteRunner:
                         f"{hashlib.sha256(self.gds).hexdigest()}"
                     )
             return CommandResult(0, "\n".join(lines) + "\n", "")
-        if "rm -f -- " in command:
+        if "rm -f " in command:
             if isinstance(self.discard, BaseException):
                 raise self.discard
             assert isinstance(self.discard, CommandResult)
             return self.discard
-        if "rm -rf -- " in command:
+        if "rm -rf " in command:
             if isinstance(self.cleanup, BaseException):
                 raise self.cleanup
             assert isinstance(self.cleanup, CommandResult)
@@ -600,19 +601,31 @@ def test_remote_finalization_sentinel_uses_sha256_fallbacks(
         assert utility_path is not None
         (fake_bin / utility).symlink_to(utility_path)
     tool = fake_bin / digest_tool
+    hash_code = (
+        "import hashlib, pathlib, sys; "
+        "p=sys.argv[-1]; "
+        "digest=hashlib.sha256(pathlib.Path(p).read_bytes()).hexdigest(); "
+    )
     if digest_tool == "sha256sum":
-        script = "#!/bin/sh\nexec /usr/bin/sha256sum \"$@\"\n"
+        script = (
+            "#!/bin/sh\n"
+            f"exec {shlex.quote(sys.executable)} -c "
+            f"{shlex.quote(hash_code + 'print(digest + \"  \" + p)')} "
+            '"$@"\n'
+        )
     elif digest_tool == "shasum":
         script = (
-            "#!/bin/sh\nshift 3\n"
-            "line=$(/usr/bin/sha256sum -- \"$1\") || exit $?\n"
-            "printf '%s  %s\\n' \"${line%% *}\" \"$1\"\n"
+            "#!/bin/sh\n"
+            f"exec {shlex.quote(sys.executable)} -c "
+            f"{shlex.quote(hash_code + 'print(digest + \"  \" + p)')} "
+            '"$@"\n'
         )
     else:
         script = (
-            "#!/bin/sh\nshift 2\n"
-            "line=$(/usr/bin/sha256sum -- \"$1\") || exit $?\n"
-            "printf 'SHA2-256(%s)= %s\\n' \"$1\" \"${line%% *}\"\n"
+            "#!/bin/sh\n"
+            f"exec {shlex.quote(sys.executable)} -c "
+            f"{shlex.quote(hash_code + 'print(\"SHA2-256(\" + p + \")= \" + digest)')} "
+            '"$@"\n'
         )
     tool.write_text(script, encoding="utf-8")
     tool.chmod(0o755)
@@ -895,7 +908,7 @@ def test_remote_export_stages_owned_posix_run_and_all_request_fields(
     )
     assert "\\" not in result.remote_run_dir
     assert "umask 077" in runner.calls[0][0]
-    assert f"mkdir -m 700 -- '{result.remote_run_dir}'" in runner.calls[0][0]
+    assert f"mkdir -m 700 '{result.remote_run_dir}'" in runner.calls[0][0]
     assert all(timeout > 0.0 for _command, timeout in runner.calls)
     assert len(client.uploads) == 1
     assert client.uploads[0][0] == stream_map
@@ -1166,7 +1179,7 @@ def test_remote_delete_command_revalidates_chain_before_exact_remove(
     assert gds_path.read_bytes() == b"must-survive"
     exact_target = paths.run_dir if remove_run else paths.gds
     action = "rm -rf" if remove_run else "rm -f"
-    assert f"{action} -- {shlex.quote(exact_target.as_posix())}" in command
+    assert f"{action} {shlex.quote(exact_target.as_posix())}" in command
 
 
 def test_remote_export_downloads_log_before_gds_and_publishes_atomically(
@@ -1354,7 +1367,7 @@ def test_remote_export_full_log_overrides_successful_tail_and_blocks_gds(
         "xstream.log"
     ]
     assert any(
-        "rm -f -- " in command
+        "rm -f " in command
         for command, _timeout in runner.calls
     )
 
@@ -1639,10 +1652,10 @@ def test_remote_success_cleanup_reports_exact_retention_state(
     cleanup_calls = [
         command
         for command, _timeout in runner.calls
-        if "rm -rf -- " in command
+        if "rm -rf " in command
     ]
     assert len(cleanup_calls) == 1
-    assert f"rm -rf -- {result.remote_run_dir}" in cleanup_calls[0]
+    assert f"rm -rf {result.remote_run_dir}" in cleanup_calls[0]
     if cleanup_result.returncode != 0:
         assert any("cleanup" in warning for warning in result.warnings)
 
@@ -1671,8 +1684,8 @@ def test_remote_always_cleanup_runs_after_failed_log_and_preserves_reason(
     assert result.reason == GdsExportReason.XSTREAM_FAILURE
     assert result.remote_files_retained is False
     commands = [command for command, _timeout in runner.calls]
-    assert any("rm -f -- " in command for command in commands)
-    assert f"rm -rf -- {result.remote_run_dir}" in commands[-1]
+    assert any("rm -f " in command for command in commands)
+    assert f"rm -rf {result.remote_run_dir}" in commands[-1]
 
 
 def test_remote_always_cleanup_retains_run_when_full_log_download_fails(
@@ -1697,7 +1710,7 @@ def test_remote_always_cleanup_retains_run_when_full_log_download_fails(
     assert result.reason == GdsExportReason.TRANSPORT_ERROR
     assert result.remote_files_retained is True
     assert not any(
-        "rm -rf -- " in command
+        "rm -rf " in command
         for command, _timeout in runner.calls
     )
 
@@ -1731,7 +1744,7 @@ def test_remote_cleanup_budget_exhaustion_sends_no_cleanup_command(
     assert result.status == ExecutionStatus.SUCCESS
     assert result.remote_files_retained is True
     assert not any(
-        "rm -rf -- " in command
+        "rm -rf " in command
         for command, _timeout in runner.calls
     )
     assert any("cleanup skipped" in warning for warning in result.warnings)

--- a/tests/test_layout_streamout.py
+++ b/tests/test_layout_streamout.py
@@ -1,0 +1,5510 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import stat
+from dataclasses import FrozenInstanceError, fields
+from pathlib import Path, PurePosixPath
+from typing import Any, Callable
+
+import pytest
+
+from virtuoso_bridge import SSHClient, VirtuosoClient
+from virtuoso_bridge.models import ExecutionStatus, VirtuosoResult
+from virtuoso_bridge.transport.ssh import CommandResult
+from virtuoso_bridge.virtuoso import layout as layout_api
+from virtuoso_bridge.virtuoso.layout import streamout
+from virtuoso_bridge.virtuoso.layout.streamout import (
+    GdsExportReason,
+    GdsExportResult,
+    _Budget,
+    _BudgetExpired,
+    _classify_export,
+    _is_indeterminate_skill_timeout,
+    _validate_export_inputs,
+)
+from virtuoso_bridge.virtuoso.layout.xstream import XStreamLogResult
+
+
+_GDS_EXPORT_RESULT_FIELDS = (
+    "status",
+    "reason",
+    "timed_out",
+    "library",
+    "cell",
+    "view",
+    "execution_time",
+    "local_gds_path",
+    "local_log_path",
+    "log_result",
+    "errors",
+    "warnings",
+    "remote_run_dir",
+    "local_run_dir",
+    "remote_files_retained",
+)
+_EXPORT_INPUT_FIELDS = (
+    "library",
+    "cell",
+    "view",
+    "output_path",
+    "log_path",
+    "stream_map",
+    "timeout",
+    "poll_interval",
+    "skill_timeout",
+    "finalization_reserve",
+    "cleanup_policy",
+)
+
+_PUBLIC_LAYOUT_STREAMOUT_NAMES = (
+    "XStreamExportRequest",
+    "XStreamTranslatedStructure",
+    "XStreamLogResult",
+    "GdsExportReason",
+    "GdsExportResult",
+    "xstream_export_gds_skill",
+    "parse_xstream_log",
+    "export_gds",
+)
+
+
+class _FakeClock:
+    def __init__(
+        self,
+        now: float,
+        on_sleep: Callable[[float], None] | None = None,
+    ) -> None:
+        self.now = now
+        self.on_sleep = on_sleep
+        self.sleeps: list[float] = []
+
+    def __call__(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        assert seconds > 0.0
+        self.sleeps.append(seconds)
+        self.now += seconds
+        if self.on_sleep is not None:
+            self.on_sleep(seconds)
+
+
+class _SequenceClock:
+    def __init__(self, *values: float) -> None:
+        self._values = iter(values)
+        self.now = values[-1]
+
+    def __call__(self) -> float:
+        try:
+            self.now = next(self._values)
+        except StopIteration:
+            pass
+        return self.now
+
+
+class _FakeLocalClient:
+    ssh_runner = None
+
+    def __init__(
+        self,
+        execute: Callable[[str, float], object],
+        *,
+        is_remote: bool = False,
+    ) -> None:
+        self.is_remote = is_remote
+        self._execute = execute
+        self.skill_calls: list[tuple[str, float]] = []
+
+    def execute_skill(self, skill_code: str, timeout: float) -> object:
+        assert timeout > 0.0
+        self.skill_calls.append((skill_code, timeout))
+        return self._execute(skill_code, timeout)
+
+    def upload_file(self, *args: object, **kwargs: object) -> object:
+        raise AssertionError("local export must not upload files")
+
+    def download_file(self, *args: object, **kwargs: object) -> object:
+        raise AssertionError("local export must not download files")
+
+    def dismiss_dialog(self, *args: object, **kwargs: object) -> object:
+        raise AssertionError("local export must not use X11 recovery")
+
+
+class _FakeRemoteRunner:
+    def __init__(
+        self,
+        *,
+        user: str | None = "remote/user",
+        whoami: CommandResult | None = None,
+        mkdir: CommandResult | None = None,
+        log_text: str | None = None,
+        gds: bytes | None = None,
+        cleanup: object | None = None,
+        discard: object | None = None,
+    ) -> None:
+        self.user = user
+        self.whoami = whoami or CommandResult(0, "ignored\n", "")
+        self.mkdir = mkdir or CommandResult(0, "", "")
+        self.log_text = log_text
+        self.gds = gds
+        self.cleanup = cleanup or CommandResult(0, "", "")
+        self.discard = discard or CommandResult(0, "", "")
+        self.calls: list[tuple[str, float]] = []
+
+    def run_command(self, command: str, timeout: float) -> CommandResult:
+        assert timeout > 0.0
+        self.calls.append((command, timeout))
+        if command == "whoami":
+            return self.whoami
+        if "VBXSTREAM_STAGE_READY" in command:
+            if self.mkdir.returncode == 0 and not self.mkdir.stdout:
+                return CommandResult(
+                    0,
+                    "VBXSTREAM_STAGE_CREATED\nVBXSTREAM_STAGE_READY\n",
+                    self.mkdir.stderr,
+                )
+            return self.mkdir
+        if " LOG_SIZE " in command and " GDS_SIZE " in command:
+            match = re.search(r"VBXSTREAM_[A-Za-z0-9]+", command)
+            assert match is not None
+            token = match.group(0)
+            include_digests = "LOG_SHA256" in command
+            lines: list[str] = []
+            if self.log_text is None:
+                lines.append(f"{token} LOG_MISSING")
+            else:
+                tail = "\n".join(self.log_text.splitlines()[-200:])
+                log_bytes = self.log_text.encode("utf-8")
+                lines.append(f"{token} LOG_SIZE {len(log_bytes)}")
+                if include_digests:
+                    lines.append(
+                        f"{token} LOG_SHA256 "
+                        f"{hashlib.sha256(log_bytes).hexdigest()}"
+                    )
+                lines.extend(
+                    [f"{token} LOG_BEGIN", tail, f"{token} LOG_END"]
+                )
+            if self.gds is None:
+                lines.append(f"{token} GDS_MISSING")
+            else:
+                lines.append(f"{token} GDS_SIZE {len(self.gds)}")
+                if include_digests:
+                    lines.append(
+                        f"{token} GDS_SHA256 "
+                        f"{hashlib.sha256(self.gds).hexdigest()}"
+                    )
+            return CommandResult(0, "\n".join(lines) + "\n", "")
+        if "rm -f -- " in command:
+            if isinstance(self.discard, BaseException):
+                raise self.discard
+            assert isinstance(self.discard, CommandResult)
+            return self.discard
+        if "rm -rf -- " in command:
+            if isinstance(self.cleanup, BaseException):
+                raise self.cleanup
+            assert isinstance(self.cleanup, CommandResult)
+            return self.cleanup
+        raise AssertionError(f"unexpected remote command: {command}")
+
+
+class _FakeRemoteClient:
+    def __init__(
+        self,
+        runner: _FakeRemoteRunner,
+        *,
+        upload_result: object | None = None,
+        skill_result: object | None = None,
+        remote_log: bytes | None = None,
+        remote_gds: bytes | None = None,
+    ) -> None:
+        self.ssh_runner = runner
+        self.upload_result = upload_result or VirtuosoResult(
+            status=ExecutionStatus.SUCCESS,
+        )
+        self.skill_result = skill_result or VirtuosoResult(
+            status=ExecutionStatus.ERROR,
+            errors=["remote launch rejected"],
+        )
+        self.remote_log = remote_log
+        self.remote_gds = remote_gds
+        self.uploads: list[tuple[Path, str, float]] = []
+        self.skills: list[tuple[str, float]] = []
+        self.downloads: list[tuple[str, Path, float]] = []
+
+    def upload_file(
+        self,
+        local_path: Path,
+        remote_path: str,
+        *,
+        timeout: float,
+    ) -> object:
+        assert timeout > 0.0
+        self.uploads.append((Path(local_path), remote_path, timeout))
+        return self.upload_result
+
+    def execute_skill(self, skill_code: str, timeout: float) -> object:
+        assert timeout > 0.0
+        self.skills.append((skill_code, timeout))
+        return self.skill_result
+
+    def download_file(
+        self,
+        remote_path: str,
+        local_path: Path,
+        *,
+        timeout: float,
+    ) -> object:
+        assert timeout > 0.0
+        self.downloads.append((remote_path, Path(local_path), timeout))
+        if remote_path.endswith("/xstream.log") and self.remote_log is not None:
+            Path(local_path).write_bytes(self.remote_log)
+        elif remote_path.endswith("/output.gds") and self.remote_gds is not None:
+            Path(local_path).write_bytes(self.remote_gds)
+        else:
+            raise AssertionError("missing remote artifacts must not be downloaded")
+        return VirtuosoResult(status=ExecutionStatus.SUCCESS)
+
+
+_PARTIAL_LOG = "\n".join(
+    [
+        "Product : Virtuoso(R) XStream Out",
+        "Started at: SYNTHETIC_TIME",
+        "Translating cellview demo/top/layout as STRUCTURE top.",
+    ]
+) + "\n"
+_SUCCESS_LOG = (
+    _PARTIAL_LOG
+    + "INFO (XSTRM-234): Translation completed. 0 error(s) and "
+    "0 warning(s) found.\n"
+)
+_TERMINAL_LOG = (
+    _PARTIAL_LOG + "INFO (XSTRM-273): Translation failed.\n"
+)
+_MALFORMED_LOG = (
+    _PARTIAL_LOG
+    + "INFO (XSTRM-234): Translation completed. unavailable error(s) and "
+    "unavailable warning(s) found.\n"
+)
+_ERROR_COMPLETION_LOG = (
+    _PARTIAL_LOG
+    + "ERROR: current-run XStream error matching nonzero completion count\n"
+    + "INFO (XSTRM-234): Translation completed. 2 error(s) and "
+    "1 warning(s) found.\n"
+)
+_PARTIAL_WITH_ERROR_LOG = (
+    _PARTIAL_LOG + "ERROR: current-run XStream diagnostic before completion\n"
+)
+_ZERO_COUNT_WITH_ERROR_LOG = (
+    _PARTIAL_LOG
+    + "ERROR: current-run XStream error despite zero completion count\n"
+    + "INFO (XSTRM-234): Translation completed. 0 error(s) and "
+    "0 warning(s) found.\n"
+)
+_STARTED_WIRE = '("xstreamRequest" "started" nil nil)'
+
+
+def _skill_field(skill: str, field: str) -> str:
+    match = re.search(
+        rf'xstSetField\("{re.escape(field)}" "([^"]+)"\)',
+        skill,
+    )
+    assert match is not None, f"missing XStream field {field}"
+    return match.group(1)
+
+
+def _request_artifacts(skill: str) -> tuple[Path, Path, Path]:
+    return (
+        Path(_skill_field(skill, "runDir")),
+        Path(_skill_field(skill, "strmFile")),
+        Path(_skill_field(skill, "logFile")),
+    )
+
+
+def _write_artifacts(
+    skill: str,
+    *,
+    log_text: str | None = _SUCCESS_LOG,
+    gds: bytes | None = b"current-run-gds",
+) -> tuple[Path, Path, Path]:
+    run_dir, gds_path, log_path = _request_artifacts(skill)
+    assert gds_path == run_dir / "output.gds"
+    assert log_path == run_dir / "xstream.log"
+    if log_text is not None:
+        log_path.write_text(log_text, encoding="utf-8")
+    if gds is not None:
+        gds_path.write_bytes(gds)
+    return run_dir, gds_path, log_path
+
+
+def _started_result() -> VirtuosoResult:
+    return VirtuosoResult(
+        status=ExecutionStatus.SUCCESS,
+        output=_STARTED_WIRE,
+    )
+
+
+def _artifact_client(
+    *,
+    log_text: str | None = _SUCCESS_LOG,
+    gds: bytes | None = b"current-run-gds",
+    response: object | None = None,
+    is_remote: bool = False,
+) -> _FakeLocalClient:
+    def execute(skill: str, _timeout: float) -> object:
+        _write_artifacts(skill, log_text=log_text, gds=gds)
+        return _started_result() if response is None else response
+
+    return _FakeLocalClient(execute, is_remote=is_remote)
+
+
+def _use_fake_time(
+    monkeypatch: pytest.MonkeyPatch,
+    clock: _FakeClock | _SequenceClock,
+) -> None:
+    monkeypatch.setattr(streamout, "_MONOTONIC", clock)
+    if isinstance(clock, _FakeClock):
+        monkeypatch.setattr(streamout, "_SLEEP", clock.sleep)
+
+
+def _run_export(
+    client: object,
+    output_path: Path,
+    stream_map: Path,
+    **overrides: Any,
+) -> GdsExportResult:
+    options: dict[str, Any] = {
+        "stream_map": stream_map,
+        "view": "layout",
+        "log_path": None,
+        "timeout": 4.0,
+        "poll_interval": 0.5,
+        "skill_timeout": 2.0,
+        "finalization_reserve": 1.0,
+        "cleanup_policy": "success",
+        "recovery_hook": None,
+    }
+    options.update(overrides)
+    return streamout.export_gds(
+        client,
+        "demo",
+        "top",
+        output_path,
+        **options,
+    )
+
+
+def _write_stream_map(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("# synthetic stream map\n", encoding="utf-8")
+    return path
+
+
+def _validation_kwargs(stream_map: Path) -> dict[str, object]:
+    return {
+        "stream_map": stream_map,
+        "view": "layout",
+        "log_path": None,
+        "timeout": 30.0,
+        "poll_interval": 0.25,
+        "skill_timeout": 5.0,
+        "finalization_reserve": 2.0,
+        "cleanup_policy": "success",
+    }
+
+
+def _log_result(
+    *,
+    completed: bool = False,
+    error_count: int | None = None,
+    warning_count: int | None = None,
+    errors: tuple[str, ...] = (),
+    terminal_failures: tuple[str, ...] = (),
+) -> XStreamLogResult:
+    return XStreamLogResult(
+        completed=completed,
+        completion_line="Translation completed" if completed else None,
+        error_count=error_count,
+        warning_count=warning_count,
+        translated_structures=(),
+        warnings=(),
+        errors=errors,
+        terminal_failures=terminal_failures,
+        parse_errors=(),
+        current_run_text="",
+    )
+
+
+def _remote_test_paths() -> streamout._RemoteExportPaths:
+    owned_root = PurePosixPath(
+        "/tmp/virtuoso_bridge_remote/client/xstream"
+    )
+    run_dir = owned_root / ("a" * 32)
+    return streamout._RemoteExportPaths(
+        owned_root=owned_root,
+        run_dir=run_dir,
+        gds=run_dir / "output.gds",
+        log=run_dir / "xstream.log",
+        stream_map=run_dir / "stream.map",
+    )
+
+
+def _remote_paths_under(scratch: Path) -> streamout._RemoteExportPaths:
+    owned_root = PurePosixPath(
+        (scratch / "virtuoso_bridge_secureuser" / "client" / "xstream").as_posix()
+    )
+    run_dir = owned_root / ("c" * 32)
+    return streamout._RemoteExportPaths(
+        owned_root=owned_root,
+        run_dir=run_dir,
+        gds=run_dir / "output.gds",
+        log=run_dir / "xstream.log",
+        stream_map=run_dir / "stream.map",
+    )
+
+
+def test_layout_public_api_exports_xstream_streamout_names() -> None:
+    for name in _PUBLIC_LAYOUT_STREAMOUT_NAMES:
+        assert hasattr(layout_api, name)
+        assert name in layout_api.__all__
+
+
+def test_layout_ops_export_gds_delegates_all_arguments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner = object()
+    output_path = Path("build/top.gds")
+    stream_map = Path("pdk/stream.map")
+    log_path = Path("build/top.log")
+    recovery_hook = lambda: None
+    sentinel = object()
+    captured: dict[str, object] = {}
+
+    def fake_export_gds(*args: object, **kwargs: object) -> object:
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return sentinel
+
+    monkeypatch.setattr(layout_api, "export_gds", fake_export_gds)
+
+    result = layout_api.LayoutOps(owner).export_gds(
+        "worklib",
+        "top",
+        output_path,
+        stream_map=stream_map,
+        view="maskLayout",
+        log_path=log_path,
+        timeout=120.0,
+        poll_interval=0.25,
+        skill_timeout=12.0,
+        finalization_reserve=18.0,
+        cleanup_policy="never",
+        recovery_hook=recovery_hook,
+    )
+
+    assert result is sentinel
+    assert captured["args"] == (owner, "worklib", "top", output_path)
+    kwargs = captured["kwargs"]
+    assert isinstance(kwargs, dict)
+    assert kwargs == {
+        "stream_map": stream_map,
+        "view": "maskLayout",
+        "log_path": log_path,
+        "timeout": 120.0,
+        "poll_interval": 0.25,
+        "skill_timeout": 12.0,
+        "finalization_reserve": 18.0,
+        "cleanup_policy": "never",
+        "recovery_hook": recovery_hook,
+    }
+    assert kwargs["recovery_hook"] is recovery_hook
+
+
+@pytest.mark.parametrize("unlink_fails", [False, True])
+def test_remote_download_temp_cleanup_runs_after_deadline(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    unlink_fails: bool,
+) -> None:
+    clock = _FakeClock(0.0)
+    budget = _Budget.start(4.0, 1.0, clock=clock)
+    temporary = tmp_path / (".vbd-" + ("a" * 32) + ".tmp")
+    temporary.write_bytes(b"staged")
+    if unlink_fails:
+        def fail_unlink(_path: Path) -> None:
+            raise OSError("file is locked")
+
+        monkeypatch.setattr(Path, "unlink", fail_unlink)
+    clock.now = 4.0
+    warnings: list[str] = []
+
+    streamout._cleanup_local_download_temp(temporary, budget, warnings)
+
+    assert temporary.exists() is unlink_fails
+    if unlink_fails:
+        assert warnings == [
+            f"local download temp retained: {temporary}: file is locked"
+        ]
+    else:
+        assert warnings == [
+            f"local download temp removed after export deadline: {temporary}"
+        ]
+
+
+def test_remote_sentinel_command_reports_missing_artifacts_with_exit_zero(
+    tmp_path: Path,
+) -> None:
+    log_path = PurePosixPath((tmp_path / "remote scratch" / "xstream.log").as_posix())
+    gds_path = PurePosixPath((tmp_path / "remote scratch" / "output.gds").as_posix())
+    token = "VBXSTREAM_0123456789abcdef"
+
+    command = streamout._remote_poll_command(log_path, gds_path, token)
+    completed = subprocess.run(
+        ["sh", "-c", command],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    observation = streamout._parse_remote_poll_output(completed.stdout, token)
+    assert observation == streamout._ArtifactObservation()
+    assert "'" + log_path.as_posix() + "'" in command
+    assert "'" + gds_path.as_posix() + "'" in command
+    assert "sha256sum" not in command
+    assert "shasum" not in command
+    assert "openssl" not in command
+
+
+@pytest.mark.parametrize("digest_tool", ["sha256sum", "shasum", "openssl"])
+def test_remote_finalization_sentinel_uses_sha256_fallbacks(
+    tmp_path: Path,
+    digest_tool: str,
+) -> None:
+    run_dir = tmp_path / "remote scratch"
+    run_dir.mkdir()
+    log_path = run_dir / "xstream.log"
+    gds_path = run_dir / "output.gds"
+    log_bytes = b"current full log\n"
+    gds_bytes = b"current-gds"
+    log_path.write_bytes(log_bytes)
+    gds_path.write_bytes(gds_bytes)
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    for utility in ("rm", "tail", "wc"):
+        utility_path = shutil.which(utility)
+        assert utility_path is not None
+        (fake_bin / utility).symlink_to(utility_path)
+    tool = fake_bin / digest_tool
+    if digest_tool == "sha256sum":
+        script = "#!/bin/sh\nexec /usr/bin/sha256sum \"$@\"\n"
+    elif digest_tool == "shasum":
+        script = (
+            "#!/bin/sh\nshift 3\n"
+            "line=$(/usr/bin/sha256sum -- \"$1\") || exit $?\n"
+            "printf '%s  %s\\n' \"${line%% *}\" \"$1\"\n"
+        )
+    else:
+        script = (
+            "#!/bin/sh\nshift 2\n"
+            "line=$(/usr/bin/sha256sum -- \"$1\") || exit $?\n"
+            "printf 'SHA2-256(%s)= %s\\n' \"$1\" \"${line%% *}\"\n"
+        )
+    tool.write_text(script, encoding="utf-8")
+    tool.chmod(0o755)
+    token = "VBXSTREAM_abcdef0123456789"
+    command = streamout._remote_poll_command(
+        PurePosixPath(log_path.as_posix()),
+        PurePosixPath(gds_path.as_posix()),
+        token,
+        include_digests=True,
+    )
+
+    completed = subprocess.run(
+        ["/bin/sh", "-c", command],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PATH": fake_bin.as_posix()},
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    observation = streamout._parse_remote_poll_output(
+        completed.stdout,
+        token,
+        require_digests=True,
+    )
+    assert observation.log_digest == hashlib.sha256(log_bytes).hexdigest()
+    assert observation.gds_digest == hashlib.sha256(gds_bytes).hexdigest()
+    assert command.index("sha256sum") < command.index("shasum")
+    assert command.index("shasum") < command.index("openssl")
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        (
+            "{token} LOG_SIZE 1\n{token} LOG_SHA256 nope\n"
+            "{token} LOG_BEGIN\nx\n{token} LOG_END\n"
+            "{token} GDS_MISSING\n"
+        ),
+        (
+            "{token} LOG_SIZE 1\n{token} LOG_SHA256 {digest}\n"
+            "{token} LOG_SHA256 {digest}\n{token} LOG_BEGIN\nx\n"
+            "{token} LOG_END\n{token} GDS_MISSING\n"
+        ),
+        (
+            "{token} LOG_MISSING\n{token} LOG_SHA256 {digest}\n"
+            "{token} GDS_MISSING\n"
+        ),
+        (
+            "{token} LOG_SIZE 1\n{token} LOG_BEGIN\nx\n"
+            "{token} LOG_END\n{token} GDS_MISSING\n"
+        ),
+        (
+            "{token} LOG_MISSING\n{token} GDS_SHA256 {digest}\n"
+            "{token} GDS_MISSING\n"
+        ),
+        "{token} LOG_MISSING\n{token} GDS_SIZE 1\n",
+    ],
+)
+def test_remote_finalization_parser_rejects_invalid_digest_protocol(
+    payload: str,
+) -> None:
+    token = "VBXSTREAM_abcdef0123456789"
+
+    with pytest.raises(ValueError, match="remote XStream sentinel"):
+        streamout._parse_remote_poll_output(
+            payload.format(token=token, digest="a" * 64),
+            token,
+            require_digests=True,
+        )
+
+
+def test_remote_sentinel_parser_keeps_log_text_inside_random_frame(
+    tmp_path: Path,
+) -> None:
+    run_dir = tmp_path / "remote scratch"
+    run_dir.mkdir()
+    log_path = run_dir / "xstream.log"
+    gds_path = run_dir / "output.gds"
+    token = "VBXSTREAM_abcdef0123456789"
+    lines = [f"line {index}" for index in range(205)]
+    lines[-2] = f"{token} GDS_SIZE 999"
+    log_path.write_text("\n".join(lines), encoding="utf-8")
+    gds_path.write_bytes(b"fresh-gds")
+
+    command = streamout._remote_poll_command(
+        PurePosixPath(log_path.as_posix()),
+        PurePosixPath(gds_path.as_posix()),
+        token,
+    )
+    completed = subprocess.run(
+        ["sh", "-c", command],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    observation = streamout._parse_remote_poll_output(completed.stdout, token)
+    assert observation.log_present is True
+    assert observation.log_size == log_path.stat().st_size
+    assert observation.log_text.splitlines()[0] == "line 5"
+    assert f"{token} GDS_SIZE 999" in observation.log_text
+    assert observation.gds_present is True
+    assert observation.gds_size == len(b"fresh-gds")
+
+
+def test_remote_sentinel_parser_fails_closed_on_dynamic_log_end_collision(
+    tmp_path: Path,
+) -> None:
+    run_dir = tmp_path / "remote scratch"
+    run_dir.mkdir()
+    log_path = run_dir / "xstream.log"
+    gds_path = run_dir / "output.gds"
+    token = "VBXSTREAM_abcdef0123456789"
+    log_path.write_text(
+        f"ordinary line\n{token} LOG_END\nline after collision\n",
+        encoding="utf-8",
+    )
+    command = streamout._remote_poll_command(
+        PurePosixPath(log_path.as_posix()),
+        PurePosixPath(gds_path.as_posix()),
+        token,
+    )
+    completed = subprocess.run(
+        ["sh", "-c", command],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    with pytest.raises(ValueError, match="remote XStream sentinel"):
+        streamout._parse_remote_poll_output(completed.stdout, token)
+
+
+def test_remote_sentinel_bounds_long_single_line_and_keeps_completion(
+    tmp_path: Path,
+) -> None:
+    run_dir = tmp_path / "remote scratch"
+    run_dir.mkdir()
+    log_path = run_dir / "xstream.log"
+    gds_path = run_dir / "output.gds"
+    token = "VBXSTREAM_abcdef0123456789"
+    log_text = (
+        "X" * (256 * 1024)
+        + "\nINFO (XSTRM-234): Translation completed. 0 error(s) and "
+        "0 warning(s) found.\n"
+    )
+    log_path.write_text(log_text, encoding="utf-8")
+    command = streamout._remote_poll_command(
+        PurePosixPath(log_path.as_posix()),
+        PurePosixPath(gds_path.as_posix()),
+        token,
+    )
+    completed = subprocess.run(
+        ["sh", "-c", command],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    assert len(completed.stdout) <= (128 * 1024) + 4096
+    observation = streamout._parse_remote_poll_output(completed.stdout, token)
+    assert observation.log_tail_truncated is True
+    assert len(observation.log_bytes) <= 128 * 1024
+    assert streamout.parse_xstream_log(observation.log_text).completed is True
+
+
+@pytest.mark.parametrize(
+    "failed_tail_args",
+    ["-c 131073", "-c 131072", "-n 200"],
+)
+def test_remote_sentinel_propagates_each_tail_read_failure(
+    tmp_path: Path,
+    failed_tail_args: str,
+) -> None:
+    run_dir = tmp_path / "remote scratch"
+    run_dir.mkdir()
+    log_path = run_dir / "xstream.log"
+    gds_path = run_dir / "output.gds"
+    log_path.write_text(
+        "X" * ((128 * 1024) + 512)
+        + "\nINFO (XSTRM-234): Translation completed. 0 error(s) and "
+        "0 warning(s) found.\n",
+        encoding="utf-8",
+    )
+    real_tail = shutil.which("tail")
+    assert real_tail is not None
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    fake_tail = fake_bin / "tail"
+    fake_tail.write_text(
+        "#!/bin/sh\n"
+        'if [ "$1 $2" = "$VB_FAIL_TAIL_ARGS" ]; then exit 91; fi\n'
+        f"exec {shlex.quote(real_tail)} \"$@\"\n",
+        encoding="utf-8",
+    )
+    fake_tail.chmod(0o755)
+    token = "VBXSTREAM_abcdef0123456789"
+    command = streamout._remote_poll_command(
+        PurePosixPath(log_path.as_posix()),
+        PurePosixPath(gds_path.as_posix()),
+        token,
+    )
+
+    completed = subprocess.run(
+        ["/bin/sh", "-c", command],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+            "VB_FAIL_TAIL_ARGS": failed_tail_args,
+        },
+    )
+
+    assert completed.returncode == 91
+    assert f"{token} LOG_END" not in completed.stdout
+    assert not list(run_dir.glob(f".{token}.*"))
+
+
+def test_remote_sentinel_parser_rejects_oversized_stdout_before_split() -> None:
+    token = "VBXSTREAM_abcdef0123456789"
+
+    with pytest.raises(ValueError, match="exceeds remote XStream sentinel limit"):
+        streamout._parse_remote_poll_output("X" * (140 * 1024), token)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "{token} LOG_MISSING\n{token} LOG_MISSING\n{token} GDS_MISSING\n",
+        "{token} LOG_SIZE -1\n{token} LOG_BEGIN\n{token} LOG_END\n{token} GDS_MISSING\n",
+        "{token} LOG_SIZE nope\n{token} LOG_BEGIN\n{token} LOG_END\n{token} GDS_MISSING\n",
+        "{token} LOG_MISSING\n{token} LOG_SIZE 0\n{token} LOG_BEGIN\n{token} LOG_END\n{token} GDS_MISSING\n",
+        "{token} LOG_SIZE 0\n{token} LOG_BEGIN\nunterminated\n{token} GDS_MISSING\n",
+        "{token} LOG_MISSING\n{token} GDS_MISSING\n{token} GDS_MISSING\n",
+        "{token} LOG_MISSING\n{token} GDS_MISSING\n{token} GDS_SIZE 0\n",
+        "{token} LOG_MISSING\n{token} GDS_SIZE -1\n",
+        "{token} LOG_MISSING\n{token} GDS_SIZE nope\n",
+    ],
+)
+def test_remote_sentinel_parser_rejects_malformed_control_protocol(
+    payload: str,
+) -> None:
+    token = "VBXSTREAM_abcdef0123456789"
+
+    with pytest.raises(ValueError, match="remote XStream sentinel"):
+        streamout._parse_remote_poll_output(payload.format(token=token), token)
+
+
+def test_remote_export_stages_owned_posix_run_and_all_request_fields(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VB_REMOTE_SCRATCH_ROOT", "/scratch root")
+    monkeypatch.setenv("VB_CLIENT_ID", "client/id")
+    stream_map = _write_stream_map(tmp_path / "caller map" / "layers.map")
+    runner = _FakeRemoteRunner(user="remote/user")
+    client = _FakeRemoteClient(runner)
+
+    result = _run_export(
+        client,
+        tmp_path / "local outputs" / "top.gds",
+        stream_map,
+        cleanup_policy="never",
+    )
+
+    assert result.status == ExecutionStatus.ERROR
+    assert result.reason == GdsExportReason.SKILL_ERROR
+    assert result.remote_files_retained is True
+    assert result.local_run_dir is None
+    assert result.remote_run_dir is not None
+    assert re.fullmatch(
+        r"/scratch root/virtuoso_bridge_remote_user/client_id/xstream/[0-9a-f]{32}",
+        result.remote_run_dir,
+    )
+    assert "\\" not in result.remote_run_dir
+    assert "umask 077" in runner.calls[0][0]
+    assert f"mkdir -m 700 -- '{result.remote_run_dir}'" in runner.calls[0][0]
+    assert all(timeout > 0.0 for _command, timeout in runner.calls)
+    assert len(client.uploads) == 1
+    assert client.uploads[0][0] == stream_map
+    assert client.uploads[0][1] == f"{result.remote_run_dir}/stream.map"
+    assert len(client.skills) == 1
+    skill, skill_timeout = client.skills[0]
+    assert 0.0 < skill_timeout <= 2.0
+    assert _skill_field(skill, "library") == "demo"
+    assert _skill_field(skill, "topCell") == "top"
+    assert _skill_field(skill, "view") == "layout"
+    assert _skill_field(skill, "strmFile") == f"{result.remote_run_dir}/output.gds"
+    assert _skill_field(skill, "layerMap") == f"{result.remote_run_dir}/stream.map"
+    assert _skill_field(skill, "logFile") == f"{result.remote_run_dir}/xstream.log"
+    assert _skill_field(skill, "runDir") == result.remote_run_dir
+    assert str(tmp_path) not in skill
+    assert not any(command == "whoami" for command, _timeout in runner.calls)
+
+
+def test_remote_export_budgeted_whoami_is_sanitized_and_runs_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VB_REMOTE_SCRATCH_ROOT", "/tmp")
+    monkeypatch.setenv("VB_CLIENT_ID", "laptop")
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    runner = _FakeRemoteRunner(
+        user="   ",
+        whoami=CommandResult(0, "cad/user\n", ""),
+    )
+    client = _FakeRemoteClient(runner)
+
+    first = _run_export(
+        client,
+        tmp_path / "first.gds",
+        stream_map,
+        cleanup_policy="never",
+    )
+    second = _run_export(
+        client,
+        tmp_path / "second.gds",
+        stream_map,
+        cleanup_policy="never",
+    )
+
+    assert first.remote_run_dir is not None
+    assert second.remote_run_dir is not None
+    assert "/virtuoso_bridge_cad_user/laptop/xstream/" in first.remote_run_dir
+    assert first.remote_run_dir != second.remote_run_dir
+    whoami_calls = [call for call in runner.calls if call[0] == "whoami"]
+    assert len(whoami_calls) == 2
+    assert all(timeout > 0.0 for _command, timeout in whoami_calls)
+    assert len(client.uploads) == 2
+
+
+def test_remote_export_mkdir_failure_is_transport_error_without_launch(
+    tmp_path: Path,
+) -> None:
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    runner = _FakeRemoteRunner(
+        mkdir=CommandResult(1, "", "permission denied"),
+    )
+    client = _FakeRemoteClient(runner)
+
+    result = _run_export(client, tmp_path / "top.gds", stream_map)
+
+    assert result.status == ExecutionStatus.ERROR
+    assert result.reason == GdsExportReason.TRANSPORT_ERROR
+    assert result.remote_run_dir is not None
+    assert result.remote_files_retained is None
+    assert "permission denied" in "\n".join(result.errors)
+    assert client.uploads == []
+    assert client.skills == []
+
+
+def test_remote_export_upload_failure_retains_created_run_without_launch(
+    tmp_path: Path,
+) -> None:
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    runner = _FakeRemoteRunner()
+    client = _FakeRemoteClient(
+        runner,
+        upload_result=VirtuosoResult(
+            status=ExecutionStatus.ERROR,
+            errors=["scp failed"],
+        ),
+    )
+
+    result = _run_export(client, tmp_path / "top.gds", stream_map)
+
+    assert result.status == ExecutionStatus.ERROR
+    assert result.reason == GdsExportReason.TRANSPORT_ERROR
+    assert result.remote_run_dir is not None
+    assert result.remote_files_retained is True
+    assert result.errors == ("failed to upload remote XStream stream map: scp failed",)
+    assert len(client.uploads) == 1
+    assert client.skills == []
+
+
+@pytest.mark.parametrize(
+    ("stage", "expected_retained"),
+    [("mkdir", None), ("upload", True)],
+)
+def test_remote_staging_exceptions_preserve_retention_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    stage: str,
+    expected_retained: bool | None,
+) -> None:
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    runner = _FakeRemoteRunner()
+    client = _FakeRemoteClient(runner)
+    if stage == "mkdir":
+        real_run_command = runner.run_command
+
+        def fail_mkdir(command: str, timeout: float) -> CommandResult:
+            if "VBXSTREAM_STAGE_READY" in command:
+                raise OSError("mkdir transport exploded")
+            return real_run_command(command, timeout)
+
+        monkeypatch.setattr(runner, "run_command", fail_mkdir)
+    else:
+        def fail_upload(*_args: object, **_kwargs: object) -> object:
+            raise OSError("upload transport exploded")
+
+        monkeypatch.setattr(client, "upload_file", fail_upload)
+
+    result = _run_export(client, tmp_path / "top.gds", stream_map)
+
+    assert result.status == ExecutionStatus.ERROR
+    assert result.reason == GdsExportReason.TRANSPORT_ERROR
+    assert result.remote_run_dir is not None
+    assert result.remote_files_retained is expected_retained
+    assert "transport exploded" in "\n".join(result.errors)
+    assert client.skills == []
+
+
+@pytest.mark.parametrize("scenario", ["symlink", "wrong_owner", "unsafe_mode"])
+def test_remote_stage_command_secures_private_chain(
+    tmp_path: Path,
+    scenario: str,
+) -> None:
+    scratch = tmp_path / "scratch root"
+    scratch.mkdir()
+    paths = _remote_paths_under(scratch)
+    user_dir = Path(paths.owned_root.parent.parent.as_posix())
+    environment = os.environ.copy()
+    if scenario == "symlink":
+        target = tmp_path / "attacker target"
+        target.mkdir()
+        user_dir.symlink_to(target, target_is_directory=True)
+    else:
+        user_dir.mkdir(mode=0o755 if scenario == "unsafe_mode" else 0o700)
+    if scenario == "wrong_owner":
+        fake_bin = tmp_path / "fake-bin"
+        fake_bin.mkdir()
+        fake_stat = fake_bin / "stat"
+        fake_stat.write_text("#!/bin/sh\nprintf '999999 700\\n'\n", encoding="utf-8")
+        fake_stat.chmod(0o755)
+        environment["PATH"] = f"{fake_bin}{os.pathsep}{environment['PATH']}"
+
+    completed = subprocess.run(
+        ["sh", "-c", streamout._remote_stage_command(paths)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+
+    if scenario == "unsafe_mode":
+        assert completed.returncode == 0
+        assert completed.stdout.splitlines() == [
+            "VBXSTREAM_STAGE_CREATED",
+            "VBXSTREAM_STAGE_READY",
+        ]
+        for directory in (
+            user_dir,
+            user_dir / "client",
+            user_dir / "client" / "xstream",
+            Path(paths.run_dir.as_posix()),
+        ):
+            assert stat.S_IMODE(directory.stat().st_mode) == 0o700
+    else:
+        assert completed.returncode != 0
+        assert "VBXSTREAM_STAGE_CREATED" not in completed.stdout
+        assert not Path(paths.run_dir.as_posix()).exists()
+
+
+def test_remote_export_rejects_preexisting_private_chain_symlink(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scratch = tmp_path / "scratch root"
+    scratch.mkdir()
+    attacker_target = tmp_path / "attacker target"
+    attacker_target.mkdir()
+    (scratch / "virtuoso_bridge_secureuser").symlink_to(
+        attacker_target,
+        target_is_directory=True,
+    )
+    monkeypatch.setenv("VB_REMOTE_SCRATCH_ROOT", scratch.as_posix())
+    monkeypatch.setenv("VB_CLIENT_ID", "client")
+
+    class LocalShellRunner:
+        user = "secureuser"
+
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, float]] = []
+
+        def run_command(self, command: str, timeout: float) -> CommandResult:
+            self.calls.append((command, timeout))
+            completed = subprocess.run(
+                ["sh", "-c", command],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+            return CommandResult(
+                completed.returncode,
+                completed.stdout,
+                completed.stderr,
+            )
+
+    runner = LocalShellRunner()
+    client = _FakeRemoteClient(runner)  # type: ignore[arg-type]
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+
+    result = _run_export(client, tmp_path / "top.gds", stream_map)
+
+    assert result.status == ExecutionStatus.ERROR
+    assert result.reason == GdsExportReason.TRANSPORT_ERROR
+    assert result.remote_files_retained is None
+    assert client.uploads == []
+    assert client.skills == []
+    assert not (attacker_target / "client").exists()
+
+
+@pytest.mark.parametrize("remove_run", [False, True])
+def test_remote_delete_command_revalidates_chain_before_exact_remove(
+    tmp_path: Path,
+    remove_run: bool,
+) -> None:
+    scratch = tmp_path / "scratch root"
+    scratch.mkdir()
+    paths = _remote_paths_under(scratch)
+    user_dir = Path(paths.owned_root.parent.parent.as_posix())
+    user_dir.mkdir(mode=0o700)
+    attacker_client = tmp_path / "attacker client"
+    run_dir = attacker_client / "xstream" / paths.run_dir.name
+    run_dir.mkdir(parents=True, mode=0o700)
+    gds_path = run_dir / "output.gds"
+    gds_path.write_bytes(b"must-survive")
+    (user_dir / "client").symlink_to(
+        attacker_client,
+        target_is_directory=True,
+    )
+
+    command = streamout._remote_delete_command(paths, remove_run=remove_run)
+    completed = subprocess.run(
+        ["sh", "-c", command],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode != 0
+    assert run_dir.is_dir()
+    assert gds_path.read_bytes() == b"must-survive"
+    exact_target = paths.run_dir if remove_run else paths.gds
+    action = "rm -rf" if remove_run else "rm -f"
+    assert f"{action} -- {shlex.quote(exact_target.as_posix())}" in command
+
+
+def test_remote_export_downloads_log_before_gds_and_publishes_atomically(
+    tmp_path: Path,
+) -> None:
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    gds_bytes = b"fresh-remote-gds"
+    runner = _FakeRemoteRunner(log_text=_SUCCESS_LOG, gds=gds_bytes)
+    client = _FakeRemoteClient(
+        runner,
+        skill_result=_started_result(),
+        remote_log=_SUCCESS_LOG.encode("utf-8"),
+        remote_gds=gds_bytes,
+    )
+    output_path = tmp_path / "published" / "top.gds"
+    log_path = tmp_path / "diagnostics" / "top.log"
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        log_path=log_path,
+        cleanup_policy="never",
+    )
+
+    assert result.status == ExecutionStatus.SUCCESS
+    assert result.reason == GdsExportReason.COMPLETED
+    assert result.timed_out is False
+    assert result.local_log_path == log_path
+    assert result.local_gds_path == output_path
+    assert log_path.read_text(encoding="utf-8") == _SUCCESS_LOG
+    assert output_path.read_bytes() == gds_bytes
+    assert result.remote_files_retained is True
+    assert [Path(remote).name for remote, _local, _timeout in client.downloads] == [
+        "xstream.log",
+        "output.gds",
+    ]
+    assert client.downloads[0][1].parent == log_path.parent
+    assert client.downloads[1][1].parent == output_path.parent
+    assert all(
+        re.fullmatch(r"\.vbd-[0-9a-f]{32}\.tmp", local.name)
+        for _remote, local, _timeout in client.downloads
+    )
+    assert all(timeout > 0.0 for _remote, _local, timeout in client.downloads)
+
+
+def test_remote_export_polls_generic_error_until_zero_count_completion(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    gds_bytes = b"fresh-remote-gds-after-poll"
+    runner = _FakeRemoteRunner(log_text=_PARTIAL_WITH_ERROR_LOG, gds=None)
+
+    def finish(_seconds: float) -> None:
+        runner.log_text = _ZERO_COUNT_WITH_ERROR_LOG
+        runner.gds = gds_bytes
+
+    clock = _FakeClock(0.0, on_sleep=finish)
+    _use_fake_time(monkeypatch, clock)
+    client = _FakeRemoteClient(
+        runner,
+        skill_result=_started_result(),
+        remote_log=_ZERO_COUNT_WITH_ERROR_LOG.encode("utf-8"),
+        remote_gds=gds_bytes,
+    )
+    output_path = tmp_path / "top.gds"
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        poll_interval=0.25,
+        cleanup_policy="never",
+    )
+
+    assert result.status == ExecutionStatus.SUCCESS
+    assert result.reason == GdsExportReason.COMPLETED
+    assert result.local_gds_path == output_path
+    assert result.log_result is not None
+    assert result.log_result.errors == (
+        "ERROR: current-run XStream error despite zero completion count",
+    )
+    assert result.errors == result.log_result.errors
+    assert output_path.read_bytes() == gds_bytes
+    assert clock.sleeps == [0.25]
+
+
+@pytest.mark.parametrize(
+    ("cleanup_policy", "expected_retained"),
+    [("never", True), ("always", False)],
+)
+def test_remote_gds_download_failure_preserves_old_output_and_retention(
+    tmp_path: Path,
+    cleanup_policy: str,
+    expected_retained: bool,
+) -> None:
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    runner = _FakeRemoteRunner(log_text=_SUCCESS_LOG, gds=b"remote-gds")
+
+    class FailingGdsClient(_FakeRemoteClient):
+        def download_file(
+            self,
+            remote_path: str,
+            local_path: Path,
+            *,
+            timeout: float,
+        ) -> object:
+            if remote_path.endswith("/output.gds"):
+                self.downloads.append((remote_path, Path(local_path), timeout))
+                return VirtuosoResult(
+                    status=ExecutionStatus.ERROR,
+                    errors=["GDS transfer failed"],
+                )
+            return super().download_file(
+                remote_path,
+                local_path,
+                timeout=timeout,
+            )
+
+    client = FailingGdsClient(
+        runner,
+        skill_result=_started_result(),
+        remote_log=_SUCCESS_LOG.encode("utf-8"),
+    )
+    output_path = tmp_path / "top.gds"
+    log_path = tmp_path / "top.log"
+    output_path.write_bytes(b"old-gds")
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        log_path=log_path,
+        cleanup_policy=cleanup_policy,
+    )
+
+    assert result.status == ExecutionStatus.ERROR
+    assert result.reason == GdsExportReason.TRANSPORT_ERROR
+    assert result.local_log_path == log_path
+    assert result.local_gds_path is None
+    assert output_path.read_bytes() == b"old-gds"
+    assert result.remote_files_retained is expected_retained
+    assert any("GDS transfer failed" in error for error in result.errors)
+
+
+def test_remote_export_full_log_overrides_successful_tail_and_blocks_gds(
+    tmp_path: Path,
+) -> None:
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    full_log = (
+        _PARTIAL_LOG
+        + "INFO (XSTRM-273): Translation failed.\n"
+        + "\n".join(f"detail {index}" for index in range(210))
+        + "\nINFO (XSTRM-234): Translation completed. 0 error(s) and "
+        "0 warning(s) found.\n"
+    )
+    gds_bytes = b"unverified-remote-gds"
+    runner = _FakeRemoteRunner(log_text=full_log, gds=gds_bytes)
+    client = _FakeRemoteClient(
+        runner,
+        skill_result=_started_result(),
+        remote_log=full_log.encode("utf-8"),
+        remote_gds=gds_bytes,
+    )
+    output_path = tmp_path / "top.gds"
+    output_path.write_bytes(b"old-gds")
+    log_path = tmp_path / "top.log"
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        log_path=log_path,
+        cleanup_policy="never",
+    )
+
+    assert result.status == ExecutionStatus.FAILURE
+    assert result.reason == GdsExportReason.XSTREAM_FAILURE
+    assert result.local_log_path == log_path
+    assert result.local_gds_path is None
+    assert log_path.read_text(encoding="utf-8") == full_log
+    assert output_path.read_bytes() == b"old-gds"
+    assert [Path(remote).name for remote, _local, _timeout in client.downloads] == [
+        "xstream.log"
+    ]
+    assert any(
+        "rm -f -- " in command
+        for command, _timeout in runner.calls
+    )
+
+
+def test_remote_log_republish_failure_drops_stale_path_and_keeps_current_log(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    runner = _FakeRemoteRunner(log_text=_SUCCESS_LOG, gds=b"remote-gds")
+
+    class CurrentLogClient(_FakeRemoteClient):
+        def download_file(
+            self,
+            remote_path: str,
+            local_path: Path,
+            *,
+            timeout: float,
+        ) -> object:
+            assert timeout > 0.0
+            self.downloads.append((remote_path, Path(local_path), timeout))
+            if remote_path.endswith("/xstream.log"):
+                assert runner.log_text is not None
+                Path(local_path).write_text(runner.log_text, encoding="utf-8")
+            else:
+                assert runner.gds is not None
+                Path(local_path).write_bytes(runner.gds)
+            return VirtuosoResult(status=ExecutionStatus.SUCCESS)
+
+    client = CurrentLogClient(runner, skill_result=_started_result())
+    output_path = tmp_path / "top.gds"
+    log_path = tmp_path / "top.log"
+    output_path.write_bytes(b"old-gds")
+    real_publish = streamout._publish_file
+    log_publications = 0
+
+    def fail_second_log_publication(
+        source: Path,
+        destination: Path,
+        **kwargs: Any,
+    ) -> None:
+        nonlocal log_publications
+        if destination == log_path.resolve():
+            log_publications += 1
+            if log_publications == 2:
+                raise OSError("second log publication denied")
+        real_publish(source, destination, **kwargs)
+        if destination == log_path.resolve() and log_publications == 1:
+            runner.log_text = _TERMINAL_LOG
+
+    monkeypatch.setattr(
+        streamout,
+        "_publish_file",
+        fail_second_log_publication,
+    )
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        log_path=log_path,
+        cleanup_policy="never",
+    )
+
+    assert result.status == ExecutionStatus.ERROR
+    assert result.reason == GdsExportReason.PUBLICATION_ERROR
+    assert result.log_result is not None
+    assert result.log_result.terminal_failures
+    assert result.local_log_path is None
+    assert result.local_gds_path is None
+    assert "INFO (XSTRM-273): Translation failed." in result.errors
+    assert any("second log publication denied" in error for error in result.errors)
+    assert log_path.read_text(encoding="utf-8") == _SUCCESS_LOG
+    assert output_path.read_bytes() == b"old-gds"
+
+
+def test_remote_poll_exact_timeout_recovers_once_after_progress(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    monkeypatch.setattr(streamout, "_SLEEP", clock.sleep)
+    runner = _FakeRemoteRunner(log_text=_PARTIAL_LOG)
+    budget = _Budget.start(1.0, 0.2, clock=clock)
+    recovery_calls: list[str] = []
+    warnings: list[str] = []
+
+    outcome = streamout._poll_remote_artifacts(
+        runner,
+        _remote_test_paths(),
+        budget,
+        0.25,
+        should_poll=True,
+        launch_indeterminate=True,
+        recovery_hook=lambda: recovery_calls.append("recover"),
+        warnings=warnings,
+    )
+
+    assert outcome.deadline_expired is True
+    assert outcome.saw_evidence is True
+    assert outcome.log is not None
+    assert outcome.log.completed is False
+    assert recovery_calls == ["recover"]
+    assert len(runner.calls) == 4
+    assert all(timeout > 0.0 for _command, timeout in runner.calls)
+    assert warnings == []
+
+
+def test_remote_poll_timeout_stops_without_call_after_expiry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    monkeypatch.setattr(streamout, "_SLEEP", clock.sleep)
+
+    class TimeoutRunner:
+        def __init__(self) -> None:
+            self.calls: list[float] = []
+
+        def run_command(self, _command: str, timeout: float) -> CommandResult:
+            assert timeout > 0.0
+            self.calls.append(timeout)
+            clock.now += timeout
+            raise subprocess.TimeoutExpired("ssh", timeout)
+
+    runner = TimeoutRunner()
+    budget = _Budget.start(1.0, 0.2, clock=clock)
+
+    outcome = streamout._poll_remote_artifacts(
+        runner,
+        _remote_test_paths(),
+        budget,
+        0.25,
+        should_poll=True,
+        launch_indeterminate=True,
+        recovery_hook=None,
+        warnings=[],
+    )
+
+    assert outcome.deadline_expired is True
+    assert outcome.staging_error is not None
+    assert "timed out" in outcome.staging_error
+    assert runner.calls == [pytest.approx(0.8)]
+    assert clock.sleeps == []
+
+
+def test_remote_nonzero_poll_is_transport_error_and_preserves_old_outputs(
+    tmp_path: Path,
+) -> None:
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+
+    class NonzeroPollRunner(_FakeRemoteRunner):
+        def run_command(self, command: str, timeout: float) -> CommandResult:
+            if " LOG_SIZE " in command and " GDS_SIZE " in command:
+                assert timeout > 0.0
+                self.calls.append((command, timeout))
+                return CommandResult(7, "", "remote poll transport failed")
+            return super().run_command(command, timeout)
+
+    runner = NonzeroPollRunner()
+    client = _FakeRemoteClient(runner, skill_result=_started_result())
+    output_path = tmp_path / "top.gds"
+    log_path = tmp_path / "top.log"
+    output_path.write_bytes(b"old-gds")
+    log_path.write_text("old-log\n", encoding="utf-8")
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        log_path=log_path,
+        cleanup_policy="never",
+    )
+
+    assert result.status == ExecutionStatus.ERROR
+    assert result.reason == GdsExportReason.TRANSPORT_ERROR
+    assert "remote poll transport failed" in "\n".join(result.errors)
+    assert result.local_log_path is None
+    assert result.local_gds_path is None
+    assert result.remote_files_retained is True
+    assert output_path.read_bytes() == b"old-gds"
+    assert log_path.read_text(encoding="utf-8") == "old-log\n"
+    assert client.downloads == []
+
+
+def test_remote_missing_sha256_tools_is_transport_error(
+    tmp_path: Path,
+) -> None:
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+
+    class MissingDigestRunner(_FakeRemoteRunner):
+        def run_command(self, command: str, timeout: float) -> CommandResult:
+            if "LOG_SHA256" in command:
+                assert timeout > 0.0
+                self.calls.append((command, timeout))
+                return CommandResult(78, "", "no SHA-256 tool available")
+            return super().run_command(command, timeout)
+
+    runner = MissingDigestRunner(log_text=_SUCCESS_LOG, gds=b"remote-gds")
+    client = _FakeRemoteClient(runner, skill_result=_started_result())
+    output_path = tmp_path / "top.gds"
+    output_path.write_bytes(b"old-gds")
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        cleanup_policy="never",
+    )
+
+    assert result.status == ExecutionStatus.ERROR
+    assert result.reason == GdsExportReason.TRANSPORT_ERROR
+    assert "no SHA-256 tool available" in "\n".join(result.errors)
+    assert result.local_gds_path is None
+    assert output_path.read_bytes() == b"old-gds"
+    assert client.downloads == []
+    normal_polls = [
+        command
+        for command, _timeout in runner.calls
+        if " LOG_SIZE " in command and "LOG_SHA256" not in command
+    ]
+    assert normal_polls
+
+
+def test_remote_non_timeout_skill_error_observes_once_without_sleep(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    runner = _FakeRemoteRunner()
+    client = _FakeRemoteClient(runner)
+
+    result = _run_export(
+        client,
+        tmp_path / "top.gds",
+        stream_map,
+        cleanup_policy="never",
+    )
+
+    sentinel_calls = [
+        command
+        for command, _timeout in runner.calls
+        if " LOG_SIZE " in command and " GDS_SIZE " in command
+    ]
+    assert result.reason == GdsExportReason.SKILL_ERROR
+    assert len(sentinel_calls) == 1
+    assert clock.sleeps == []
+
+
+@pytest.mark.parametrize(
+    ("cleanup_result", "expected_retained"),
+    [
+        (CommandResult(0, "", ""), False),
+        (CommandResult(1, "", "permission denied"), True),
+        (CommandResult(255, "", "Connection reset by peer"), None),
+    ],
+)
+def test_remote_success_cleanup_reports_exact_retention_state(
+    tmp_path: Path,
+    cleanup_result: CommandResult,
+    expected_retained: bool | None,
+) -> None:
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    gds_bytes = b"fresh-gds"
+    runner = _FakeRemoteRunner(
+        log_text=_SUCCESS_LOG,
+        gds=gds_bytes,
+        cleanup=cleanup_result,
+    )
+    client = _FakeRemoteClient(
+        runner,
+        skill_result=_started_result(),
+        remote_log=_SUCCESS_LOG.encode("utf-8"),
+        remote_gds=gds_bytes,
+    )
+
+    result = _run_export(client, tmp_path / "top.gds", stream_map)
+
+    assert result.status == ExecutionStatus.SUCCESS
+    assert result.reason == GdsExportReason.COMPLETED
+    assert result.remote_files_retained is expected_retained
+    cleanup_calls = [
+        command
+        for command, _timeout in runner.calls
+        if "rm -rf -- " in command
+    ]
+    assert len(cleanup_calls) == 1
+    assert f"rm -rf -- {result.remote_run_dir}" in cleanup_calls[0]
+    if cleanup_result.returncode != 0:
+        assert any("cleanup" in warning for warning in result.warnings)
+
+
+def test_remote_always_cleanup_runs_after_failed_log_and_preserves_reason(
+    tmp_path: Path,
+) -> None:
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    gds_bytes = b"unverified-gds"
+    runner = _FakeRemoteRunner(log_text=_TERMINAL_LOG, gds=gds_bytes)
+    client = _FakeRemoteClient(
+        runner,
+        skill_result=_started_result(),
+        remote_log=_TERMINAL_LOG.encode("utf-8"),
+        remote_gds=gds_bytes,
+    )
+
+    result = _run_export(
+        client,
+        tmp_path / "top.gds",
+        stream_map,
+        cleanup_policy="always",
+    )
+
+    assert result.status == ExecutionStatus.FAILURE
+    assert result.reason == GdsExportReason.XSTREAM_FAILURE
+    assert result.remote_files_retained is False
+    commands = [command for command, _timeout in runner.calls]
+    assert any("rm -f -- " in command for command in commands)
+    assert f"rm -rf -- {result.remote_run_dir}" in commands[-1]
+
+
+def test_remote_always_cleanup_retains_run_when_full_log_download_fails(
+    tmp_path: Path,
+) -> None:
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    runner = _FakeRemoteRunner(log_text=_SUCCESS_LOG, gds=b"remote-gds")
+    client = _FakeRemoteClient(
+        runner,
+        skill_result=_started_result(),
+        remote_gds=b"remote-gds",
+    )
+
+    result = _run_export(
+        client,
+        tmp_path / "top.gds",
+        stream_map,
+        cleanup_policy="always",
+    )
+
+    assert result.status == ExecutionStatus.ERROR
+    assert result.reason == GdsExportReason.TRANSPORT_ERROR
+    assert result.remote_files_retained is True
+    assert not any(
+        "rm -rf -- " in command
+        for command, _timeout in runner.calls
+    )
+
+
+def test_remote_cleanup_budget_exhaustion_sends_no_cleanup_command(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    gds_bytes = b"fresh-gds"
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    runner = _FakeRemoteRunner(log_text=_SUCCESS_LOG, gds=gds_bytes)
+    client = _FakeRemoteClient(
+        runner,
+        skill_result=_started_result(),
+        remote_log=_SUCCESS_LOG.encode("utf-8"),
+        remote_gds=gds_bytes,
+    )
+    real_publish = streamout._publish_file
+
+    def expire_after_gds(source: Path, destination: Path, **kwargs: Any) -> None:
+        real_publish(source, destination, **kwargs)
+        if destination.suffix == ".gds":
+            clock.now = 4.0
+
+    monkeypatch.setattr(streamout, "_publish_file", expire_after_gds)
+
+    result = _run_export(client, tmp_path / "top.gds", stream_map)
+
+    assert result.status == ExecutionStatus.SUCCESS
+    assert result.remote_files_retained is True
+    assert not any(
+        "rm -rf -- " in command
+        for command, _timeout in runner.calls
+    )
+    assert any("cleanup skipped" in warning for warning in result.warnings)
+
+
+def test_remote_cleanup_refuses_unowned_path_without_command() -> None:
+    paths = _remote_test_paths()
+    unowned = streamout._RemoteExportPaths(
+        owned_root=paths.owned_root,
+        run_dir=paths.owned_root.parent,
+        gds=paths.owned_root.parent / "output.gds",
+        log=paths.owned_root.parent / "xstream.log",
+        stream_map=paths.owned_root.parent / "stream.map",
+    )
+    runner = _FakeRemoteRunner()
+    budget = _Budget.start(10.0, 1.0, clock=lambda: 0.0)
+    warnings: list[str] = []
+
+    retained = streamout._cleanup_remote_run(
+        runner,
+        unowned,
+        budget,
+        warnings,
+    )
+
+    assert retained is True
+    assert runner.calls == []
+    assert warnings == ["refused to clean unowned remote XStream path"]
+
+
+def test_remote_cleanup_refuses_parent_traversal_without_command() -> None:
+    owned_root = PurePosixPath(
+        "/tmp/safe/../escape/virtuoso_bridge_user/client/xstream"
+    )
+    run_dir = owned_root / ("b" * 32)
+    paths = streamout._RemoteExportPaths(
+        owned_root=owned_root,
+        run_dir=run_dir,
+        gds=run_dir / "output.gds",
+        log=run_dir / "xstream.log",
+        stream_map=run_dir / "stream.map",
+    )
+    runner = _FakeRemoteRunner()
+    budget = _Budget.start(10.0, 1.0, clock=lambda: 0.0)
+    warnings: list[str] = []
+
+    retained = streamout._cleanup_remote_run(
+        runner,
+        paths,
+        budget,
+        warnings,
+    )
+
+    assert retained is True
+    assert runner.calls == []
+    assert warnings == ["refused to clean unowned remote XStream path"]
+
+
+def test_remote_cleanup_permission_exception_means_files_retained() -> None:
+    runner = _FakeRemoteRunner(cleanup=PermissionError("cleanup denied"))
+    budget = _Budget.start(10.0, 1.0, clock=lambda: 0.0)
+    warnings: list[str] = []
+
+    retained = streamout._cleanup_remote_run(
+        runner,
+        _remote_test_paths(),
+        budget,
+        warnings,
+    )
+
+    assert retained is True
+    assert any("cleanup failed" in warning for warning in warnings)
+
+
+def test_remote_gds_size_race_republishes_changed_terminal_log_first(
+    tmp_path: Path,
+) -> None:
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    initial_gds = b"initial-remote-gds"
+    runner = _FakeRemoteRunner(log_text=_SUCCESS_LOG, gds=initial_gds)
+
+    class RacingClient(_FakeRemoteClient):
+        def __init__(self) -> None:
+            super().__init__(runner, skill_result=_started_result())
+            self.gds_downloads = 0
+
+        def download_file(
+            self,
+            remote_path: str,
+            local_path: Path,
+            *,
+            timeout: float,
+        ) -> object:
+            assert timeout > 0.0
+            self.downloads.append((remote_path, Path(local_path), timeout))
+            if remote_path.endswith("/xstream.log"):
+                assert runner.log_text is not None
+                Path(local_path).write_text(runner.log_text, encoding="utf-8")
+            else:
+                self.gds_downloads += 1
+                if self.gds_downloads == 1:
+                    runner.log_text = _TERMINAL_LOG
+                    runner.gds = b"x"
+                assert runner.gds is not None
+                Path(local_path).write_bytes(runner.gds)
+            return VirtuosoResult(status=ExecutionStatus.SUCCESS)
+
+    client = RacingClient()
+    output_path = tmp_path / "top.gds"
+    log_path = tmp_path / "top.log"
+    output_path.write_bytes(b"old-gds")
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        log_path=log_path,
+        cleanup_policy="never",
+    )
+
+    assert result.status == ExecutionStatus.FAILURE
+    assert result.reason == GdsExportReason.XSTREAM_FAILURE
+    assert result.local_gds_path is None
+    assert output_path.read_bytes() == b"old-gds"
+    assert log_path.read_text(encoding="utf-8") == _TERMINAL_LOG
+
+
+@pytest.mark.parametrize(
+    (
+        "artifact",
+        "expected_reason",
+        "expected_log_downloads",
+        "expected_gds_downloads",
+    ),
+    [
+        ("log", GdsExportReason.TRANSPORT_ERROR, 3, 0),
+        ("gds", GdsExportReason.PUBLICATION_ERROR, 1, 3),
+    ],
+)
+def test_remote_artifact_churn_is_bounded_without_old_gds_replacement(
+    tmp_path: Path,
+    artifact: str,
+    expected_reason: GdsExportReason,
+    expected_log_downloads: int,
+    expected_gds_downloads: int,
+) -> None:
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    runner = _FakeRemoteRunner(log_text=_SUCCESS_LOG, gds=b"remote-gds")
+
+    class ChurningClient(_FakeRemoteClient):
+        def __init__(self) -> None:
+            super().__init__(runner, skill_result=_started_result())
+            self.log_generation = 0
+
+        def download_file(
+            self,
+            remote_path: str,
+            local_path: Path,
+            *,
+            timeout: float,
+        ) -> object:
+            self.downloads.append((remote_path, Path(local_path), timeout))
+            if remote_path.endswith("/xstream.log"):
+                assert runner.log_text is not None
+                Path(local_path).write_text(runner.log_text, encoding="utf-8")
+                if artifact == "log":
+                    self.log_generation += 1
+                    runner.log_text = (
+                        _SUCCESS_LOG
+                        + f"remote generation {self.log_generation}\n"
+                    )
+            else:
+                assert runner.gds is not None
+                Path(local_path).write_bytes(runner.gds)
+                if artifact == "gds":
+                    runner.gds += b"x"
+            return VirtuosoResult(status=ExecutionStatus.SUCCESS)
+
+    client = ChurningClient()
+    output_path = tmp_path / "top.gds"
+    log_path = tmp_path / "top.log"
+    output_path.write_bytes(b"old-gds")
+    log_path.write_text("old-log\n", encoding="utf-8")
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        log_path=log_path,
+        cleanup_policy="never",
+    )
+
+    downloaded_names = [
+        Path(remote_path).name
+        for remote_path, _local_path, _timeout in client.downloads
+    ]
+    assert result.status == ExecutionStatus.ERROR
+    assert result.reason == expected_reason
+    assert result.local_gds_path is None
+    assert output_path.read_bytes() == b"old-gds"
+    assert downloaded_names.count("xstream.log") == expected_log_downloads
+    assert downloaded_names.count("output.gds") == expected_gds_downloads
+    if artifact == "log":
+        assert result.local_log_path is None
+        assert log_path.read_text(encoding="utf-8") == "old-log\n"
+    else:
+        assert result.local_log_path == log_path
+        assert log_path.read_text(encoding="utf-8") == _SUCCESS_LOG
+
+
+def test_remote_same_size_early_log_rewrite_uses_current_full_log(
+    tmp_path: Path,
+) -> None:
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    terminal_line = "INFO (XSTRM-273): Translation failed."
+    benign_line = "ordinary early diagnostic".ljust(len(terminal_line))
+    suffix = (
+        "\n".join(f"detail {index:03d}" for index in range(220))
+        + "\nINFO (XSTRM-234): Translation completed. 0 error(s) and "
+        "0 warning(s) found.\n"
+    )
+    first_log = _PARTIAL_LOG + benign_line + "\n" + suffix
+    current_log = _PARTIAL_LOG + terminal_line + "\n" + suffix
+    assert len(first_log.encode("utf-8")) == len(current_log.encode("utf-8"))
+    assert first_log.splitlines()[-200:] == current_log.splitlines()[-200:]
+    runner = _FakeRemoteRunner(log_text=first_log, gds=b"remote-gds")
+
+    class RewritingLogClient(_FakeRemoteClient):
+        def __init__(self) -> None:
+            super().__init__(runner, skill_result=_started_result())
+            self.log_downloads = 0
+
+        def download_file(
+            self,
+            remote_path: str,
+            local_path: Path,
+            *,
+            timeout: float,
+        ) -> object:
+            self.downloads.append((remote_path, Path(local_path), timeout))
+            if remote_path.endswith("/xstream.log"):
+                self.log_downloads += 1
+                assert runner.log_text is not None
+                Path(local_path).write_text(runner.log_text, encoding="utf-8")
+                if self.log_downloads == 1:
+                    runner.log_text = current_log
+            else:
+                assert runner.gds is not None
+                Path(local_path).write_bytes(runner.gds)
+            return VirtuosoResult(status=ExecutionStatus.SUCCESS)
+
+    client = RewritingLogClient()
+    output_path = tmp_path / "top.gds"
+    log_path = tmp_path / "top.log"
+    output_path.write_bytes(b"old-gds")
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        log_path=log_path,
+        cleanup_policy="never",
+    )
+
+    assert result.status == ExecutionStatus.FAILURE
+    assert result.reason == GdsExportReason.XSTREAM_FAILURE
+    assert result.local_gds_path is None
+    assert log_path.read_text(encoding="utf-8") == current_log
+    assert output_path.read_bytes() == b"old-gds"
+
+
+@pytest.mark.parametrize("downloaded_version", ["old", "torn"])
+def test_remote_same_size_gds_rewrite_publishes_current_content(
+    tmp_path: Path,
+    downloaded_version: str,
+) -> None:
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    first_gds = b"A" * 4096
+    current_gds = b"B" * 4096
+    torn_gds = first_gds[:2048] + current_gds[2048:]
+    runner = _FakeRemoteRunner(log_text=_SUCCESS_LOG, gds=first_gds)
+
+    class RewritingGdsClient(_FakeRemoteClient):
+        def __init__(self) -> None:
+            super().__init__(runner, skill_result=_started_result())
+            self.gds_downloads = 0
+
+        def download_file(
+            self,
+            remote_path: str,
+            local_path: Path,
+            *,
+            timeout: float,
+        ) -> object:
+            self.downloads.append((remote_path, Path(local_path), timeout))
+            if remote_path.endswith("/xstream.log"):
+                assert runner.log_text is not None
+                Path(local_path).write_text(runner.log_text, encoding="utf-8")
+            else:
+                self.gds_downloads += 1
+                if self.gds_downloads == 1:
+                    Path(local_path).write_bytes(
+                        first_gds if downloaded_version == "old" else torn_gds
+                    )
+                    runner.gds = current_gds
+                else:
+                    assert runner.gds is not None
+                    Path(local_path).write_bytes(runner.gds)
+            return VirtuosoResult(status=ExecutionStatus.SUCCESS)
+
+    client = RewritingGdsClient()
+    output_path = tmp_path / "top.gds"
+    output_path.write_bytes(b"old-gds")
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        cleanup_policy="never",
+    )
+
+    assert result.status == ExecutionStatus.SUCCESS
+    assert result.local_gds_path == output_path
+    assert output_path.read_bytes() == current_gds
+    assert client.gds_downloads == 2
+
+
+def test_remote_gds_publication_failure_keeps_paths_and_old_gds_consistent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    gds_bytes = b"remote-gds"
+    runner = _FakeRemoteRunner(log_text=_SUCCESS_LOG, gds=gds_bytes)
+    client = _FakeRemoteClient(
+        runner,
+        skill_result=_started_result(),
+        remote_log=_SUCCESS_LOG.encode("utf-8"),
+        remote_gds=gds_bytes,
+    )
+    output_path = tmp_path / "top.gds"
+    log_path = tmp_path / "top.log"
+    output_path.write_bytes(b"old-gds")
+    log_path.write_text("old-log\n", encoding="utf-8")
+    real_publish = streamout._publish_file
+
+    def fail_selected_publication(
+        source: Path,
+        destination: Path,
+        **kwargs: Any,
+    ) -> None:
+        if destination == output_path.resolve():
+            raise OSError("GDS publication denied")
+        real_publish(source, destination, **kwargs)
+
+    monkeypatch.setattr(
+        streamout,
+        "_publish_file",
+        fail_selected_publication,
+    )
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        log_path=log_path,
+        cleanup_policy="never",
+    )
+
+    downloaded_names = [
+        Path(remote_path).name
+        for remote_path, _local_path, _timeout in client.downloads
+    ]
+    assert result.status == ExecutionStatus.ERROR
+    assert result.reason == GdsExportReason.PUBLICATION_ERROR
+    assert result.local_gds_path is None
+    assert output_path.read_bytes() == b"old-gds"
+    assert result.remote_files_retained is True
+    assert any("GDS publication denied" in error for error in result.errors)
+    assert result.local_log_path == log_path
+    assert log_path.read_text(encoding="utf-8") == _SUCCESS_LOG
+    assert downloaded_names == ["xstream.log", "output.gds"]
+
+
+def test_remote_validator_budget_expiry_blocks_gds_commit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    gds_bytes = b"fresh-gds"
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+
+    class DeadlineRunner(_FakeRemoteRunner):
+        def __init__(self) -> None:
+            super().__init__(log_text=_SUCCESS_LOG, gds=gds_bytes)
+            self.sentinel_calls = 0
+
+        def run_command(self, command: str, timeout: float) -> CommandResult:
+            result = super().run_command(command, timeout)
+            if " LOG_SIZE " in command and " GDS_SIZE " in command:
+                self.sentinel_calls += 1
+                if self.sentinel_calls == 6:
+                    clock.now = 4.0
+            return result
+
+    runner = DeadlineRunner()
+    client = _FakeRemoteClient(
+        runner,
+        skill_result=_started_result(),
+        remote_log=_SUCCESS_LOG.encode("utf-8"),
+        remote_gds=gds_bytes,
+    )
+    output_path = tmp_path / "top.gds"
+    output_path.write_bytes(b"old-gds")
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        cleanup_policy="never",
+    )
+
+    assert runner.sentinel_calls == 6
+    assert result.status == ExecutionStatus.ERROR
+    assert result.reason == GdsExportReason.TRANSPORT_ERROR
+    assert result.timed_out is True
+    assert result.local_gds_path is None
+    assert output_path.read_bytes() == b"old-gds"
+
+
+def test_remote_prefinal_budget_expiry_before_skill_makes_no_more_calls(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    runner = _FakeRemoteRunner()
+
+    class ExpiringUploadClient(_FakeRemoteClient):
+        def upload_file(
+            self,
+            local_path: Path,
+            remote_path: str,
+            *,
+            timeout: float,
+        ) -> object:
+            response = super().upload_file(
+                local_path,
+                remote_path,
+                timeout=timeout,
+            )
+            clock.now = 3.0
+            return response
+
+    client = ExpiringUploadClient(runner)
+
+    result = _run_export(client, tmp_path / "top.gds", stream_map)
+
+    assert result.status == ExecutionStatus.ERROR
+    assert result.reason == GdsExportReason.TRANSPORT_ERROR
+    assert result.timed_out is True
+    assert result.remote_files_retained is True
+    assert client.skills == []
+    assert len(runner.calls) == 1
+    assert "VBXSTREAM_STAGE_READY" in runner.calls[0][0]
+
+
+def test_remote_gds_validation_uses_stat_without_full_file_read(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    gds_bytes = b"fresh-gds"
+    runner = _FakeRemoteRunner(log_text=_SUCCESS_LOG, gds=gds_bytes)
+    client = _FakeRemoteClient(
+        runner,
+        skill_result=_started_result(),
+        remote_log=_SUCCESS_LOG.encode("utf-8"),
+        remote_gds=gds_bytes,
+    )
+    real_read = streamout._read_downloaded_file
+    read_labels: list[str] = []
+
+    def reject_gds_read(path: Path, *, label: str) -> bytes:
+        read_labels.append(label)
+        if label == "GDS":
+            raise AssertionError("GDS validation must not read full contents")
+        return real_read(path, label=label)
+
+    monkeypatch.setattr(streamout, "_read_downloaded_file", reject_gds_read)
+
+    result = _run_export(
+        client,
+        tmp_path / "top.gds",
+        stream_map,
+        cleanup_policy="never",
+    )
+
+    assert result.status == ExecutionStatus.SUCCESS
+    assert read_labels == ["log"]
+
+
+def test_remote_gds_digest_checks_budget_before_each_chunk(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gds_path = tmp_path / "download.gds"
+    gds_path.write_bytes(b"0123456789")
+    monkeypatch.setattr(streamout, "_REMOTE_HASH_CHUNK_BYTES", 4)
+
+    class ExpiringBudget:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def timeout(self, *, finalizing: bool) -> float:
+            assert finalizing is True
+            self.calls += 1
+            if self.calls == 3:
+                raise _BudgetExpired("export time budget exhausted")
+            return 1.0
+
+    budget = ExpiringBudget()
+
+    with pytest.raises(_BudgetExpired, match="budget exhausted"):
+        streamout._stream_file_sha256(gds_path, budget)
+
+    assert budget.calls == 3
+
+
+@pytest.mark.parametrize(
+    (
+        "log_text",
+        "gds_bytes",
+        "skill_result",
+        "expected_status",
+        "expected_reason",
+        "expected_timed_out",
+    ),
+    [
+        (
+            _SUCCESS_LOG,
+            None,
+            _started_result(),
+            ExecutionStatus.PARTIAL,
+            GdsExportReason.MISSING_GDS,
+            True,
+        ),
+        (
+            _SUCCESS_LOG,
+            b"",
+            _started_result(),
+            ExecutionStatus.PARTIAL,
+            GdsExportReason.EMPTY_GDS,
+            True,
+        ),
+        (
+            _PARTIAL_LOG,
+            None,
+            _started_result(),
+            ExecutionStatus.PARTIAL,
+            GdsExportReason.INCOMPLETE_LOG,
+            True,
+        ),
+        (
+            _MALFORMED_LOG,
+            b"invalid-gds",
+            _started_result(),
+            ExecutionStatus.ERROR,
+            GdsExportReason.MALFORMED_LOG,
+            False,
+        ),
+        (
+            _ERROR_COMPLETION_LOG,
+            b"invalid-gds",
+            _started_result(),
+            ExecutionStatus.FAILURE,
+            GdsExportReason.XSTREAM_ERRORS,
+            False,
+        ),
+        (
+            _ZERO_COUNT_WITH_ERROR_LOG,
+            b"diagnostic-gds",
+            _started_result(),
+            ExecutionStatus.SUCCESS,
+            GdsExportReason.COMPLETED,
+            False,
+        ),
+        (
+            _TERMINAL_LOG,
+            b"invalid-gds",
+            _started_result(),
+            ExecutionStatus.FAILURE,
+            GdsExportReason.XSTREAM_FAILURE,
+            False,
+        ),
+        (
+            _SUCCESS_LOG,
+            b"blocked-gds",
+            VirtuosoResult(
+                status=ExecutionStatus.SUCCESS,
+                output=(
+                    '("xstreamRequest" "started" nil '
+                    '("failed to restore XStream field runDir"))'
+                ),
+            ),
+            ExecutionStatus.ERROR,
+            GdsExportReason.REQUEST_CLEANUP_ERROR,
+            False,
+        ),
+        (
+            _SUCCESS_LOG,
+            b"blocked-gds",
+            VirtuosoResult(
+                status=ExecutionStatus.ERROR,
+                errors=["daemon rejected launch"],
+            ),
+            ExecutionStatus.ERROR,
+            GdsExportReason.SKILL_ERROR,
+            False,
+        ),
+        (
+            None,
+            None,
+            VirtuosoResult(
+                status=ExecutionStatus.ERROR,
+                errors=["Socket timeout after 2s"],
+            ),
+            ExecutionStatus.PARTIAL,
+            GdsExportReason.LAUNCH_INDETERMINATE,
+            True,
+        ),
+        (
+            _SUCCESS_LOG,
+            b"recovered-gds",
+            VirtuosoResult(
+                status=ExecutionStatus.ERROR,
+                errors=["SKILL execution timeout in Virtuoso"],
+                warnings=["bridge warning"],
+            ),
+            ExecutionStatus.SUCCESS,
+            GdsExportReason.COMPLETED,
+            False,
+        ),
+    ],
+)
+def test_remote_export_preserves_exact_reason_priority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    log_text: str | None,
+    gds_bytes: bytes | None,
+    skill_result: VirtuosoResult,
+    expected_status: ExecutionStatus,
+    expected_reason: GdsExportReason,
+    expected_timed_out: bool,
+) -> None:
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    runner = _FakeRemoteRunner(log_text=log_text, gds=gds_bytes)
+    client = _FakeRemoteClient(
+        runner,
+        skill_result=skill_result,
+        remote_log=(
+            log_text.encode("utf-8") if log_text is not None else None
+        ),
+        remote_gds=gds_bytes,
+    )
+
+    result = _run_export(
+        client,
+        tmp_path / "top.gds",
+        stream_map,
+        cleanup_policy="never",
+    )
+
+    assert result.status == expected_status
+    assert result.reason == expected_reason
+    assert result.timed_out is expected_timed_out
+    if expected_reason in {
+        GdsExportReason.REQUEST_CLEANUP_ERROR,
+        GdsExportReason.SKILL_ERROR,
+        GdsExportReason.MALFORMED_LOG,
+        GdsExportReason.XSTREAM_ERRORS,
+        GdsExportReason.XSTREAM_FAILURE,
+    }:
+        assert result.local_gds_path is None
+    if "bridge warning" in skill_result.warnings:
+        assert "bridge warning" in result.warnings
+
+
+def test_gds_export_reason_has_exact_string_values_and_public_exports() -> None:
+    assert {reason.value for reason in GdsExportReason} == {
+        "completed",
+        "xstream_failure",
+        "xstream_errors",
+        "request_cleanup_error",
+        "skill_error",
+        "launch_indeterminate",
+        "incomplete_log",
+        "missing_gds",
+        "empty_gds",
+        "malformed_log",
+        "staging_error",
+        "transport_error",
+        "publication_error",
+    }
+    assert all(isinstance(reason, str) for reason in GdsExportReason)
+    assert streamout.__all__ == [
+        "GdsExportReason",
+        "GdsExportResult",
+        "export_gds",
+    ]
+
+
+def test_gds_export_result_is_frozen_with_exact_tuple_fields() -> None:
+    log = _log_result(completed=True, error_count=0, warning_count=1)
+    result = GdsExportResult(
+        status=ExecutionStatus.FAILURE,
+        reason=GdsExportReason.XSTREAM_ERRORS,
+        timed_out=False,
+        library="demo",
+        cell="top",
+        view="layout",
+        execution_time=1.25,
+        local_gds_path=Path("top.gds"),
+        local_log_path=Path("top.xstream.log"),
+        log_result=log,
+        errors=("XSTRM error",),
+        warnings=("XSTRM warning",),
+        remote_run_dir="/tmp/run",
+        local_run_dir=Path("run"),
+        remote_files_retained=True,
+    )
+
+    assert tuple(field.name for field in fields(GdsExportResult)) == (
+        _GDS_EXPORT_RESULT_FIELDS
+    )
+    assert result.errors == ("XSTRM error",)
+    assert result.warnings == ("XSTRM warning",)
+    assert isinstance(result.errors, tuple)
+    assert isinstance(result.warnings, tuple)
+    with pytest.raises(FrozenInstanceError):
+        result.cell = "other"  # type: ignore[misc]
+
+
+def test_gds_export_result_normalizes_diagnostic_lists_to_tuples() -> None:
+    errors = ["XSTRM error"]
+    warnings = ["XSTRM warning"]
+    result = GdsExportResult(
+        status=ExecutionStatus.FAILURE,
+        reason=GdsExportReason.XSTREAM_ERRORS,
+        timed_out=False,
+        library="demo",
+        cell="top",
+        view="layout",
+        execution_time=1.0,
+        errors=errors,  # type: ignore[arg-type]
+        warnings=warnings,  # type: ignore[arg-type]
+    )
+    errors.append("later error")
+    warnings.append("later warning")
+
+    assert result.errors == ("XSTRM error",)
+    assert result.warnings == ("XSTRM warning",)
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        ExecutionStatus.SUCCESS,
+        ExecutionStatus.FAILURE,
+        ExecutionStatus.PARTIAL,
+        ExecutionStatus.ERROR,
+    ],
+)
+def test_gds_export_result_ok_only_for_success(status: ExecutionStatus) -> None:
+    result = GdsExportResult(
+        status=status,
+        reason=GdsExportReason.COMPLETED,
+        timed_out=False,
+        library="demo",
+        cell="top",
+        view="layout",
+        execution_time=0.1,
+    )
+
+    assert result.ok is (status == ExecutionStatus.SUCCESS)
+    assert result.errors == ()
+    assert result.warnings == ()
+
+
+def test_validate_export_inputs_normalizes_paths_and_default_log(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    stream_map = _write_stream_map(home / "layers.map")
+    monkeypatch.setenv("HOME", str(home))
+
+    inputs = _validate_export_inputs(
+        "demo",
+        "top",
+        "~/exports/../top.gds",
+        stream_map="~/layers.map",
+        view="layout",
+        log_path=None,
+        timeout=30,
+        poll_interval=1,
+        skill_timeout=5,
+        finalization_reserve=2,
+        cleanup_policy="success",
+    )
+
+    assert tuple(field.name for field in fields(type(inputs))) == _EXPORT_INPUT_FIELDS
+    assert inputs.library == "demo"
+    assert inputs.cell == "top"
+    assert inputs.view == "layout"
+    assert inputs.output_path == (home / "top.gds").resolve()
+    assert inputs.log_path == (home / "top.xstream.log").resolve()
+    assert inputs.stream_map == stream_map.resolve()
+    assert inputs.timeout == 30.0
+    assert inputs.poll_interval == 1.0
+    assert inputs.skill_timeout == 5.0
+    assert inputs.finalization_reserve == 2.0
+    assert inputs.cleanup_policy == "success"
+    with pytest.raises(FrozenInstanceError):
+        inputs.cell = "other"  # type: ignore[misc]
+
+
+def test_validate_export_inputs_normalizes_explicit_log_path(tmp_path: Path) -> None:
+    stream_map = _write_stream_map(tmp_path / "tech" / "layers.map")
+    kwargs = _validation_kwargs(stream_map)
+    kwargs["log_path"] = tmp_path / "logs" / ".." / "custom.log"
+
+    inputs = _validate_export_inputs(
+        "demo",
+        "top",
+        tmp_path / "runs" / ".." / "top.gds",
+        **kwargs,
+    )
+
+    assert inputs.output_path == (tmp_path / "top.gds").resolve()
+    assert inputs.log_path == (tmp_path / "custom.log").resolve()
+
+
+@pytest.mark.parametrize("map_kind", ["missing", "directory"])
+def test_validate_export_inputs_requires_regular_stream_map(
+    tmp_path: Path,
+    map_kind: str,
+) -> None:
+    stream_map = tmp_path / "layers.map"
+    if map_kind == "directory":
+        stream_map.mkdir()
+
+    with pytest.raises(FileNotFoundError):
+        _validate_export_inputs(
+            "demo",
+            "top",
+            tmp_path / "top.gds",
+            **_validation_kwargs(stream_map),
+        )
+
+
+@pytest.mark.parametrize("alias_pair", ["output_log", "output_map", "log_map"])
+def test_validate_export_inputs_rejects_all_normalized_path_aliases(
+    tmp_path: Path,
+    alias_pair: str,
+) -> None:
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    output_path = tmp_path / "top.gds"
+    log_path = tmp_path / "top.xstream.log"
+    if alias_pair == "output_log":
+        log_path = tmp_path / "nested" / ".." / "top.gds"
+    elif alias_pair == "output_map":
+        output_path = tmp_path / "nested" / ".." / "layers.map"
+    else:
+        log_path = tmp_path / "nested" / ".." / "layers.map"
+    kwargs = _validation_kwargs(stream_map)
+    kwargs["log_path"] = log_path
+
+    with pytest.raises(ValueError, match="distinct"):
+        _validate_export_inputs("demo", "top", output_path, **kwargs)
+
+
+@pytest.mark.parametrize("alias_pair", ["output_map", "log_map", "output_log"])
+def test_validate_export_inputs_rejects_existing_hardlink_aliases(
+    tmp_path: Path,
+    alias_pair: str,
+) -> None:
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    output_path = tmp_path / "top.gds"
+    log_path = tmp_path / "top.xstream.log"
+    if alias_pair == "output_map":
+        os.link(stream_map, output_path)
+    elif alias_pair == "log_map":
+        os.link(stream_map, log_path)
+    else:
+        output_path.write_bytes(b"synthetic gds")
+        os.link(output_path, log_path)
+    kwargs = _validation_kwargs(stream_map)
+    kwargs["log_path"] = log_path
+
+    with pytest.raises(ValueError, match="distinct"):
+        _validate_export_inputs("demo", "top", output_path, **kwargs)
+
+
+@pytest.mark.parametrize("field", ["library", "cell", "view"])
+@pytest.mark.parametrize(
+    "value",
+    ["", "   ", "\t", None, 1],
+    ids=["empty", "spaces", "tab", "none", "integer"],
+)
+def test_validate_export_inputs_requires_nonempty_string_names(
+    tmp_path: Path,
+    field: str,
+    value: object,
+) -> None:
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    names: dict[str, object] = {
+        "library": "demo",
+        "cell": "top",
+        "view": "layout",
+    }
+    names[field] = value
+    kwargs = _validation_kwargs(stream_map)
+    kwargs["view"] = names["view"]
+
+    with pytest.raises(ValueError, match=field):
+        _validate_export_inputs(
+            names["library"],  # type: ignore[arg-type]
+            names["cell"],  # type: ignore[arg-type]
+            tmp_path / "top.gds",
+            **kwargs,
+        )
+
+
+def test_validate_export_inputs_preserves_nonempty_name_whitespace(
+    tmp_path: Path,
+) -> None:
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    kwargs = _validation_kwargs(stream_map)
+    kwargs["view"] = "layout "
+
+    inputs = _validate_export_inputs(
+        " demo",
+        "\ttop",
+        tmp_path / "top.gds",
+        **kwargs,
+    )
+
+    assert inputs.library == " demo"
+    assert inputs.cell == "\ttop"
+    assert inputs.view == "layout "
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["timeout", "poll_interval", "skill_timeout", "finalization_reserve"],
+)
+@pytest.mark.parametrize(
+    "value",
+    [True, False, 0, -0.5, float("nan"), float("inf"), -float("inf"), "1", None],
+    ids=[
+        "true",
+        "false",
+        "zero",
+        "negative",
+        "nan",
+        "positive_infinity",
+        "negative_infinity",
+        "string",
+        "none",
+    ],
+)
+def test_validate_export_inputs_rejects_invalid_numeric_controls(
+    tmp_path: Path,
+    field: str,
+    value: object,
+) -> None:
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    kwargs = _validation_kwargs(stream_map)
+    kwargs[field] = value
+
+    with pytest.raises(ValueError, match=field):
+        _validate_export_inputs(
+            "demo",
+            "top",
+            tmp_path / "top.gds",
+            **kwargs,
+        )
+
+
+@pytest.mark.parametrize("reserve", [30.0, 31.0])
+def test_validate_export_inputs_requires_reserve_smaller_than_timeout(
+    tmp_path: Path,
+    reserve: float,
+) -> None:
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    kwargs = _validation_kwargs(stream_map)
+    kwargs["finalization_reserve"] = reserve
+
+    with pytest.raises(ValueError, match="finalization_reserve"):
+        _validate_export_inputs(
+            "demo",
+            "top",
+            tmp_path / "top.gds",
+            **kwargs,
+        )
+
+
+@pytest.mark.parametrize("cleanup_policy", [None, "", "Success", "sometimes", True])
+def test_validate_export_inputs_rejects_invalid_cleanup_policy(
+    tmp_path: Path,
+    cleanup_policy: object,
+) -> None:
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    kwargs = _validation_kwargs(stream_map)
+    kwargs["cleanup_policy"] = cleanup_policy
+
+    with pytest.raises(ValueError, match="cleanup_policy"):
+        _validate_export_inputs(
+            "demo",
+            "top",
+            tmp_path / "top.gds",
+            **kwargs,
+        )
+
+
+@pytest.mark.parametrize("cleanup_policy", ["success", "always", "never"])
+def test_validate_export_inputs_accepts_exact_cleanup_policies(
+    tmp_path: Path,
+    cleanup_policy: str,
+) -> None:
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    kwargs = _validation_kwargs(stream_map)
+    kwargs["cleanup_policy"] = cleanup_policy
+
+    inputs = _validate_export_inputs(
+        "demo",
+        "top",
+        tmp_path / "top.gds",
+        **kwargs,
+    )
+
+    assert inputs.cleanup_policy == cleanup_policy
+
+
+def test_budget_reserves_finalization_time_applies_cap_and_tracks_elapsed() -> None:
+    clock = _FakeClock(100.0)
+    budget = _Budget.start(10.0, 2.0, clock=clock)
+
+    assert budget.started_at == 100.0
+    assert budget.prefinalization_deadline == 108.0
+    assert budget.deadline == 110.0
+    assert budget.remaining(finalizing=False) == 8.0
+    assert budget.remaining(finalizing=True) == 10.0
+    assert budget.timeout(finalizing=False, cap=3.0) == 3.0
+    assert budget.timeout(finalizing=False, cap=20.0) == 8.0
+    assert budget.elapsed() == 0.0
+
+    clock.now = 103.25
+    assert budget.remaining(finalizing=False) == 4.75
+    assert budget.remaining(finalizing=True) == 6.75
+    assert budget.elapsed() == 3.25
+    with pytest.raises(FrozenInstanceError):
+        budget.deadline = 200.0  # type: ignore[misc]
+
+
+def test_budget_timeout_preserves_positive_subsecond_remainder() -> None:
+    clock = _FakeClock(0.0)
+    budget = _Budget.start(0.75, 0.25, clock=clock)
+    clock.now = 0.749999
+
+    timeout = budget.timeout(finalizing=True)
+
+    assert timeout == pytest.approx(0.000001)
+    assert timeout > 0.0
+
+
+def test_budget_prefinal_exhaustion_leaves_final_budget() -> None:
+    clock = _FakeClock(20.0)
+    budget = _Budget.start(5.0, 1.0, clock=clock)
+    clock.now = 24.0
+
+    assert budget.remaining(finalizing=False) == 0.0
+    assert budget.remaining(finalizing=True) == 1.0
+    with pytest.raises(_BudgetExpired):
+        budget.timeout(finalizing=False)
+    assert budget.timeout(finalizing=True) == 1.0
+
+
+def test_budget_total_exhaustion_raises_for_timeout() -> None:
+    clock = _FakeClock(20.0)
+    budget = _Budget.start(5.0, 1.0, clock=clock)
+    clock.now = 25.0
+
+    assert budget.remaining(finalizing=False) == 0.0
+    assert budget.remaining(finalizing=True) == 0.0
+    with pytest.raises(_BudgetExpired):
+        budget.timeout(finalizing=False)
+    with pytest.raises(_BudgetExpired):
+        budget.timeout(finalizing=True)
+
+
+def test_budget_elapsed_never_returns_negative_for_regressing_clock() -> None:
+    clock = _FakeClock(20.0)
+    budget = _Budget.start(5.0, 1.0, clock=clock)
+    clock.now = 19.5
+
+    assert budget.elapsed() == 0.0
+
+
+@pytest.mark.parametrize(
+    ("errors", "expected"),
+    [
+        ((), False),
+        (("SKILL execution timeout in Virtuoso",), True),
+        (("Socket timeout after 5s",), True),
+        (("Socket timeout after 0.25s",), True),
+        (("Socket timeout after 1e-06s",), True),
+        (("Socket timeout after 2E+3s",), True),
+        (
+            (
+                "SKILL execution timeout in Virtuoso",
+                "Socket timeout after 12.5s",
+            ),
+            True,
+        ),
+        (("prefix SKILL execution timeout in Virtuoso",), False),
+        (("SKILL execution timeout in Virtuoso.",), False),
+        (("Socket timeout after .5s",), False),
+        (("Socket timeout after 5.s",), False),
+        (("Socket timeout after -1s",), False),
+        (("Socket timeout after 1.2.3s",), False),
+        (("Socket timeout after 5s extra",), False),
+        (("prefix Socket timeout after 5s",), False),
+        (("Socket timeout after nans",), False),
+        (("Socket timeout after infs",), False),
+        (("Socket timeout after -infs",), False),
+        (("Socket timeout after s",), False),
+        (("timed out after 5s",), False),
+        (("socket timeout after 5s",), False),
+        (
+            (
+                "Socket timeout after 5s",
+                "other timeout while waiting",
+            ),
+            False,
+        ),
+    ],
+)
+def test_indeterminate_skill_timeout_requires_every_exact_match(
+    errors: tuple[str, ...],
+    expected: bool,
+) -> None:
+    assert _is_indeterminate_skill_timeout(errors) is expected
+
+
+@pytest.mark.parametrize(
+    ("observations", "expected"),
+    [
+        pytest.param(
+            {
+                "cleanup_failures": ("failed to restore logFile",),
+                "log": _log_result(
+                    completed=True,
+                    error_count=None,
+                    warning_count=None,
+                    terminal_failures=("XSTRM-273: Translation failed",),
+                ),
+                "skill_errors": ("explicit SKILL failure",),
+                "launch_indeterminate": True,
+                "saw_evidence": False,
+                "deadline_expired": True,
+            },
+            (
+                ExecutionStatus.ERROR,
+                GdsExportReason.REQUEST_CLEANUP_ERROR,
+                True,
+            ),
+            id="cleanup-wins-over-all-overlapping-observations",
+        ),
+        pytest.param(
+            {
+                "log": _log_result(
+                    completed=True,
+                    error_count=None,
+                    warning_count=0,
+                    terminal_failures=("XSTRM-273: Translation failed",),
+                ),
+                "skill_errors": ("explicit SKILL failure",),
+                "deadline_expired": True,
+            },
+            (ExecutionStatus.FAILURE, GdsExportReason.XSTREAM_FAILURE, True),
+            id="terminal-log-wins-over-non-timeout-skill-error",
+        ),
+        pytest.param(
+            {
+                "log": _log_result(
+                    completed=True,
+                    error_count=None,
+                    warning_count=0,
+                    errors=("ERROR: diagnostic before malformed completion",),
+                ),
+                "skill_errors": ("explicit SKILL failure",),
+                "deadline_expired": True,
+            },
+            (ExecutionStatus.ERROR, GdsExportReason.MALFORMED_LOG, True),
+            id="malformed-error-count-wins-over-non-timeout-skill-error",
+        ),
+        pytest.param(
+            {
+                "log": _log_result(
+                    completed=True,
+                    error_count=0,
+                    warning_count=None,
+                ),
+                "skill_errors": ("explicit SKILL failure",),
+                "deadline_expired": False,
+            },
+            (ExecutionStatus.ERROR, GdsExportReason.MALFORMED_LOG, False),
+            id="malformed-warning-count-wins-over-non-timeout-skill-error",
+        ),
+        pytest.param(
+            {
+                "log": _log_result(
+                    completed=True,
+                    error_count=2,
+                    warning_count=0,
+                    errors=("ERROR: diagnostic matching completion count",),
+                ),
+                "skill_errors": ("explicit SKILL failure",),
+                "deadline_expired": True,
+            },
+            (ExecutionStatus.FAILURE, GdsExportReason.XSTREAM_ERRORS, True),
+            id="xstream-error-count-wins-over-non-timeout-skill-error",
+        ),
+        pytest.param(
+            {
+                "log": _log_result(
+                    completed=True,
+                    error_count=0,
+                    warning_count=0,
+                ),
+                "skill_errors": (
+                    "Socket timeout after 1.5s",
+                    "explicit SKILL failure",
+                ),
+                "gds_present": False,
+                "deadline_expired": True,
+            },
+            (ExecutionStatus.ERROR, GdsExportReason.SKILL_ERROR, False),
+            id="non-timeout-skill-error-wins-over-missing-gds",
+        ),
+        pytest.param(
+            {
+                "log": _log_result(
+                    completed=True,
+                    error_count=0,
+                    warning_count=0,
+                ),
+                "gds_present": False,
+                "deadline_expired": False,
+            },
+            (ExecutionStatus.PARTIAL, GdsExportReason.MISSING_GDS, True),
+            id="valid-completion-with-missing-gds",
+        ),
+        pytest.param(
+            {
+                "log": _log_result(
+                    completed=True,
+                    error_count=0,
+                    warning_count=1,
+                ),
+                "gds_present": True,
+                "gds_size": 0,
+            },
+            (ExecutionStatus.PARTIAL, GdsExportReason.EMPTY_GDS, True),
+            id="valid-completion-with-empty-gds",
+        ),
+        pytest.param(
+            {
+                "log": _log_result(),
+                "launch_indeterminate": False,
+                "saw_evidence": False,
+            },
+            (ExecutionStatus.PARTIAL, GdsExportReason.INCOMPLETE_LOG, True),
+            id="returned-launch-with-incomplete-log",
+        ),
+        pytest.param(
+            {
+                "log": None,
+                "launch_indeterminate": True,
+                "saw_evidence": True,
+            },
+            (ExecutionStatus.PARTIAL, GdsExportReason.INCOMPLETE_LOG, True),
+            id="indeterminate-launch-with-evidence-is-incomplete-log",
+        ),
+        pytest.param(
+            {
+                "log": None,
+                "skill_errors": ("Socket timeout after 30s",),
+                "launch_indeterminate": True,
+                "saw_evidence": False,
+            },
+            (
+                ExecutionStatus.PARTIAL,
+                GdsExportReason.LAUNCH_INDETERMINATE,
+                True,
+            ),
+            id="indeterminate-launch-without-evidence",
+        ),
+        pytest.param(
+            {
+                "log": _log_result(
+                    completed=True,
+                    error_count=0,
+                    warning_count=2,
+                    errors=("ERROR: retained zero-count diagnostic",),
+                ),
+                "gds_present": True,
+                "gds_size": 1024,
+                "gds_published": True,
+                "deadline_expired": True,
+            },
+            (ExecutionStatus.SUCCESS, GdsExportReason.COMPLETED, False),
+            id="valid-completion-with-published-nonempty-gds",
+        ),
+    ],
+)
+def test_classify_export_applies_exact_priority_matrix(
+    observations: dict[str, object],
+    expected: tuple[ExecutionStatus, GdsExportReason, bool],
+) -> None:
+    defaults: dict[str, object] = {
+        "cleanup_failures": (),
+        "log": None,
+        "skill_errors": (),
+        "launch_indeterminate": False,
+        "saw_evidence": False,
+        "gds_present": False,
+        "gds_size": 0,
+        "gds_published": False,
+        "deadline_expired": False,
+    }
+    defaults.update(observations)
+
+    assert _classify_export(**defaults) == expected  # type: ignore[arg-type]
+
+
+def test_classify_export_rejects_unclassifiable_publication_invariant() -> None:
+    with pytest.raises(ValueError, match="unclassifiable"):
+        _classify_export(
+            cleanup_failures=(),
+            log=_log_result(
+                completed=True,
+                error_count=0,
+                warning_count=0,
+            ),
+            skill_errors=(),
+            launch_indeterminate=False,
+            saw_evidence=True,
+            gds_present=True,
+            gds_size=1,
+            gds_published=False,
+            deadline_expired=False,
+        )
+
+
+def test_export_gds_local_success_uses_direct_paths_without_transfers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(10.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "published" / "top.gds"
+    log_path = tmp_path / "logs" / "top.log"
+    stream_map = _write_stream_map(tmp_path / "maps" / "layers.map")
+    client = _artifact_client()
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        log_path=log_path,
+    )
+
+    assert result.status == ExecutionStatus.SUCCESS
+    assert result.reason == GdsExportReason.COMPLETED
+    assert result.timed_out is False
+    assert result.library == "demo"
+    assert result.cell == "top"
+    assert result.view == "layout"
+    assert result.execution_time == 0.0
+    assert result.local_gds_path == output_path.resolve()
+    assert result.local_log_path == log_path.resolve()
+    assert result.local_run_dir is None
+    assert result.remote_run_dir is None
+    assert result.remote_files_retained is None
+    assert result.errors == ()
+    assert output_path.read_bytes() == b"current-run-gds"
+    assert log_path.read_text(encoding="utf-8") == _SUCCESS_LOG
+    assert len(client.skill_calls) == 1
+    skill, used_timeout = client.skill_calls[0]
+    run_dir, staged_gds, staged_log = _request_artifacts(skill)
+    assert _skill_field(skill, "library") == "demo"
+    assert _skill_field(skill, "topCell") == "top"
+    assert _skill_field(skill, "view") == "layout"
+    assert _skill_field(skill, "runDir") == str(run_dir)
+    assert _skill_field(skill, "strmFile") == str(staged_gds)
+    assert _skill_field(skill, "logFile") == str(staged_log)
+    assert _skill_field(skill, "layerMap") == str(stream_map.resolve())
+    assert run_dir.parent == output_path.parent.resolve()
+    assert run_dir != output_path.parent.resolve()
+    assert staged_gds == run_dir / "output.gds"
+    assert staged_log == run_dir / "xstream.log"
+    assert 0.0 < used_timeout <= 2.0
+    assert clock.sleeps == []
+
+
+def test_export_gds_ignores_is_remote_when_runner_is_none(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _artifact_client(is_remote=True)
+
+    result = _run_export(client, output_path, stream_map)
+
+    assert result.status == ExecutionStatus.SUCCESS
+    assert result.local_gds_path == output_path.resolve()
+    assert len(client.skill_calls) == 1
+
+
+def test_export_gds_localhost_tunnel_shape_uses_local_filesystem(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    tunnel = SSHClient(remote_host="localhost", port=65432)
+    client = VirtuosoClient.from_tunnel(tunnel)
+    assert client.is_remote is True
+    assert client.ssh_runner is None
+    calls: list[tuple[str, float]] = []
+
+    def execute(skill: str, timeout: float) -> VirtuosoResult:
+        calls.append((skill, timeout))
+        _write_artifacts(skill)
+        return _started_result()
+
+    def forbidden(*args: object, **kwargs: object) -> object:
+        raise AssertionError("local tunnel export must not use transfer or X11 APIs")
+
+    monkeypatch.setattr(client, "execute_skill", execute)
+    monkeypatch.setattr(client, "upload_file", forbidden)
+    monkeypatch.setattr(client, "download_file", forbidden)
+    monkeypatch.setattr(client, "dismiss_dialog", forbidden)
+
+    result = _run_export(client, output_path, stream_map)
+
+    assert result.status == ExecutionStatus.SUCCESS
+    assert output_path.read_bytes() == b"current-run-gds"
+    assert len(calls) == 1
+
+
+def test_export_gds_non_none_runner_delegates_to_remote_dispatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+
+    class RemoteClient:
+        ssh_runner = object()
+
+        def execute_skill(self, *_args: object, **_kwargs: object) -> object:
+            raise AssertionError("remote dispatch must not enter local execution")
+
+    client = RemoteClient()
+    calls: list[tuple[object, object, object, object]] = []
+
+    def remote_dispatch(
+        used_client: object,
+        inputs: object,
+        budget: object,
+        recovery_hook: object,
+    ) -> GdsExportResult:
+        calls.append((used_client, inputs, budget, recovery_hook))
+        return GdsExportResult(
+            status=ExecutionStatus.ERROR,
+            reason=GdsExportReason.TRANSPORT_ERROR,
+            timed_out=False,
+            library="demo",
+            cell="top",
+            view="layout",
+            execution_time=0.0,
+            errors=("remote stub",),
+        )
+
+    monkeypatch.setattr(streamout, "_export_gds_remote", remote_dispatch)
+
+    result = _run_export(client, output_path, stream_map)
+
+    assert result.reason == GdsExportReason.TRANSPORT_ERROR
+    assert result.errors == ("remote stub",)
+    assert len(calls) == 1
+    assert calls[0][0] is client
+    assert calls[0][3] is None
+
+
+def test_export_gds_structures_ssh_runner_getter_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+
+    class BrokenClient:
+        @property
+        def ssh_runner(self) -> object:
+            raise RuntimeError("runner discovery failed")
+
+    result = _run_export(BrokenClient(), output_path, stream_map)
+
+    assert result.status == ExecutionStatus.ERROR
+    assert result.reason == GdsExportReason.TRANSPORT_ERROR
+    assert result.timed_out is False
+    assert result.local_gds_path is None
+    assert result.local_log_path is None
+    assert result.local_run_dir is None
+    assert any("runner discovery failed" in error for error in result.errors)
+
+
+def test_export_gds_uses_unique_current_run_and_never_reports_stale_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    output_path.write_bytes(b"stale-old-gds")
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    response = VirtuosoResult(
+        status=ExecutionStatus.ERROR,
+        errors=["explicit SKILL failure"],
+    )
+    first = _artifact_client(log_text=None, gds=None, response=response)
+    second = _artifact_client(log_text=None, gds=None, response=response)
+
+    first_result = _run_export(
+        first,
+        output_path,
+        stream_map,
+        cleanup_policy="never",
+    )
+    second_result = _run_export(
+        second,
+        output_path,
+        stream_map,
+        cleanup_policy="never",
+    )
+
+    assert first_result.reason == GdsExportReason.SKILL_ERROR
+    assert second_result.reason == GdsExportReason.SKILL_ERROR
+    assert first_result.local_gds_path is None
+    assert second_result.local_gds_path is None
+    assert first_result.local_run_dir is not None
+    assert second_result.local_run_dir is not None
+    assert first_result.local_run_dir != second_result.local_run_dir
+    assert first_result.local_run_dir.parent == output_path.parent.resolve()
+    assert second_result.local_run_dir.parent == output_path.parent.resolve()
+    assert output_path.read_bytes() == b"stale-old-gds"
+
+
+def test_export_gds_polls_generic_error_until_zero_count_completion(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    staged: dict[str, Path] = {}
+
+    def execute(skill: str, _timeout: float) -> VirtuosoResult:
+        run_dir, gds_path, log_path = _write_artifacts(
+            skill,
+            log_text=_PARTIAL_WITH_ERROR_LOG,
+            gds=None,
+        )
+        staged.update(run_dir=run_dir, gds=gds_path, log=log_path)
+        return _started_result()
+
+    def finish(_seconds: float) -> None:
+        staged["log"].write_text(
+            _ZERO_COUNT_WITH_ERROR_LOG,
+            encoding="utf-8",
+        )
+        staged["gds"].write_bytes(b"finished-after-one-poll")
+
+    clock = _FakeClock(0.0, on_sleep=finish)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _FakeLocalClient(execute)
+
+    result = _run_export(client, output_path, stream_map, poll_interval=0.25)
+
+    assert result.status == ExecutionStatus.SUCCESS
+    assert result.reason == GdsExportReason.COMPLETED
+    assert result.log_result is not None
+    assert result.log_result.errors == (
+        "ERROR: current-run XStream error despite zero completion count",
+    )
+    assert result.errors == result.log_result.errors
+    assert output_path.read_bytes() == b"finished-after-one-poll"
+    assert clock.sleeps == [0.25]
+
+
+def test_export_gds_observes_artifacts_when_skill_returns_at_prefinal_deadline(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+
+    def execute(skill: str, _timeout: float) -> object:
+        _write_artifacts(skill)
+        clock.now = 3.0
+        return {
+            "status": "error",
+            "errors": ["SKILL execution timeout in Virtuoso"],
+        }
+
+    client = _FakeLocalClient(execute)
+
+    result = _run_export(client, output_path, stream_map)
+
+    assert result.status == ExecutionStatus.SUCCESS
+    assert result.reason == GdsExportReason.COMPLETED
+    assert result.local_gds_path == output_path.resolve()
+    assert result.local_log_path == output_path.with_name("top.xstream.log")
+    assert result.local_log_path.read_text(encoding="utf-8") == _SUCCESS_LOG
+    assert clock.sleeps == []
+
+
+def test_export_gds_reobserves_artifacts_completed_during_final_sleep(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    staged: dict[str, Path] = {}
+
+    def execute(skill: str, _timeout: float) -> VirtuosoResult:
+        _run_dir, gds_path, log_path = _write_artifacts(
+            skill,
+            log_text=_PARTIAL_LOG,
+            gds=None,
+        )
+        staged.update(gds=gds_path, log=log_path)
+        return _started_result()
+
+    clock = _FakeClock(0.0)
+
+    def complete_on_boundary(_seconds: float) -> None:
+        if clock.now == pytest.approx(1.5):
+            staged["log"].write_text(_SUCCESS_LOG, encoding="utf-8")
+            staged["gds"].write_bytes(b"boundary-gds")
+
+    clock.on_sleep = complete_on_boundary
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _FakeLocalClient(execute)
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        timeout=2.0,
+        finalization_reserve=0.5,
+        poll_interval=1.0,
+    )
+
+    assert result.status == ExecutionStatus.SUCCESS
+    assert result.reason == GdsExportReason.COMPLETED
+    assert output_path.read_bytes() == b"boundary-gds"
+    assert clock.sleeps == [1.0, 0.5]
+
+
+def test_export_gds_does_not_observe_after_sleep_overshoots_total_deadline(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    staged: dict[str, Path] = {}
+
+    def execute(skill: str, _timeout: float) -> VirtuosoResult:
+        _run_dir, gds_path, log_path = _write_artifacts(
+            skill,
+            log_text=_PARTIAL_LOG,
+            gds=None,
+        )
+        staged.update(gds=gds_path, log=log_path)
+        return _started_result()
+
+    def oversleep_with_completion(_seconds: float) -> None:
+        clock.now = 5.0
+        staged["log"].write_text(_SUCCESS_LOG, encoding="utf-8")
+        staged["gds"].write_bytes(b"completed-during-oversleep")
+
+    clock = _FakeClock(0.0, on_sleep=oversleep_with_completion)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _FakeLocalClient(execute)
+    real_observe = streamout._observe_local_artifacts
+    observation_calls: list[Path] = []
+
+    def record_observation(paths: Any) -> Any:
+        observation_calls.append(paths.run_dir)
+        return real_observe(paths)
+
+    monkeypatch.setattr(
+        streamout,
+        "_observe_local_artifacts",
+        record_observation,
+    )
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        cleanup_policy="never",
+    )
+
+    assert result.status == ExecutionStatus.ERROR
+    assert result.reason == GdsExportReason.PUBLICATION_ERROR
+    assert result.timed_out is True
+    assert result.log_result is not None
+    assert result.log_result.completed is False
+    assert result.local_gds_path is None
+    assert result.local_log_path is None
+    assert result.local_run_dir is not None
+    assert (result.local_run_dir / "output.gds").read_bytes() == (
+        b"completed-during-oversleep"
+    )
+    assert len(observation_calls) == 1
+    assert clock.sleeps == [0.5]
+
+
+def test_export_gds_structures_sleep_overflow_for_large_finite_controls(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _artifact_client(log_text=None, gds=None)
+    sleep_calls: list[float] = []
+
+    def overflow(seconds: float) -> None:
+        sleep_calls.append(seconds)
+        raise OverflowError("timestamp out of range")
+
+    monkeypatch.setattr(streamout, "_SLEEP", overflow)
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        timeout=1e308,
+        poll_interval=1e308,
+        skill_timeout=1.0,
+        finalization_reserve=1.0,
+    )
+
+    assert result.status == ExecutionStatus.ERROR
+    assert result.reason == GdsExportReason.STAGING_ERROR
+    assert result.timed_out is False
+    assert sleep_calls == [pytest.approx(1e308)]
+    assert any("timestamp out of range" in error for error in result.errors)
+
+
+@pytest.mark.parametrize(
+    ("log_text", "expected_status", "expected_reason"),
+    [
+        (
+            _TERMINAL_LOG,
+            ExecutionStatus.FAILURE,
+            GdsExportReason.XSTREAM_FAILURE,
+        ),
+        (
+            _MALFORMED_LOG,
+            ExecutionStatus.ERROR,
+            GdsExportReason.MALFORMED_LOG,
+        ),
+        (
+            _ERROR_COMPLETION_LOG,
+            ExecutionStatus.FAILURE,
+            GdsExportReason.XSTREAM_ERRORS,
+        ),
+    ],
+)
+def test_export_gds_terminal_and_invalid_completions_exit_without_sleep(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    log_text: str,
+    expected_status: ExecutionStatus,
+    expected_reason: GdsExportReason,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    output_path.write_bytes(b"old-gds")
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _artifact_client(log_text=log_text)
+
+    result = _run_export(client, output_path, stream_map)
+
+    assert result.status == expected_status
+    assert result.reason == expected_reason
+    assert result.timed_out is False
+    assert result.local_gds_path is None
+    assert result.local_log_path == output_path.with_name("top.xstream.log")
+    assert output_path.read_bytes() == b"old-gds"
+    assert clock.sleeps == []
+
+
+def test_export_gds_exact_skill_timeout_can_recover_from_current_artifacts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    timeout_error = "SKILL execution timeout in Virtuoso"
+    response = {
+        "status": ExecutionStatus.ERROR,
+        "errors": [timeout_error],
+    }
+    client = _artifact_client(response=response)
+    recovery_calls: list[str] = []
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        recovery_hook=lambda: recovery_calls.append("called"),
+    )
+
+    assert result.status == ExecutionStatus.SUCCESS
+    assert result.reason == GdsExportReason.COMPLETED
+    assert result.timed_out is False
+    assert result.errors == (timeout_error,)
+    assert recovery_calls == ["called"]
+    assert clock.sleeps == []
+
+
+def test_export_gds_timeout_without_progress_waits_then_is_indeterminate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    response = {
+        "status": "error",
+        "errors": ["Socket timeout after 1.5s"],
+    }
+    client = _artifact_client(log_text=None, gds=None, response=response)
+    recovery_calls: list[str] = []
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        timeout=3.0,
+        finalization_reserve=1.0,
+        poll_interval=0.75,
+        recovery_hook=lambda: recovery_calls.append("called"),
+    )
+
+    assert result.status == ExecutionStatus.PARTIAL
+    assert result.reason == GdsExportReason.LAUNCH_INDETERMINATE
+    assert result.timed_out is True
+    assert result.local_gds_path is None
+    assert result.local_log_path == output_path.with_name("top.xstream.log")
+    assert "Socket timeout after 1.5s" in result.local_log_path.read_text(
+        encoding="utf-8"
+    )
+    assert recovery_calls == []
+    assert clock.sleeps == [0.75, 0.75, 0.5]
+    assert sum(clock.sleeps) == 2.0
+
+
+def test_export_gds_recovery_hook_runs_once_after_progress_and_warning_is_safe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    staged: dict[str, Path] = {}
+
+    def execute(skill: str, _timeout: float) -> object:
+        _run_dir, gds_path, log_path = _write_artifacts(
+            skill,
+            log_text=_PARTIAL_LOG,
+            gds=None,
+        )
+        staged.update(gds=gds_path, log=log_path)
+        return {
+            "status": "error",
+            "errors": ["SKILL execution timeout in Virtuoso"],
+        }
+
+    def finish(_seconds: float) -> None:
+        if len(clock.sleeps) == 1:
+            staged["log"].write_text(
+                _PARTIAL_LOG + "WARNING: recovery still in progress\n",
+                encoding="utf-8",
+            )
+        else:
+            staged["log"].write_text(_SUCCESS_LOG, encoding="utf-8")
+            staged["gds"].write_bytes(b"recovered")
+
+    hook_calls: list[str] = []
+
+    def recovery_hook() -> None:
+        hook_calls.append("called")
+        raise RuntimeError("X11 recovery unavailable")
+
+    clock = _FakeClock(0.0, on_sleep=finish)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _FakeLocalClient(execute)
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        recovery_hook=recovery_hook,
+    )
+
+    assert result.status == ExecutionStatus.SUCCESS
+    assert output_path.read_bytes() == b"recovered"
+    assert hook_calls == ["called"]
+    assert len(result.warnings) == 1
+    assert "X11 recovery unavailable" in result.warnings[0]
+    assert clock.sleeps == [0.5, 0.5]
+
+
+def test_export_gds_normal_response_never_calls_recovery_hook(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _artifact_client()
+
+    def forbidden_hook() -> None:
+        raise AssertionError("normal launch must not recover")
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        recovery_hook=forbidden_hook,
+    )
+
+    assert result.status == ExecutionStatus.SUCCESS
+    assert result.warnings == ()
+
+
+def test_export_gds_default_recovery_is_headless_for_indeterminate_timeout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _artifact_client(
+        log_text=_PARTIAL_LOG,
+        gds=None,
+        response=VirtuosoResult(
+            status=ExecutionStatus.ERROR,
+            errors=["SKILL execution timeout in Virtuoso"],
+        ),
+    )
+
+    result = streamout.export_gds(
+        client,
+        "demo",
+        "top",
+        output_path,
+        stream_map=stream_map,
+        timeout=2.0,
+        poll_interval=0.5,
+        skill_timeout=1.0,
+        finalization_reserve=0.5,
+    )
+
+    assert result.status == ExecutionStatus.PARTIAL
+    assert result.reason == GdsExportReason.INCOMPLETE_LOG
+    assert result.timed_out is True
+    assert clock.sleeps == [0.5, 0.5, 0.5]
+
+
+@pytest.mark.parametrize(
+    ("response", "diagnostic"),
+    [
+        (
+            VirtuosoResult(
+                status=ExecutionStatus.ERROR,
+                errors=["explicit SKILL failure"],
+            ),
+            "explicit SKILL failure",
+        ),
+        (
+            {"status": "error", "errors": []},
+            "SKILL request returned non-success status",
+        ),
+        (
+            {
+                "status": "success",
+                "output": '("xstreamRequest" "failed" "body failed" nil)',
+            },
+            "body failed",
+        ),
+        (
+            {"status": "success", "output": "malformed wire"},
+            "malformed XStream request response",
+        ),
+    ],
+    ids=["explicit", "status-only", "body", "malformed-wire"],
+)
+def test_export_gds_non_timeout_skill_failures_observe_once_without_sleep(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    response: object,
+    diagnostic: str,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    output_path.write_bytes(b"old-gds")
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _artifact_client(
+        log_text=_PARTIAL_LOG + "INFO: launch diagnostic\n",
+        gds=b"unvalidated",
+        response=response,
+    )
+    observation_calls: list[Path] = []
+    real_observe = streamout._observe_local_artifacts
+
+    def recording_observe(paths: Any) -> Any:
+        observation_calls.append(paths.run_dir)
+        return real_observe(paths)
+
+    monkeypatch.setattr(
+        streamout,
+        "_observe_local_artifacts",
+        recording_observe,
+    )
+
+    result = _run_export(client, output_path, stream_map)
+
+    assert result.status == ExecutionStatus.ERROR
+    assert result.reason == GdsExportReason.SKILL_ERROR
+    assert result.timed_out is False
+    assert any(diagnostic in error for error in result.errors)
+    assert result.local_gds_path is None
+    assert result.local_log_path == output_path.with_name("top.xstream.log")
+    assert "launch diagnostic" in result.local_log_path.read_text(encoding="utf-8")
+    assert output_path.read_bytes() == b"old-gds"
+    assert len(observation_calls) == 1
+    assert clock.sleeps == []
+
+
+@pytest.mark.parametrize(
+    ("log_text", "expected_status", "expected_reason"),
+    [
+        (
+            _TERMINAL_LOG,
+            ExecutionStatus.FAILURE,
+            GdsExportReason.XSTREAM_FAILURE,
+        ),
+        (
+            _MALFORMED_LOG,
+            ExecutionStatus.ERROR,
+            GdsExportReason.MALFORMED_LOG,
+        ),
+        (
+            _ERROR_COMPLETION_LOG,
+            ExecutionStatus.FAILURE,
+            GdsExportReason.XSTREAM_ERRORS,
+        ),
+    ],
+    ids=["terminal", "malformed", "nonzero"],
+)
+def test_export_gds_non_timeout_skill_error_yields_to_higher_priority_log(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    log_text: str,
+    expected_status: ExecutionStatus,
+    expected_reason: GdsExportReason,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    output_path.write_bytes(b"old-gds")
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _artifact_client(
+        log_text=log_text,
+        gds=b"diagnostic-only-gds",
+        response=VirtuosoResult(
+            status=ExecutionStatus.ERROR,
+            errors=["explicit SKILL failure"],
+        ),
+    )
+
+    result = _run_export(client, output_path, stream_map)
+
+    assert result.status == expected_status
+    assert result.reason == expected_reason
+    assert result.timed_out is False
+    assert "explicit SKILL failure" in result.errors
+    assert result.local_gds_path is None
+    assert output_path.read_bytes() == b"old-gds"
+    assert clock.sleeps == []
+
+
+def test_export_gds_refreshes_skill_error_log_before_final_classification(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    log_path = tmp_path / "top.log"
+    output_path.write_bytes(b"old-gds")
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _artifact_client(
+        log_text=_PARTIAL_LOG,
+        gds=None,
+        response=VirtuosoResult(
+            status=ExecutionStatus.ERROR,
+            errors=["explicit SKILL failure"],
+        ),
+    )
+    real_finalize = streamout._finalize_local_export
+
+    def append_terminal_before_finalization(
+        inputs: object,
+        paths: Any,
+        budget: object,
+        outcome: object,
+        **kwargs: Any,
+    ) -> GdsExportResult:
+        paths.log.write_text(_TERMINAL_LOG, encoding="utf-8")
+        return real_finalize(inputs, paths, budget, outcome, **kwargs)
+
+    monkeypatch.setattr(
+        streamout,
+        "_finalize_local_export",
+        append_terminal_before_finalization,
+    )
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        log_path=log_path,
+    )
+
+    assert result.status == ExecutionStatus.FAILURE
+    assert result.reason == GdsExportReason.XSTREAM_FAILURE
+    assert result.timed_out is False
+    assert "explicit SKILL failure" in result.errors
+    assert result.log_result is not None
+    assert result.log_result.terminal_failures
+    assert result.local_gds_path is None
+    assert result.local_log_path == log_path.resolve()
+    assert log_path.read_text(encoding="utf-8") == _TERMINAL_LOG
+    assert output_path.read_bytes() == b"old-gds"
+    assert clock.sleeps == []
+
+
+def test_export_gds_structures_execute_skill_exception(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+
+    def execute(_skill: str, _timeout: float) -> object:
+        raise RuntimeError("execute transport broke")
+
+    result = _run_export(_FakeLocalClient(execute), output_path, stream_map)
+
+    assert result.status == ExecutionStatus.ERROR
+    assert result.reason == GdsExportReason.SKILL_ERROR
+    assert any("execute transport broke" in error for error in result.errors)
+    assert result.local_log_path == output_path.with_name("top.xstream.log")
+
+
+def test_export_gds_structures_response_normalization_exception(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _artifact_client(log_text=None, gds=None)
+
+    def fail_normalization(_response: object) -> object:
+        raise RuntimeError("normalization broke")
+
+    monkeypatch.setattr(streamout, "response_fields", fail_normalization)
+
+    result = _run_export(client, output_path, stream_map)
+
+    assert result.status == ExecutionStatus.ERROR
+    assert result.reason == GdsExportReason.SKILL_ERROR
+    assert any("normalization broke" in error for error in result.errors)
+    assert result.local_log_path == output_path.with_name("top.xstream.log")
+
+
+def test_export_gds_preserves_virtuoso_result_warnings(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _artifact_client(
+        response=VirtuosoResult(
+            status=ExecutionStatus.SUCCESS,
+            output=_STARTED_WIRE,
+            warnings=["bridge warning"],
+        )
+    )
+
+    result = _run_export(client, output_path, stream_map)
+
+    assert result.status == ExecutionStatus.SUCCESS
+    assert result.warnings == ("bridge warning",)
+
+
+def test_export_gds_structures_surrogate_diagnostic_encoding_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _artifact_client(
+        log_text=None,
+        gds=None,
+        response=VirtuosoResult(
+            status=ExecutionStatus.ERROR,
+            errors=["explicit SKILL failure"],
+        ),
+    )
+
+    result = streamout.export_gds(
+        client,
+        "demo\udcff",
+        "top",
+        output_path,
+        stream_map=stream_map,
+        timeout=4.0,
+        poll_interval=0.5,
+        skill_timeout=2.0,
+        finalization_reserve=1.0,
+    )
+
+    assert result.status == ExecutionStatus.ERROR
+    assert result.reason == GdsExportReason.PUBLICATION_ERROR
+    assert result.local_log_path is None
+    assert any("surrogate" in error.lower() for error in result.errors)
+
+
+def test_export_gds_request_cleanup_failure_beats_successful_artifacts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    output_path.write_bytes(b"old-gds")
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    response = {
+        "status": "success",
+        "output": (
+            '("xstreamRequest" "started" nil '
+            '("failed to restore XStream field logFile"))'
+        ),
+    }
+    client = _artifact_client(response=response)
+
+    result = _run_export(client, output_path, stream_map)
+
+    assert result.status == ExecutionStatus.ERROR
+    assert result.reason == GdsExportReason.REQUEST_CLEANUP_ERROR
+    assert result.timed_out is False
+    assert result.errors[0] == "failed to restore XStream field logFile"
+    assert result.local_gds_path is None
+    assert result.local_log_path == output_path.with_name("top.xstream.log")
+    assert output_path.read_bytes() == b"old-gds"
+    assert clock.sleeps == []
+
+
+@pytest.mark.parametrize(
+    ("gds", "expected_reason"),
+    [
+        (None, GdsExportReason.MISSING_GDS),
+        (b"", GdsExportReason.EMPTY_GDS),
+    ],
+    ids=["missing", "empty"],
+)
+def test_export_gds_valid_completion_waits_for_missing_or_empty_gds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    gds: bytes | None,
+    expected_reason: GdsExportReason,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    output_path.write_bytes(b"old-gds")
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _artifact_client(gds=gds)
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        timeout=2.0,
+        finalization_reserve=0.5,
+        poll_interval=1.0,
+    )
+
+    assert result.status == ExecutionStatus.PARTIAL
+    assert result.reason == expected_reason
+    assert result.timed_out is True
+    assert result.local_gds_path is None
+    assert result.local_log_path == output_path.with_name("top.xstream.log")
+    assert output_path.read_bytes() == b"old-gds"
+    assert clock.sleeps == [1.0, 0.5]
+    assert result.local_run_dir is not None
+    assert not (result.local_run_dir / "output.gds").exists()
+
+
+def test_export_gds_incomplete_log_waits_to_prefinal_deadline(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _artifact_client(log_text=_PARTIAL_LOG, gds=None)
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        timeout=2.0,
+        finalization_reserve=0.5,
+        poll_interval=0.6,
+    )
+
+    assert result.status == ExecutionStatus.PARTIAL
+    assert result.reason == GdsExportReason.INCOMPLETE_LOG
+    assert result.timed_out is True
+    assert result.log_result is not None
+    assert result.log_result.completed is False
+    assert clock.sleeps == [0.6, 0.6, pytest.approx(0.3)]
+
+
+def test_publish_file_uses_temporary_sibling_and_cleans_it_on_replace_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "source.gds"
+    destination = tmp_path / "published" / ("d" * 200 + ".gds")
+    source.write_bytes(b"new-gds")
+    destination.parent.mkdir()
+    destination.write_bytes(b"old-gds")
+    replace_calls: list[tuple[Path, Path]] = []
+
+    def fail_replace(source_path: str | Path, destination_path: str | Path) -> None:
+        replace_calls.append((Path(source_path), Path(destination_path)))
+        raise OSError("replace denied")
+
+    monkeypatch.setattr(streamout.os, "replace", fail_replace)
+
+    with pytest.raises(OSError, match="replace denied"):
+        streamout._publish_file(source, destination)
+
+    assert len(replace_calls) == 1
+    temporary, used_destination = replace_calls[0]
+    assert temporary.parent == destination.parent
+    assert temporary != destination
+    assert temporary.name.startswith(".vbp-")
+    assert len(temporary.name) <= 48
+    assert destination.name not in temporary.name
+    assert used_destination == destination
+    assert not temporary.exists()
+    assert destination.read_bytes() == b"old-gds"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX mode semantics")
+@pytest.mark.parametrize("suffix", [".log", ".gds"])
+def test_publish_file_preserves_existing_destination_mode(
+    tmp_path: Path,
+    suffix: str,
+) -> None:
+    source = tmp_path / f"source{suffix}"
+    destination = tmp_path / f"published{suffix}"
+    source.write_bytes(b"new-data")
+    destination.write_bytes(b"old-data")
+    source.chmod(0o664)
+    destination.chmod(0o600)
+    original_owner = destination.stat().st_uid
+
+    streamout._publish_file(source, destination)
+
+    metadata = destination.stat()
+    assert destination.read_bytes() == b"new-data"
+    assert stat.S_IMODE(metadata.st_mode) == 0o600
+    assert metadata.st_uid == original_owner
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX mode semantics")
+@pytest.mark.parametrize("suffix", [".log", ".gds"])
+def test_publish_file_first_publication_inherits_source_mode(
+    tmp_path: Path,
+    suffix: str,
+) -> None:
+    source = tmp_path / f"source{suffix}"
+    destination = tmp_path / f"published{suffix}"
+    source.write_bytes(b"new-data")
+    source.chmod(0o640)
+
+    streamout._publish_file(source, destination)
+
+    assert destination.read_bytes() == b"new-data"
+    assert stat.S_IMODE(destination.stat().st_mode) == 0o640
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX owner semantics")
+def test_publish_file_refuses_to_change_existing_destination_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "source.log"
+    destination = tmp_path / "published.log"
+    source.write_bytes(b"new-data")
+    destination.write_bytes(b"old-data")
+    real_stat = Path.stat
+
+    def report_different_temp_owner(path: Path, *args: Any, **kwargs: Any) -> Any:
+        metadata = real_stat(path, *args, **kwargs)
+        if path.parent == tmp_path and path not in (source, destination):
+            values = list(metadata)
+            values[4] = metadata.st_uid + 1
+            return os.stat_result(values)
+        return metadata
+
+    monkeypatch.setattr(Path, "stat", report_different_temp_owner)
+
+    with pytest.raises(OSError, match="owner"):
+        streamout._publish_file(source, destination)
+
+    assert destination.read_bytes() == b"old-data"
+    assert not tuple(tmp_path.glob(".vbp-*.tmp"))
+
+
+def test_publish_file_rejects_empty_temporary_before_replace(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "empty.gds"
+    destination = tmp_path / "top.gds"
+    source.write_bytes(b"")
+    destination.write_bytes(b"old-gds")
+
+    with pytest.raises(OSError, match="empty"):
+        streamout._publish_file(source, destination)
+
+    assert destination.read_bytes() == b"old-gds"
+    assert not tuple(tmp_path.glob(".vbp-*.tmp"))
+
+
+def test_publish_file_rejects_source_change_during_validator(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source.gds"
+    destination = tmp_path / "published.gds"
+    source.write_bytes(b"copied-snapshot")
+    destination.write_bytes(b"old-gds")
+
+    def mutate_source() -> None:
+        source.write_bytes(b"newer-source")
+
+    with pytest.raises(streamout._SourceSnapshotChanged):
+        streamout._publish_file(
+            source,
+            destination,
+            validator=mutate_source,
+        )
+
+    assert source.read_bytes() == b"newer-source"
+    assert destination.read_bytes() == b"old-gds"
+    assert not tuple(tmp_path.glob(".vbp-*.tmp"))
+
+
+def test_export_gds_publishes_log_before_gds_atomically(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    log_path = tmp_path / "top.log"
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _artifact_client()
+    publish_order: list[Path] = []
+    real_publish = streamout._publish_file
+
+    def recording_publish(
+        source: Path,
+        destination: Path,
+        *,
+        validator: Callable[[], None] | None = None,
+    ) -> None:
+        publish_order.append(destination)
+        if validator is None:
+            real_publish(source, destination)
+        else:
+            real_publish(source, destination, validator=validator)
+
+    monkeypatch.setattr(streamout, "_publish_file", recording_publish)
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        log_path=log_path,
+    )
+
+    assert result.status == ExecutionStatus.SUCCESS
+    assert publish_order == [log_path.resolve(), output_path.resolve()]
+
+
+def test_export_gds_revalidates_gds_after_log_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    log_path = tmp_path / "top.log"
+    output_path.write_bytes(b"old-gds")
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _artifact_client()
+    real_publish = streamout._publish_file
+
+    def truncate_after_log(source: Path, destination: Path) -> None:
+        real_publish(source, destination)
+        if destination == log_path.resolve():
+            (source.parent / "output.gds").write_bytes(b"")
+
+    monkeypatch.setattr(streamout, "_publish_file", truncate_after_log)
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        log_path=log_path,
+    )
+
+    assert result.status == ExecutionStatus.PARTIAL
+    assert result.reason == GdsExportReason.EMPTY_GDS
+    assert result.timed_out is True
+    assert result.local_gds_path is None
+    assert result.local_log_path == log_path.resolve()
+    assert result.local_run_dir is not None
+    assert output_path.read_bytes() == b"old-gds"
+
+
+def test_export_gds_rechecks_log_after_log_publication_before_gds_commit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    log_path = tmp_path / "top.log"
+    output_path.write_bytes(b"old-gds")
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _artifact_client(gds=b"must-not-publish")
+    real_publish = streamout._publish_file
+    changed_live_log = False
+
+    def append_terminal_after_log_publish(
+        source: Path,
+        destination: Path,
+    ) -> None:
+        nonlocal changed_live_log
+        real_publish(source, destination)
+        if destination == log_path.resolve() and not changed_live_log:
+            changed_live_log = True
+            (source.parent / "xstream.log").write_text(
+                _TERMINAL_LOG,
+                encoding="utf-8",
+            )
+
+    monkeypatch.setattr(
+        streamout,
+        "_publish_file",
+        append_terminal_after_log_publish,
+    )
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        log_path=log_path,
+    )
+
+    assert result.status == ExecutionStatus.FAILURE
+    assert result.reason == GdsExportReason.XSTREAM_FAILURE
+    assert result.local_gds_path is None
+    assert result.local_log_path == log_path.resolve()
+    assert result.log_result is not None
+    assert result.log_result.terminal_failures
+    assert result.errors == result.log_result.terminal_failures
+    assert log_path.read_text(encoding="utf-8") == _TERMINAL_LOG
+    assert output_path.read_bytes() == b"old-gds"
+
+
+def test_export_gds_rechecks_log_after_gds_revalidation_before_commit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    log_path = tmp_path / "top.log"
+    output_path.write_bytes(b"old-gds")
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _artifact_client(gds=b"must-not-publish")
+    real_publish = streamout._publish_file
+    real_file_size = streamout._local_file_size
+    log_published = False
+    changed_live_log = False
+
+    def record_log_publication(source: Path, destination: Path) -> None:
+        nonlocal log_published
+        real_publish(source, destination)
+        if destination == log_path.resolve():
+            log_published = True
+
+    def append_terminal_during_gds_revalidation(path: Path) -> tuple[bool, int]:
+        nonlocal changed_live_log
+        result = real_file_size(path)
+        if log_published and path.name == "output.gds" and not changed_live_log:
+            changed_live_log = True
+            path.with_name("xstream.log").write_text(
+                _TERMINAL_LOG,
+                encoding="utf-8",
+            )
+        return result
+
+    monkeypatch.setattr(streamout, "_publish_file", record_log_publication)
+    monkeypatch.setattr(
+        streamout,
+        "_local_file_size",
+        append_terminal_during_gds_revalidation,
+    )
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        log_path=log_path,
+    )
+
+    assert result.status == ExecutionStatus.FAILURE
+    assert result.reason == GdsExportReason.XSTREAM_FAILURE
+    assert result.local_gds_path is None
+    assert result.local_log_path == log_path.resolve()
+    assert result.log_result is not None
+    assert result.log_result.terminal_failures
+    assert result.errors == result.log_result.terminal_failures
+    assert log_path.read_text(encoding="utf-8") == _TERMINAL_LOG
+    assert output_path.read_bytes() == b"old-gds"
+
+
+def test_export_gds_validates_log_inside_gds_publication_before_replace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    log_path = tmp_path / "top.log"
+    output_path.write_bytes(b"old-gds")
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _artifact_client(gds=b"must-not-publish")
+    real_publish = streamout._publish_file
+    validator_calls = 0
+
+    def mutate_before_replace(
+        source: Path,
+        destination: Path,
+        *,
+        validator: Callable[[], None] | None = None,
+    ) -> None:
+        nonlocal validator_calls
+        if destination != output_path.resolve():
+            real_publish(source, destination)
+            return
+        assert validator is not None
+
+        def append_terminal_then_validate() -> None:
+            nonlocal validator_calls
+            validator_calls += 1
+            temporary_files = tuple(
+                destination.parent.glob(".vbp-*.tmp")
+            )
+            assert len(temporary_files) == 1
+            assert temporary_files[0].read_bytes() == source.read_bytes()
+            source.with_name("xstream.log").write_text(
+                _TERMINAL_LOG,
+                encoding="utf-8",
+            )
+            validator()
+
+        real_publish(
+            source,
+            destination,
+            validator=append_terminal_then_validate,
+        )
+
+    monkeypatch.setattr(streamout, "_publish_file", mutate_before_replace)
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        log_path=log_path,
+    )
+
+    assert result.status == ExecutionStatus.FAILURE
+    assert result.reason == GdsExportReason.XSTREAM_FAILURE
+    assert result.local_gds_path is None
+    assert result.local_log_path == log_path.resolve()
+    assert result.log_result is not None
+    assert result.log_result.terminal_failures
+    assert log_path.read_text(encoding="utf-8") == _TERMINAL_LOG
+    assert output_path.read_bytes() == b"old-gds"
+    assert validator_calls == 1
+    assert not tuple(tmp_path.glob(".vbp-*.tmp"))
+
+
+def test_export_gds_bounds_pre_replace_log_change_retries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    output_path.write_bytes(b"old-gds")
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _artifact_client(gds=b"must-not-publish")
+    real_publish = streamout._publish_file
+    validator_calls = 0
+
+    def keep_changing_before_replace(
+        source: Path,
+        destination: Path,
+        *,
+        validator: Callable[[], None] | None = None,
+    ) -> None:
+        nonlocal validator_calls
+        if destination != output_path.resolve():
+            real_publish(source, destination)
+            return
+        assert validator is not None
+
+        def change_valid_log_then_validate() -> None:
+            nonlocal validator_calls
+            validator_calls += 1
+            source.with_name("xstream.log").write_text(
+                _SUCCESS_LOG + f"INFO: late update {validator_calls}\n",
+                encoding="utf-8",
+            )
+            validator()
+
+        real_publish(
+            source,
+            destination,
+            validator=change_valid_log_then_validate,
+        )
+
+    monkeypatch.setattr(
+        streamout,
+        "_publish_file",
+        keep_changing_before_replace,
+    )
+
+    result = _run_export(client, output_path, stream_map)
+
+    assert result.status == ExecutionStatus.ERROR
+    assert result.reason == GdsExportReason.PUBLICATION_ERROR
+    assert result.local_gds_path is None
+    assert output_path.read_bytes() == b"old-gds"
+    assert validator_calls == streamout._MAX_FINAL_LOG_REFRESHES
+    assert any("did not stabilize" in error for error in result.errors)
+    assert not tuple(tmp_path.glob(".vbp-*.tmp"))
+
+
+def test_export_gds_retries_same_size_source_rewrite_during_copy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    published_old = b"published-old"
+    output_path.write_bytes(published_old)
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    original_gds = b"A" * 16
+    replacement_gds = b"B" * len(original_gds)
+    client = _artifact_client(gds=original_gds)
+    real_copyfileobj = streamout.shutil.copyfileobj
+    gds_copy_attempts = 0
+    copied_attempts: list[bytes] = []
+
+    def rewrite_during_first_gds_copy(
+        source_file: Any,
+        destination_file: Any,
+        length: int = 0,
+    ) -> None:
+        nonlocal gds_copy_attempts
+        source_path = Path(source_file.name)
+        if source_path.name != "output.gds":
+            real_copyfileobj(source_file, destination_file, length)
+            return
+
+        gds_copy_attempts += 1
+        if gds_copy_attempts == 2:
+            assert output_path.read_bytes() == published_old
+        if gds_copy_attempts == 1:
+            midpoint = len(original_gds) // 2
+            destination_file.write(source_file.read(midpoint))
+            source_metadata = os.fstat(source_file.fileno())
+            source_path.write_bytes(replacement_gds)
+            os.utime(
+                source_path,
+                ns=(
+                    source_metadata.st_atime_ns,
+                    source_metadata.st_mtime_ns + 1_000_000_000,
+                ),
+            )
+        real_copyfileobj(source_file, destination_file, length)
+        destination_file.flush()
+        copied_attempts.append(Path(destination_file.name).read_bytes())
+
+    monkeypatch.setattr(
+        streamout.shutil,
+        "copyfileobj",
+        rewrite_during_first_gds_copy,
+    )
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        cleanup_policy="never",
+    )
+
+    assert result.status == ExecutionStatus.SUCCESS
+    assert result.reason == GdsExportReason.COMPLETED
+    assert result.local_gds_path == output_path.resolve()
+    assert result.errors == ()
+    assert gds_copy_attempts == 2
+    assert copied_attempts == [b"A" * 8 + b"B" * 8, replacement_gds]
+    assert output_path.read_bytes() == replacement_gds
+    assert result.local_run_dir is not None
+    assert (result.local_run_dir / "output.gds").read_bytes() == replacement_gds
+    assert not tuple(tmp_path.rglob(".vbp-*.tmp"))
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX open-file replacement")
+def test_export_gds_retries_source_path_replacement_after_copy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    published_old = b"published-old"
+    output_path.write_bytes(published_old)
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    original_gds = b"A" * 16
+    replacement_gds = b"C" * len(original_gds)
+    client = _artifact_client(gds=original_gds)
+    real_copyfileobj = streamout.shutil.copyfileobj
+    gds_copy_attempts = 0
+    copied_attempts: list[bytes] = []
+
+    def replace_path_after_first_gds_copy(
+        source_file: Any,
+        destination_file: Any,
+        length: int = 0,
+    ) -> None:
+        nonlocal gds_copy_attempts
+        source_path = Path(source_file.name)
+        if source_path.name != "output.gds":
+            real_copyfileobj(source_file, destination_file, length)
+            return
+
+        gds_copy_attempts += 1
+        if gds_copy_attempts == 2:
+            assert output_path.read_bytes() == published_old
+        real_copyfileobj(source_file, destination_file, length)
+        destination_file.flush()
+        copied_attempts.append(Path(destination_file.name).read_bytes())
+        if gds_copy_attempts == 1:
+            source_metadata = os.fstat(source_file.fileno())
+            replacement_path = source_path.with_name("replacement.gds")
+            replacement_path.write_bytes(replacement_gds)
+            os.replace(replacement_path, source_path)
+            assert not os.path.samestat(source_metadata, source_path.stat())
+
+    monkeypatch.setattr(
+        streamout.shutil,
+        "copyfileobj",
+        replace_path_after_first_gds_copy,
+    )
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        cleanup_policy="never",
+    )
+
+    assert result.status == ExecutionStatus.SUCCESS
+    assert result.reason == GdsExportReason.COMPLETED
+    assert result.local_gds_path == output_path.resolve()
+    assert result.errors == ()
+    assert gds_copy_attempts == 2
+    assert copied_attempts == [original_gds, replacement_gds]
+    assert output_path.read_bytes() == replacement_gds
+    assert result.local_run_dir is not None
+    assert (result.local_run_dir / "output.gds").read_bytes() == replacement_gds
+    assert not tuple(tmp_path.rglob(".vbp-*.tmp"))
+
+
+def test_export_gds_uses_read_snapshot_size_for_parse_and_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    log_path = tmp_path / "top.log"
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _artifact_client(log_text="", gds=b"snapshot-gds")
+    real_read_text = Path.read_text
+    real_read_bytes = Path.read_bytes
+    completed_before_read = False
+
+    def materialize_completion(path: Path) -> None:
+        nonlocal completed_before_read
+        if path.name == "xstream.log" and not completed_before_read:
+            completed_before_read = True
+            path.write_bytes(_SUCCESS_LOG.encode("utf-8"))
+
+    def read_text(path: Path, *args: Any, **kwargs: Any) -> str:
+        materialize_completion(path)
+        return real_read_text(path, *args, **kwargs)
+
+    def read_bytes(path: Path) -> bytes:
+        materialize_completion(path)
+        return real_read_bytes(path)
+
+    monkeypatch.setattr(Path, "read_text", read_text)
+    monkeypatch.setattr(Path, "read_bytes", read_bytes)
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        log_path=log_path,
+    )
+
+    assert result.status == ExecutionStatus.SUCCESS
+    assert result.reason == GdsExportReason.COMPLETED
+    assert result.errors == ()
+    assert result.local_log_path == log_path.resolve()
+    assert log_path.read_text(encoding="utf-8") == _SUCCESS_LOG
+    assert output_path.read_bytes() == b"snapshot-gds"
+
+
+def test_export_gds_rechecks_final_log_snapshot_before_gds_commit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    log_path = tmp_path / "top.log"
+    output_path.write_bytes(b"old-gds")
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _artifact_client(gds=b"must-not-publish")
+    real_finalize = streamout._finalize_local_export
+
+    def append_terminal_before_finalization(
+        inputs: object,
+        paths: Any,
+        budget: object,
+        outcome: object,
+        **kwargs: Any,
+    ) -> GdsExportResult:
+        paths.log.write_text(_TERMINAL_LOG, encoding="utf-8")
+        return real_finalize(inputs, paths, budget, outcome, **kwargs)
+
+    monkeypatch.setattr(
+        streamout,
+        "_finalize_local_export",
+        append_terminal_before_finalization,
+    )
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        log_path=log_path,
+    )
+
+    assert result.status == ExecutionStatus.FAILURE
+    assert result.reason == GdsExportReason.XSTREAM_FAILURE
+    assert result.local_gds_path is None
+    assert result.local_log_path == log_path.resolve()
+    assert result.log_result is not None
+    assert result.log_result.terminal_failures
+    assert log_path.read_text(encoding="utf-8") == _TERMINAL_LOG
+    assert output_path.read_bytes() == b"old-gds"
+
+
+def test_export_gds_zero_completion_count_with_error_line_publishes_gds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    output_path.write_bytes(b"old-gds")
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _artifact_client(
+        log_text=_ZERO_COUNT_WITH_ERROR_LOG,
+        gds=b"current-run-gds-with-diagnostic",
+    )
+
+    result = _run_export(client, output_path, stream_map)
+
+    assert result.status == ExecutionStatus.SUCCESS
+    assert result.reason == GdsExportReason.COMPLETED
+    assert result.local_gds_path == output_path.resolve()
+    assert result.local_log_path == output_path.with_name("top.xstream.log")
+    assert result.log_result is not None
+    assert result.log_result.errors == (
+        "ERROR: current-run XStream error despite zero completion count",
+    )
+    assert result.errors == result.log_result.errors
+    assert output_path.read_bytes() == b"current-run-gds-with-diagnostic"
+
+
+def test_export_gds_log_publication_crossing_deadline_is_structured(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    log_path = tmp_path / "top.log"
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _artifact_client(log_text=_TERMINAL_LOG, gds=None)
+    real_publish = streamout._publish_file
+
+    def consume_deadline(source: Path, destination: Path) -> None:
+        real_publish(source, destination)
+        if destination == log_path.resolve():
+            clock.now = 4.0
+
+    monkeypatch.setattr(streamout, "_publish_file", consume_deadline)
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        log_path=log_path,
+        cleanup_policy="never",
+    )
+
+    assert result.status == ExecutionStatus.ERROR
+    assert result.reason == GdsExportReason.PUBLICATION_ERROR
+    assert result.timed_out is True
+    assert result.local_log_path == log_path.resolve()
+    assert result.local_gds_path is None
+    assert log_path.read_text(encoding="utf-8") == _TERMINAL_LOG
+
+
+def test_export_gds_log_publication_failure_blocks_gds_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    log_path = tmp_path / "top.log"
+    output_path.write_bytes(b"old-gds")
+    log_path.write_text("old-log\n", encoding="utf-8")
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _artifact_client()
+    publish_order: list[Path] = []
+
+    def fail_log(_source: Path, destination: Path) -> None:
+        publish_order.append(destination)
+        raise OSError("log publication denied")
+
+    monkeypatch.setattr(streamout, "_publish_file", fail_log)
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        log_path=log_path,
+    )
+
+    assert result.status == ExecutionStatus.ERROR
+    assert result.reason == GdsExportReason.PUBLICATION_ERROR
+    assert result.timed_out is False
+    assert result.local_log_path is None
+    assert result.local_gds_path is None
+    assert publish_order == [log_path.resolve()]
+    assert output_path.read_bytes() == b"old-gds"
+    assert log_path.read_text(encoding="utf-8") == "old-log\n"
+
+
+def test_export_gds_gds_publication_failure_preserves_old_gds_and_new_log(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    log_path = tmp_path / "top.log"
+    output_path.write_bytes(b"old-gds")
+    log_path.write_text("old-log\n", encoding="utf-8")
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _artifact_client()
+    publish_order: list[Path] = []
+    real_publish = streamout._publish_file
+
+    def fail_gds(
+        source: Path,
+        destination: Path,
+        *,
+        validator: Callable[[], None] | None = None,
+    ) -> None:
+        publish_order.append(destination)
+        if destination == output_path.resolve():
+            raise OSError("GDS publication denied")
+        if validator is None:
+            real_publish(source, destination)
+        else:
+            real_publish(source, destination, validator=validator)
+
+    monkeypatch.setattr(streamout, "_publish_file", fail_gds)
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        log_path=log_path,
+    )
+
+    assert result.status == ExecutionStatus.ERROR
+    assert result.reason == GdsExportReason.PUBLICATION_ERROR
+    assert result.local_log_path == log_path.resolve()
+    assert result.local_gds_path is None
+    assert publish_order == [log_path.resolve(), output_path.resolve()]
+    assert output_path.read_bytes() == b"old-gds"
+    assert log_path.read_text(encoding="utf-8") == _SUCCESS_LOG
+
+
+@pytest.mark.parametrize(
+    ("cleanup_policy", "succeeds", "run_dir_retained"),
+    [
+        ("success", True, False),
+        ("success", False, True),
+        ("always", True, False),
+        ("always", False, False),
+        ("never", True, True),
+        ("never", False, True),
+    ],
+)
+def test_export_gds_local_cleanup_policy_controls_run_retention(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    cleanup_policy: str,
+    succeeds: bool,
+    run_dir_retained: bool,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / f"{cleanup_policy}-{succeeds}" / "top.gds"
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = (
+        _artifact_client()
+        if succeeds
+        else _artifact_client(log_text=_TERMINAL_LOG, gds=None)
+    )
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        cleanup_policy=cleanup_policy,
+    )
+
+    assert result.status == (
+        ExecutionStatus.SUCCESS if succeeds else ExecutionStatus.FAILURE
+    )
+    assert result.local_log_path == output_path.with_name("top.xstream.log").resolve()
+    assert (result.local_run_dir is not None) is run_dir_retained
+    if result.local_run_dir is not None:
+        assert result.local_run_dir.is_dir()
+
+
+def test_export_gds_always_cleanup_removes_run_after_recovered_diagnostic_log(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _artifact_client(
+        log_text=None,
+        gds=None,
+        response=VirtuosoResult(
+            status=ExecutionStatus.ERROR,
+            errors=["explicit SKILL failure"],
+        ),
+    )
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        cleanup_policy="always",
+    )
+
+    assert result.reason == GdsExportReason.SKILL_ERROR
+    assert result.local_log_path == output_path.with_name("top.xstream.log")
+    assert "explicit SKILL failure" in result.local_log_path.read_text(
+        encoding="utf-8"
+    )
+    assert result.local_run_dir is None
+
+
+def test_export_gds_prefers_late_xstream_log_over_synthetic_diagnostic(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    staged_log: list[Path] = []
+
+    def execute(skill: str, _timeout: float) -> VirtuosoResult:
+        _run_dir, _gds_path, log_path = _request_artifacts(skill)
+        staged_log.append(log_path)
+        return VirtuosoResult(
+            status=ExecutionStatus.ERROR,
+            errors=["explicit SKILL failure"],
+        )
+
+    client = _FakeLocalClient(execute)
+    real_diagnostic = streamout._diagnostic_log_text
+
+    def producer_wins_race(inputs: object, errors: list[str]) -> str:
+        staged_log[0].write_text(_SUCCESS_LOG, encoding="utf-8")
+        return real_diagnostic(inputs, errors)
+
+    monkeypatch.setattr(
+        streamout,
+        "_diagnostic_log_text",
+        producer_wins_race,
+    )
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        cleanup_policy="never",
+    )
+
+    assert result.reason == GdsExportReason.SKILL_ERROR
+    assert "explicit SKILL failure" in result.errors
+    assert result.log_result is not None
+    assert result.log_result.completed is True
+    assert result.local_log_path == output_path.with_name("top.xstream.log")
+    assert result.local_log_path.read_text(encoding="utf-8") == _SUCCESS_LOG
+    assert staged_log[0].read_text(encoding="utf-8") == _SUCCESS_LOG
+
+
+def test_export_gds_always_cleanup_retains_run_when_log_cannot_publish(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _artifact_client(log_text=_TERMINAL_LOG, gds=None)
+    cleanup_calls: list[Path] = []
+
+    def fail_publish(_source: Path, _destination: Path) -> None:
+        raise OSError("publication unavailable")
+
+    monkeypatch.setattr(streamout, "_publish_file", fail_publish)
+    monkeypatch.setattr(
+        streamout.shutil,
+        "rmtree",
+        lambda path: cleanup_calls.append(Path(path)),
+    )
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        cleanup_policy="always",
+    )
+
+    assert result.reason == GdsExportReason.PUBLICATION_ERROR
+    assert result.local_log_path is None
+    assert result.local_run_dir is not None
+    assert result.local_run_dir.is_dir()
+    assert cleanup_calls == []
+
+
+@pytest.mark.parametrize("cleanup_policy", ["success", "always"])
+def test_local_cleanup_failure_preserves_status_and_reports_run_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    cleanup_policy: str,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _artifact_client()
+
+    def fail_cleanup(_path: Path) -> None:
+        raise OSError("cleanup denied")
+
+    monkeypatch.setattr(streamout.shutil, "rmtree", fail_cleanup)
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        cleanup_policy=cleanup_policy,
+    )
+
+    assert result.status == ExecutionStatus.SUCCESS
+    assert result.reason == GdsExportReason.COMPLETED
+    assert result.timed_out is False
+    assert result.local_gds_path == output_path.resolve()
+    assert result.local_log_path == output_path.with_name("top.xstream.log")
+    assert result.local_run_dir is not None
+    assert result.local_run_dir.is_dir()
+    assert result.errors == ()
+    assert any("local XStream cleanup failed" in warning for warning in result.warnings)
+    assert any("cleanup denied" in warning for warning in result.warnings)
+
+
+@pytest.mark.parametrize("cleanup_policy", ["success", "never"])
+def test_gds_commit_crossing_deadline_warns_and_retains_staging(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    cleanup_policy: str,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _artifact_client()
+    real_publish = streamout._publish_file
+
+    def consume_budget(
+        source: Path,
+        destination: Path,
+        *,
+        validator: Callable[[], None] | None = None,
+    ) -> None:
+        if validator is None:
+            real_publish(source, destination)
+        else:
+            real_publish(source, destination, validator=validator)
+        if destination == output_path.resolve():
+            clock.now = 4.0
+
+    def forbidden_cleanup(_path: Path) -> None:
+        raise AssertionError("cleanup called after total deadline")
+
+    monkeypatch.setattr(streamout, "_publish_file", consume_budget)
+    monkeypatch.setattr(streamout.shutil, "rmtree", forbidden_cleanup)
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        cleanup_policy=cleanup_policy,
+    )
+
+    assert result.status == ExecutionStatus.SUCCESS
+    assert result.reason == GdsExportReason.COMPLETED
+    assert result.timed_out is False
+    assert result.local_gds_path == output_path.resolve()
+    assert result.local_log_path == output_path.with_name("top.xstream.log")
+    assert result.local_run_dir is not None
+    assert output_path.read_bytes() == b"current-run-gds"
+    assert result.errors == ()
+    assert (
+        "GDS publication completed after the export deadline; "
+        "local staging retained"
+    ) in result.warnings
+    if cleanup_policy == "success":
+        assert "cleanup skipped because the export deadline expired" in result.warnings
+
+
+def test_export_gds_cleanup_budget_exhaustion_preserves_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _artifact_client(log_text=_TERMINAL_LOG, gds=None)
+    real_classify = streamout._classify_export
+
+    def expire_after_classification(**observations: object) -> object:
+        classified = real_classify(**observations)
+        clock.now = 4.0
+        return classified
+
+    def forbidden_cleanup(_path: Path) -> None:
+        raise AssertionError("cleanup called without remaining budget")
+
+    monkeypatch.setattr(
+        streamout,
+        "_classify_export",
+        expire_after_classification,
+    )
+    monkeypatch.setattr(streamout.shutil, "rmtree", forbidden_cleanup)
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        cleanup_policy="always",
+    )
+
+    assert result.status == ExecutionStatus.FAILURE
+    assert result.reason == GdsExportReason.XSTREAM_FAILURE
+    assert result.timed_out is False
+    assert result.local_log_path == output_path.with_name("top.xstream.log")
+    assert result.local_run_dir is not None
+    assert result.local_run_dir.is_dir()
+    assert not any("budget exhausted" in error for error in result.errors)
+    assert "cleanup skipped because the export deadline expired" in result.warnings
+
+
+def test_export_gds_cleanup_crossing_deadline_preserves_success_with_removed_run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _artifact_client()
+    real_cleanup = streamout.shutil.rmtree
+
+    def consume_deadline(path: Path) -> None:
+        real_cleanup(path)
+        clock.now = 4.0
+
+    monkeypatch.setattr(streamout.shutil, "rmtree", consume_deadline)
+
+    result = _run_export(client, output_path, stream_map)
+
+    assert result.status == ExecutionStatus.SUCCESS
+    assert result.reason == GdsExportReason.COMPLETED
+    assert result.timed_out is False
+    assert result.local_gds_path == output_path.resolve()
+    assert result.local_log_path == output_path.with_name("top.xstream.log")
+    assert result.local_run_dir is None
+    assert result.errors == ()
+    assert (
+        "local XStream cleanup completed after the export deadline"
+        in result.warnings
+    )
+
+
+def test_export_gds_cleanup_failure_after_deadline_preserves_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _artifact_client()
+
+    def fail_after_deadline(_path: Path) -> None:
+        clock.now = 4.0
+        raise OSError("late cleanup failure")
+
+    monkeypatch.setattr(streamout.shutil, "rmtree", fail_after_deadline)
+
+    result = _run_export(client, output_path, stream_map)
+
+    assert result.status == ExecutionStatus.SUCCESS
+    assert result.reason == GdsExportReason.COMPLETED
+    assert result.timed_out is False
+    assert result.local_run_dir is not None
+    assert result.local_run_dir.is_dir()
+    assert result.errors == ()
+    assert any("late cleanup failure" in warning for warning in result.warnings)
+
+
+def test_export_gds_setup_error_is_structured_and_skips_skill_call(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    blocker = tmp_path / "not-a-directory"
+    blocker.write_text("blocker\n", encoding="utf-8")
+    output_path = blocker / "top.gds"
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _artifact_client()
+
+    result = _run_export(client, output_path, stream_map)
+
+    assert result.status == ExecutionStatus.ERROR
+    assert result.reason == GdsExportReason.STAGING_ERROR
+    assert result.timed_out is False
+    assert result.local_gds_path is None
+    assert result.local_log_path is None
+    assert client.skill_calls == []
+
+
+def test_export_gds_observation_read_error_is_structured(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+
+    def execute(skill: str, _timeout: float) -> VirtuosoResult:
+        _run_dir, _gds_path, log_path = _request_artifacts(skill)
+        log_path.mkdir()
+        return _started_result()
+
+    client = _FakeLocalClient(execute)
+
+    result = _run_export(client, output_path, stream_map)
+
+    assert result.status == ExecutionStatus.ERROR
+    assert result.reason == GdsExportReason.STAGING_ERROR
+    assert result.timed_out is False
+    assert result.local_gds_path is None
+    assert result.local_log_path == output_path.with_name("top.xstream.log")
+    assert "xstream.log" in result.local_log_path.read_text(encoding="utf-8")
+    assert any("xstream.log" in error for error in result.errors)
+
+
+def test_export_gds_prefinal_budget_exhaustion_skips_skill_api(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _SequenceClock(0.0, 4.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _artifact_client()
+
+    result = _run_export(client, output_path, stream_map)
+
+    assert result.status == ExecutionStatus.ERROR
+    assert result.reason == GdsExportReason.STAGING_ERROR
+    assert result.timed_out is True
+    assert client.skill_calls == []
+
+
+def test_export_gds_prefinal_expiry_after_staging_uses_reserve_to_finalize(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _artifact_client()
+    real_renderer = streamout.xstream_export_gds_skill
+
+    def consume_prefinal_budget(request: object) -> str:
+        skill = real_renderer(request)
+        clock.now = 3.0
+        return skill
+
+    monkeypatch.setattr(
+        streamout,
+        "xstream_export_gds_skill",
+        consume_prefinal_budget,
+    )
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        cleanup_policy="always",
+    )
+
+    assert result.status == ExecutionStatus.ERROR
+    assert result.reason == GdsExportReason.STAGING_ERROR
+    assert result.timed_out is True
+    assert client.skill_calls == []
+    assert result.local_log_path == output_path.with_name("top.xstream.log")
+    assert "budget exhausted" in result.local_log_path.read_text(
+        encoding="utf-8"
+    )
+    assert result.local_run_dir is None
+
+
+def test_export_gds_skill_timeout_is_capped_by_positive_prefinal_budget(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _artifact_client()
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        timeout=2.0,
+        finalization_reserve=1.0,
+        skill_timeout=5.0,
+    )
+
+    assert result.status == ExecutionStatus.SUCCESS
+    assert len(client.skill_calls) == 1
+    assert client.skill_calls[0][1] == 1.0
+
+
+def test_export_gds_total_budget_exhaustion_blocks_finalization_operations(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    output_path.write_bytes(b"old-gds")
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+
+    def execute(skill: str, _timeout: float) -> object:
+        _write_artifacts(skill)
+        clock.now = 4.0
+        return {
+            "status": "error",
+            "errors": ["SKILL execution timeout in Virtuoso"],
+        }
+
+    client = _FakeLocalClient(execute)
+
+    def forbidden_publish(_source: Path, _destination: Path) -> None:
+        raise AssertionError("publication called after total deadline")
+
+    def forbidden_cleanup(_path: Path) -> None:
+        raise AssertionError("cleanup called after total deadline")
+
+    monkeypatch.setattr(streamout, "_publish_file", forbidden_publish)
+    monkeypatch.setattr(streamout.shutil, "rmtree", forbidden_cleanup)
+
+    result = _run_export(client, output_path, stream_map)
+
+    assert result.status == ExecutionStatus.ERROR
+    assert result.reason == GdsExportReason.PUBLICATION_ERROR
+    assert result.timed_out is True
+    assert result.local_gds_path is None
+    assert result.local_log_path is None
+    assert result.local_run_dir is not None
+    assert output_path.read_bytes() == b"old-gds"
+
+
+def test_export_gds_unvalidated_gds_cleanup_failure_only_warns_and_retains(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock(0.0)
+    _use_fake_time(monkeypatch, clock)
+    output_path = tmp_path / "top.gds"
+    stream_map = _write_stream_map(tmp_path / "layers.map")
+    client = _artifact_client(log_text=_TERMINAL_LOG, gds=b"unvalidated")
+    real_unlink = Path.unlink
+
+    def fail_staged_gds_unlink(
+        path: Path,
+        missing_ok: bool = False,
+    ) -> None:
+        if path.name == "output.gds":
+            raise OSError("staged GDS cleanup denied")
+        real_unlink(path, missing_ok=missing_ok)
+
+    monkeypatch.setattr(Path, "unlink", fail_staged_gds_unlink)
+
+    result = _run_export(
+        client,
+        output_path,
+        stream_map,
+        cleanup_policy="never",
+    )
+
+    assert result.reason == GdsExportReason.XSTREAM_FAILURE
+    assert result.local_run_dir is not None
+    assert (result.local_run_dir / "output.gds").read_bytes() == b"unvalidated"
+    assert any("staged GDS cleanup denied" in warning for warning in result.warnings)

--- a/tests/test_ssh_control_master.py
+++ b/tests/test_ssh_control_master.py
@@ -110,6 +110,78 @@ def test_macos_unix_listener_path_too_long_is_controlmaster_failure() -> None:
     assert not SSHRunner._is_cm_failure(0, stderr)
 
 
+def test_remote_scp_target_quotes_legacy_shell_metacharacters() -> None:
+    runner = SSHRunner(host="eda-host", user="designer", ssh_cmd="ssh")
+    remote_path = "/scratch root/$(touch PWNED);'quoted'[1].gds"
+    escaped_path = (
+        r"/scratch\ root/\$\(touch\ PWNED\)\;\'quoted\'\[1\].gds"
+    )
+
+    target = runner._remote_scp_target(remote_path)
+    host, separator, quoted_path = target.partition(":")
+
+    assert host == "designer@eda-host"
+    assert separator == ":"
+    assert quoted_path == escaped_path
+    assert shlex.split(quoted_path) == [remote_path]
+
+
+def test_remote_scp_target_preserves_simple_paths_and_rejects_controls() -> None:
+    runner = SSHRunner(host="eda-host", user=None, ssh_cmd="ssh")
+
+    assert runner._remote_scp_target("/tmp/result.gds") == (
+        "eda-host:/tmp/result.gds"
+    )
+    for remote_path in (
+        "/tmp/bad\x00name",
+        "/tmp/bad\tname",
+        "/tmp/bad\nname",
+        "/tmp/bad\rname",
+        "/tmp/bad\x7fname",
+    ):
+        with pytest.raises(ValueError, match="remote SCP path"):
+            runner._remote_scp_target(remote_path)
+
+
+@pytest.mark.parametrize(
+    ("remote_path", "escaped_path"),
+    [
+        ("/tmp/result.gds", "/tmp/result.gds"),
+        (
+            r"/scratch root/result\copy[1].gds",
+            r"/scratch\ root/result\\copy\[1\].gds",
+        ),
+    ],
+)
+def test_nonrecursive_download_selects_safe_scp_mode(
+    monkeypatch,
+    tmp_path: Path,
+    remote_path: str,
+    escaped_path: str,
+) -> None:
+    monkeypatch.setattr("virtuoso_bridge.transport.ssh.load_vb_env", lambda: None)
+    monkeypatch.setattr("virtuoso_bridge.transport.ssh._setup_command_log", lambda: None)
+    commands: list[list[str]] = []
+
+    def fake_run(command: list[str], **_kwargs) -> subprocess.CompletedProcess:
+        commands.append(command)
+        return subprocess.CompletedProcess(command, 0, b"", b"")
+
+    monkeypatch.setattr(
+        "virtuoso_bridge.transport.ssh.subprocess.run",
+        fake_run,
+    )
+    runner = SSHRunner(host="eda-host", user="designer", ssh_cmd="ssh")
+
+    result = runner.download(remote_path, tmp_path / "result.gds")
+
+    assert result.returncode == 0
+    assert "-O" not in commands[0]
+    target = commands[0][-2]
+    assert target == f"designer@eda-host:{escaped_path}"
+    assert shlex.split(target.partition(":")[2]) == [remote_path]
+
+
 def test_remote_python_detection_error_includes_ssh_stderr() -> None:
     class _FakeRunner:
         def run_command(self, command: str, timeout=None) -> CommandResult:
@@ -426,3 +498,300 @@ def test_recursive_download_restores_existing_target_when_install_rename_fails(
 
     assert existing.is_dir()
     assert (existing / "input.scs").read_text(encoding="utf-8") == "old netlist\n"
+
+
+class _DeadlineClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def consume(
+        self,
+        duration: float,
+        timeout: float,
+        command: object,
+    ) -> None:
+        if timeout < duration:
+            self.now += timeout
+            raise subprocess.TimeoutExpired(command, timeout)
+        self.now += duration
+
+
+def _configure_deadline_runner(monkeypatch, clock: _DeadlineClock) -> SSHRunner:
+    monkeypatch.setattr("virtuoso_bridge.transport.ssh.load_vb_env", lambda: None)
+    monkeypatch.setattr("virtuoso_bridge.transport.ssh._setup_command_log", lambda: None)
+    monkeypatch.setattr("virtuoso_bridge.transport.ssh.time.monotonic", clock)
+    return SSHRunner(host="eda-host", user="designer", ssh_cmd="ssh")
+
+
+@pytest.mark.parametrize(
+    "operation",
+    ["run_command", "scp_download", "upload_text"],
+)
+def test_retrying_public_calls_share_one_timeout_budget(
+    monkeypatch,
+    tmp_path: Path,
+    operation: str,
+) -> None:
+    clock = _DeadlineClock()
+    runner = _configure_deadline_runner(monkeypatch, clock)
+    attempt_timeouts: list[float] = []
+
+    def fake_run(command: list[str], **kwargs) -> subprocess.CompletedProcess:
+        attempt_timeout = kwargs["timeout"]
+        attempt_timeouts.append(attempt_timeout)
+        clock.consume(0.04, attempt_timeout, command)
+        return subprocess.CompletedProcess(
+            command,
+            255,
+            b"",
+            b"Connection reset by peer",
+        )
+
+    monkeypatch.setattr(
+        "virtuoso_bridge.transport.ssh.subprocess.run",
+        fake_run,
+    )
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        if operation == "run_command":
+            runner.run_command("printf ok", timeout=0.05)
+        elif operation == "scp_download":
+            runner.download(
+                "/remote/result.gds",
+                tmp_path / "result.gds",
+                timeout=0.05,
+            )
+        else:
+            runner.upload_text("payload", "/remote/input.txt", timeout=0.05)
+
+    assert attempt_timeouts == pytest.approx([0.05, 0.01])
+    assert clock.now == pytest.approx(0.05)
+
+
+def test_scp_download_cm_fallback_uses_remaining_timeout(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    clock = _DeadlineClock()
+    runner = _configure_deadline_runner(monkeypatch, clock)
+    attempt_timeouts: list[float] = []
+    commands: list[list[str]] = []
+
+    def fake_run(command: list[str], **kwargs) -> subprocess.CompletedProcess:
+        attempt_timeout = kwargs["timeout"]
+        attempt_timeouts.append(attempt_timeout)
+        commands.append(command)
+        if len(commands) == 1:
+            clock.consume(0.02, attempt_timeout, command)
+            return subprocess.CompletedProcess(
+                command,
+                255,
+                b"",
+                b"mux_client_request_session: master session id: 2",
+            )
+        clock.consume(0.01, attempt_timeout, command)
+        return subprocess.CompletedProcess(command, 0, b"", b"")
+
+    monkeypatch.setattr(
+        "virtuoso_bridge.transport.ssh.subprocess.run",
+        fake_run,
+    )
+
+    result = runner.download(
+        "/remote/result.gds",
+        tmp_path / "result.gds",
+        timeout=0.05,
+    )
+
+    assert result.returncode == 0
+    assert attempt_timeouts == pytest.approx([0.05, 0.03])
+    assert any("ControlMaster=auto" in part for part in commands[0])
+    assert not any("ControlMaster=auto" in part for part in commands[1])
+    assert runner._use_control_master is False
+
+
+def test_tar_upload_retries_share_one_timeout_budget(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    clock = _DeadlineClock()
+    runner = _configure_deadline_runner(monkeypatch, clock)
+    communicate_timeouts: list[float] = []
+
+    class _UploadProcess:
+        def __init__(self, command: list[str], **_kwargs) -> None:
+            self.command = command
+            self.is_tar = Path(command[0]).stem.lower() == "tar"
+            self.returncode = 0 if self.is_tar else 255
+            self.stdout = _Pipe()
+            self.stderr = _Stderr(b"Connection reset by peer")
+
+        def communicate(self, timeout=None):
+            assert timeout is not None
+            communicate_timeouts.append(timeout)
+            clock.consume(0.04, timeout, self.command)
+            return b"", b"Connection reset by peer"
+
+        def wait(self, timeout=None):
+            return self.returncode
+
+        def kill(self) -> None:
+            self.returncode = -9
+
+    monkeypatch.setattr(
+        "virtuoso_bridge.transport.ssh.subprocess.Popen",
+        _UploadProcess,
+    )
+    local_path = tmp_path / "input.txt"
+    local_path.write_text("payload", encoding="utf-8")
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        runner.upload(local_path, "/remote/input.txt", timeout=0.05)
+
+    assert communicate_timeouts == pytest.approx([0.05, 0.01])
+    assert clock.now == pytest.approx(0.05)
+
+
+def test_batch_upload_groups_share_one_timeout_budget(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    clock = _DeadlineClock()
+    runner = _configure_deadline_runner(monkeypatch, clock)
+    communicate_timeouts: list[float] = []
+
+    class _BatchUploadProcess:
+        def __init__(self, command: list[str], **_kwargs) -> None:
+            self.command = command
+            self.is_tar = Path(command[0]).stem.lower() == "tar"
+            self.returncode = 0
+            self.stdout = _Pipe()
+            self.stderr = _Stderr()
+
+        def communicate(self, timeout=None):
+            assert not self.is_tar
+            assert timeout is not None
+            communicate_timeouts.append(timeout)
+            clock.consume(0.04, timeout, self.command)
+            return b"", b""
+
+        def wait(self, timeout=None):
+            return self.returncode
+
+        def kill(self) -> None:
+            self.returncode = -9
+
+    monkeypatch.setattr(
+        "virtuoso_bridge.transport.ssh.subprocess.Popen",
+        _BatchUploadProcess,
+    )
+    first = tmp_path / "first.txt"
+    second = tmp_path / "second.txt"
+    first.write_text("first", encoding="utf-8")
+    second.write_text("second", encoding="utf-8")
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        runner.upload_batch(
+            [
+                (first, "/remote/a/first.txt"),
+                (second, "/remote/b/second.txt"),
+            ],
+            timeout=0.05,
+        )
+
+    assert communicate_timeouts == pytest.approx([0.05, 0.01])
+    assert clock.now == pytest.approx(0.05)
+
+
+def test_recursive_download_pipeline_shares_one_timeout_budget(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    clock = _DeadlineClock()
+    runner = _configure_deadline_runner(monkeypatch, clock)
+    tar_timeouts: list[float] = []
+    ssh_timeouts: list[float] = []
+
+    class _DownloadProcess:
+        def __init__(self, command: list[str], **kwargs) -> None:
+            self.command = command
+            self.cwd = kwargs.get("cwd")
+            self.is_tar = Path(command[0]).stem.lower() == "tar"
+            self.returncode = 0
+            self.stdout = _Pipe()
+            self.stderr = _Stderr()
+
+        def communicate(self, timeout=None):
+            assert self.is_tar
+            assert timeout is not None
+            tar_timeouts.append(timeout)
+            clock.consume(0.04, timeout, self.command)
+            extracted = Path(self.cwd) / "netlist"
+            extracted.mkdir()
+            return b"", b""
+
+        def wait(self, timeout=None):
+            assert not self.is_tar
+            assert timeout is not None
+            ssh_timeouts.append(timeout)
+            clock.consume(0.04, timeout, self.command)
+            return 0
+
+        def kill(self) -> None:
+            self.returncode = -9
+
+    monkeypatch.setattr(
+        "virtuoso_bridge.transport.ssh.subprocess.Popen",
+        _DownloadProcess,
+    )
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        runner.download(
+            "/remote/netlist",
+            tmp_path / "netlist",
+            recursive=True,
+            timeout=0.05,
+        )
+
+    assert tar_timeouts == pytest.approx([0.05])
+    assert ssh_timeouts == pytest.approx([0.01])
+    assert clock.now == pytest.approx(0.05)
+
+
+def test_persistent_shell_probe_and_command_share_one_timeout_budget(
+    monkeypatch,
+) -> None:
+    clock = _DeadlineClock()
+    runner = _configure_deadline_runner(monkeypatch, clock)
+    runner._persistent_shell_enabled = True
+    command_timeouts: list[float] = []
+
+    def fake_ensure(timeout=None, **kwargs) -> None:
+        budget = kwargs.get("_budget")
+        remaining = budget.remaining("persistent-shell probe") if budget else timeout
+        assert remaining is not None
+        clock.consume(0.04, remaining, "persistent-shell probe")
+
+    def fake_command(command: str, timeout=None, **kwargs) -> CommandResult:
+        budget = kwargs.get("_budget")
+        remaining = budget.remaining(command) if budget else timeout
+        assert remaining is not None
+        command_timeouts.append(remaining)
+        clock.consume(0.04, remaining, command)
+        return CommandResult(0, "ok", "")
+
+    monkeypatch.setattr(runner, "ensure_persistent_shell", fake_ensure)
+    monkeypatch.setattr(
+        runner,
+        "_run_command_via_persistent_shell_locked",
+        fake_command,
+    )
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        runner.run_command("printf ok", timeout=0.05)
+
+    assert command_timeouts == pytest.approx([0.01])
+    assert clock.now == pytest.approx(0.05)

--- a/tests/test_xstream_helpers.py
+++ b/tests/test_xstream_helpers.py
@@ -235,10 +235,38 @@ def test_xstream_renderer_captures_every_field_before_first_mutation() -> None:
     assert max(capture_positions) < min(set_positions)
 
 
+def test_xstream_renderer_suppresses_and_restores_completion_dialog() -> None:
+    skill = xstream_export_gds_skill(_request())
+
+    capture = (
+        'vbOldShowCompletionMsgBox = '
+        'xstGetField("showCompletionMsgBox")'
+    )
+    suppress = 'xstSetField("showCompletionMsgBox" "false")'
+    translate = "xstOutDoTranslate()"
+    restore = (
+        'vbCleanup = errset(xstSetField("showCompletionMsgBox" '
+        "vbOldShowCompletionMsgBox) nil)"
+    )
+
+    assert skill.count(capture) == 1
+    assert skill.count(suppress) == 1
+    assert skill.count(restore) == 1
+    mutation_positions = [
+        skill.index(f'xstSetField("{xstream_field}"')
+        for _request_field, xstream_field, _old_variable in _XSTREAM_FIELDS
+    ]
+    mutation_positions.append(skill.index(suppress))
+    assert skill.index(capture) < min(mutation_positions)
+    assert skill.index(suppress) < skill.index(translate)
+    assert skill.index(translate) < skill.index(restore)
+    assert "failed to restore XStream field showCompletionMsgBox" in skill
+
+
 def test_xstream_renderer_restores_exact_old_field_mapping_independently() -> None:
     skill = xstream_export_gds_skill(_request())
 
-    assert skill.count("vbCleanup = errset(xstSetField(") == 7
+    assert skill.count("vbCleanup = errset(xstSetField(") == 8
     for _request_field, xstream_field, old_variable in _XSTREAM_FIELDS:
         restore = (
             f'vbCleanup = errset(xstSetField("{xstream_field}" '

--- a/tests/test_xstream_helpers.py
+++ b/tests/test_xstream_helpers.py
@@ -1,0 +1,874 @@
+from __future__ import annotations
+
+import re
+from dataclasses import FrozenInstanceError, fields, replace
+
+import pytest
+
+from virtuoso_bridge.virtuoso.layout import xstream
+from virtuoso_bridge.virtuoso.layout.xstream import (
+    XStreamExportRequest,
+    XStreamLogResult,
+    XStreamTranslatedStructure,
+    _XStreamRequestResponse,
+    _parse_xstream_request_response,
+    parse_xstream_log,
+    xstream_export_gds_skill,
+)
+
+
+_REQUEST_FIELDS = (
+    "library",
+    "top_cell",
+    "view",
+    "stream_file",
+    "layer_map",
+    "log_file",
+    "run_dir",
+)
+
+_XSTREAM_FIELDS = (
+    ("library", "library", "vbOldLibrary"),
+    ("top_cell", "topCell", "vbOldTopCell"),
+    ("view", "view", "vbOldView"),
+    ("stream_file", "strmFile", "vbOldStreamFile"),
+    ("layer_map", "layerMap", "vbOldLayerMap"),
+    ("log_file", "logFile", "vbOldLogFile"),
+    ("run_dir", "runDir", "vbOldRunDir"),
+)
+
+_LOG_CASES = {
+    "incomplete": (
+        "Product : Virtuoso(R) XStream Out\n"
+        "Started at: SANITIZED_TIME\n"
+        "WARNING: Synthetic export remains in progress.\n"
+        "INFO (XSTRM-223): 1. Translating cellview "
+        "WORK_LIB/TOP/layout as STRUCTURE TOP.\n"
+    ),
+    "malformed_completion": (
+        "Product : Virtuoso(R) XStream Out\n"
+        "Started at: SANITIZED_TIME\n"
+        "INFO (XSTRM-234): Translation completed. unavailable error(s) "
+        "and unavailable warning(s) found.\n"
+    ),
+    "nonzero_errors": (
+        "Product : Virtuoso(R) XStream Out\n"
+        "Started at: SANITIZED_TIME\n"
+        "ERROR: Synthetic first export error.\n"
+        "ERROR: Synthetic second export error.\n"
+        'INFO (XSTRM-234): Translation completed. "2" error(s) and '
+        "0 warning(s) found.\n"
+    ),
+    "success_with_warning": (
+        "Product   : Virtuoso(R) XStream Out\n"
+        "Started at: SANITIZED_TIME\n"
+        "WARNING (XSTRM-333): Synthetic nonfatal warning.\n"
+        "INFO (XSTRM-223): 1. Translating cellview "
+        "REF_LIB/DEVICE/layout as STRUCTURE DEVICE.\n"
+        "INFO (XSTRM-223): 2. Translating cellview "
+        "WORK_LIB/TOP/layout as STRUCTURE TOP.\n"
+        "INFO (XSTRM-234): Translation completed. '0' error(s) and "
+        "'1' warning(s) found.\n"
+    ),
+    "terminal_failure": (
+        "Product : Virtuoso(R) XStream Out\n"
+        "Started at: SANITIZED_TIME\n"
+        "INFO (XSTRM-273): Translation failed.\n"
+    ),
+}
+_TRANSLATED_STRUCTURE_FIELDS = ("library", "cell", "view", "structure")
+_LOG_RESULT_FIELDS = (
+    "completed",
+    "completion_line",
+    "error_count",
+    "warning_count",
+    "translated_structures",
+    "warnings",
+    "errors",
+    "terminal_failures",
+    "parse_errors",
+    "current_run_text",
+)
+_SENSITIVE_FIXTURE_PATTERNS = {
+    "headers": re.compile(
+        r"(?im)^[ \t]*(?:copyright|confidential|directory|platform|program|release)\b"
+    ),
+    "path": re.compile(
+        r"(?i)(?<![A-Za-z0-9_.-])(?:/(?:[^/\s]+/)+[^/\s]*|[A-Z]:[\\/]|\\\\[^\\\s]+\\)"
+    ),
+    "user": re.compile(
+        r"(?im)^[ \t]*(?:user(?:[ \t]*name)?|login|owner)[ \t]*[:=]"
+    ),
+    "host": re.compile(
+        r"(?im)^[ \t]*(?:host(?:[ \t]*name)?|machine|server)[ \t]*[:=]"
+    ),
+    "time": re.compile(
+        r"(?i)\b(?:19|20)\d{2}[-/]\d{2}[-/]\d{2}\b|"
+        r"\b(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d)?\b|"
+        r"\b(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)\s+"
+        r"(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\b"
+    ),
+    "build": re.compile(
+        r"(?i)\b(?:build|release|version)\b[ \t]*(?:[:=][ \t]*)?"
+        r"[A-Za-z0-9][A-Za-z0-9._-]*"
+    ),
+    "internal IDs": re.compile(
+        r"(?im)^\s*(?:job|process|pid|session|request|run)[ _-]*"
+        r"(?:id|number)\s*[:=]|"
+        r"\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b"
+    ),
+    "window": re.compile(r"(?im)^\s*window(?:\s+id)?\s*[:=]"),
+    "frame": re.compile(r"(?im)^\s*frame(?:\s+id)?\s*[:=]"),
+    "coordinates": re.compile(
+        r"(?im)^\s*(?:coordinates?|bbox|origin)\s*[:=]|"
+        r"\bx\s*=\s*-?\d+(?:\.\d+)?\b.*\by\s*=\s*-?\d+(?:\.\d+)?\b|"
+        r"\(\s*-?\d+(?:\.\d+)?\s*,\s*-?\d+(?:\.\d+)?\s*\)"
+    ),
+}
+
+
+def _log_case(name: str) -> str:
+    return _LOG_CASES[name]
+
+
+def _request(**overrides: object) -> XStreamExportRequest:
+    values: dict[str, object] = {
+        "library": "demoLib",
+        "top_cell": "nand2",
+        "view": "layout",
+        "stream_file": "output/nand2.gds",
+        "layer_map": "maps/stream.map",
+        "log_file": "logs/xstream.log",
+        "run_dir": "runs/nand2",
+    }
+    values.update(overrides)
+    return XStreamExportRequest(**values)  # type: ignore[arg-type]
+
+
+def _assert_balanced_skill_parentheses(skill: str) -> None:
+    depth = 0
+    in_string = False
+    escaped = False
+    for character in skill:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                in_string = False
+            continue
+        if character == '"':
+            in_string = True
+        elif character == "(":
+            depth += 1
+        elif character == ")":
+            depth -= 1
+            assert depth >= 0
+    assert not in_string
+    assert depth == 0
+
+
+def test_xstream_export_request_is_frozen_with_exact_fields() -> None:
+    request = _request()
+
+    assert tuple(field.name for field in fields(request)) == _REQUEST_FIELDS
+    with pytest.raises(FrozenInstanceError):
+        request.library = "otherLib"  # type: ignore[misc]
+
+
+def test_xstream_module_exports_public_request_renderer_and_log_parser() -> None:
+    assert xstream.__all__ == [
+        "XStreamExportRequest",
+        "xstream_export_gds_skill",
+        "XStreamTranslatedStructure",
+        "XStreamLogResult",
+        "parse_xstream_log",
+    ]
+
+
+@pytest.mark.parametrize("field_name", _REQUEST_FIELDS)
+@pytest.mark.parametrize("invalid_value", ["", None])
+def test_xstream_renderer_rejects_empty_or_non_string_fields(
+    field_name: str,
+    invalid_value: object,
+) -> None:
+    request = replace(_request(), **{field_name: invalid_value})
+
+    with pytest.raises(ValueError, match=rf"^{field_name} must be a nonempty string$"):
+        xstream_export_gds_skill(request)
+
+
+def test_xstream_renderer_escapes_all_seven_request_values() -> None:
+    request = _request(
+        library='lib"\\one',
+        top_cell='cell"\\two',
+        view='view"\\three',
+        stream_file='stream"\\four',
+        layer_map='layer"\\five',
+        log_file='log"\\six',
+        run_dir='run"\\seven',
+    )
+
+    skill = xstream_export_gds_skill(request)
+
+    for request_field, xstream_field, _old_variable in _XSTREAM_FIELDS:
+        escaped = getattr(request, request_field).replace("\\", "\\\\").replace('"', '\\"')
+        assert f'xstSetField("{xstream_field}" "{escaped}")' in skill
+
+
+def test_xstream_renderer_captures_every_field_before_first_mutation() -> None:
+    request = _request()
+
+    skill = xstream_export_gds_skill(request)
+
+    capture_positions = [
+        skill.index(f'{old_variable} = xstGetField("{xstream_field}")')
+        for _request_field, xstream_field, old_variable in _XSTREAM_FIELDS
+    ]
+    set_positions = [
+        skill.index(
+            f'xstSetField("{xstream_field}" "{getattr(request, request_field)}")'
+        )
+        for request_field, xstream_field, _old_variable in _XSTREAM_FIELDS
+    ]
+    assert max(capture_positions) < min(set_positions)
+
+
+def test_xstream_renderer_restores_exact_old_field_mapping_independently() -> None:
+    skill = xstream_export_gds_skill(_request())
+
+    assert skill.count("vbCleanup = errset(xstSetField(") == 7
+    for _request_field, xstream_field, old_variable in _XSTREAM_FIELDS:
+        restore = (
+            f'vbCleanup = errset(xstSetField("{xstream_field}" '
+            f"{old_variable}) nil)"
+        )
+        assert skill.count(restore) == 1
+
+
+def test_xstream_renderer_does_not_treat_nil_cleanup_return_as_failure() -> None:
+    skill = xstream_export_gds_skill(_request())
+
+    assert "unless(vbCleanup " in skill
+    assert "car(vbCleanup)" not in skill
+
+
+def test_xstream_renderer_requires_all_three_xstream_apis() -> None:
+    skill = xstream_export_gds_skill(_request())
+
+    api_check = (
+        "unless(and(isCallable('xstGetField) isCallable('xstSetField) "
+        "isCallable('xstOutDoTranslate))"
+    )
+    assert api_check in skill
+    assert skill.index(api_check) < skill.index('vbOldLibrary = xstGetField("library")')
+    assert 'list("xstreamRequest" "failed"' in skill
+
+
+def test_xstream_renderer_treats_nil_setter_and_launch_returns_as_success() -> None:
+    skill = xstream_export_gds_skill(_request())
+
+    assert "vbBodyAttempt = errset(progn(" in skill
+    assert "xstOutDoTranslate()) nil)" in skill
+    assert "if(vbBodyAttempt " in skill
+    assert (
+        'then list("xstreamRequest" "started" nil reverse(vbCleanupFailures))'
+        in skill
+    )
+    assert "vbBodyAttempt && !vbCleanupFailures" not in skill
+    assert "car(vbBodyAttempt)" not in skill
+    assert "unless(xstSetField" not in skill
+    assert "unless(xstOutDoTranslate" not in skill
+
+
+def test_xstream_renderer_preserves_relative_execution_host_paths() -> None:
+    request = _request(
+        stream_file="../gds/out.gds",
+        layer_map="config/layers.map",
+        log_file="logs/export.log",
+        run_dir="../runs/job-1",
+    )
+
+    skill = xstream_export_gds_skill(request)
+
+    assert 'xstSetField("strmFile" "../gds/out.gds")' in skill
+    assert 'xstSetField("layerMap" "config/layers.map")' in skill
+    assert 'xstSetField("logFile" "logs/export.log")' in skill
+    assert 'xstSetField("runDir" "../runs/job-1")' in skill
+
+
+def test_parse_xstream_request_response_accepts_started_wire() -> None:
+    response = _parse_xstream_request_response(
+        '("xstreamRequest" "started" nil nil)'
+    )
+
+    assert response == _XStreamRequestResponse(
+        state="started",
+        body_error=None,
+        cleanup_failures=(),
+    )
+    with pytest.raises(FrozenInstanceError):
+        response.state = "failed"  # type: ignore[misc]
+
+
+def test_parse_xstream_request_response_accepts_failed_body_and_cleanup_wire() -> None:
+    response = _parse_xstream_request_response(
+        r'("xstreamRequest" "failed" "launch \"bad\" at C:\\tmp" '
+        r'("restore library" "restore C:\\run"))'
+    )
+
+    assert response == _XStreamRequestResponse(
+        state="failed",
+        body_error='launch "bad" at C:\\tmp',
+        cleanup_failures=("restore library", "restore C:\\run"),
+    )
+
+
+def test_parse_xstream_request_response_accepts_started_cleanup_only_wire() -> None:
+    response = _parse_xstream_request_response(
+        '("xstreamRequest" "started" nil ("restore view"))'
+    )
+
+    assert response == _XStreamRequestResponse(
+        state="started",
+        body_error=None,
+        cleanup_failures=("restore view",),
+    )
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        "",
+        "nil",
+        '("xstreamRequest" "started" nil nil',
+        '("xstreamRequest" "started" nil nil) trailing',
+        '("otherRequest" "started" nil nil)',
+        '(xstreamRequest "started" nil nil)',
+        '("xstreamRequest" started nil nil)',
+        '("xstreamRequest" "started" nil)',
+        '("xstreamRequest" "started" nil nil nil)',
+        '("xstreamRequest" "queued" nil nil)',
+        '("xstreamRequest" ("started") nil nil)',
+        '("xstreamRequest" "started" "unexpected" nil)',
+        '("xstreamRequest" "started" nil (restoreView))',
+        '("xstreamRequest" "failed" nil nil)',
+        '("xstreamRequest" "failed" nil ("restore view"))',
+        '("xstreamRequest" "failed" launchFailed nil)',
+        '("xstreamRequest" "failed" t nil)',
+        '("xstreamRequest" "failed" "launch failed" "restore failed")',
+        '("xstreamRequest" "failed" "launch failed" (t))',
+        '("xstreamRequest" "failed" "launch failed" (nil))',
+    ],
+)
+def test_parse_xstream_request_response_rejects_invalid_schema(output: str) -> None:
+    with pytest.raises(ValueError, match="malformed XStream request response"):
+        _parse_xstream_request_response(output)
+
+
+def test_xstream_renderer_has_balanced_parentheses_outside_strings() -> None:
+    skill = xstream_export_gds_skill(
+        _request(log_file='logs/(quoted-"value").log')
+    )
+
+    assert "unwindProtect(" in skill
+    _assert_balanced_skill_parentheses(skill)
+
+
+def test_xstream_log_cases_are_sanitized() -> None:
+    assert set(_LOG_CASES) == {
+        "incomplete",
+        "malformed_completion",
+        "nonzero_errors",
+        "success_with_warning",
+        "terminal_failure",
+    }
+    for name, text in _LOG_CASES.items():
+        for category, pattern in _SENSITIVE_FIXTURE_PATTERNS.items():
+            assert pattern.search(text) is None, (
+                f"{name} contains sensitive {category} data"
+            )
+
+
+@pytest.mark.parametrize(
+    ("category", "sample"),
+    [
+        ("headers", "Release: IC-SYNTHETIC"),
+        ("path", "/opt/synthetic/pdk/stream.map"),
+        ("user", "Username: synthetic_user"),
+        ("user", "User Name: synthetic_user"),
+        ("host", "Host: synthetic.example"),
+        ("host", "Host Name: synthetic.example"),
+        ("headers", "Program: xstream"),
+        ("headers", "Directory: synthetic/run"),
+        ("time", "Started at: 2026-01-02 03:04:05"),
+        ("build", "Build: 123456"),
+        ("build", "Product metadata build 123456"),
+        ("build", "Product metadata release IC-SYNTHETIC"),
+        ("internal IDs", "Session ID: synthetic-session"),
+        ("window", "Window ID: 0x123"),
+        ("frame", "Frame: synthetic-frame"),
+        ("coordinates", "Coordinates: (12, 34)"),
+    ],
+)
+def test_xstream_log_sanitization_patterns_are_generic(
+    category: str,
+    sample: str,
+) -> None:
+    assert _SENSITIVE_FIXTURE_PATTERNS[category].search(sample) is not None
+
+
+def test_parse_xstream_log_returns_success_details() -> None:
+    text = _log_case("success_with_warning")
+
+    result = parse_xstream_log(text)
+
+    assert result == XStreamLogResult(
+        completed=True,
+        completion_line=(
+            "INFO (XSTRM-234): Translation completed. '0' error(s) and "
+            "'1' warning(s) found."
+        ),
+        error_count=0,
+        warning_count=1,
+        translated_structures=(
+            XStreamTranslatedStructure(
+                library="REF_LIB",
+                cell="DEVICE",
+                view="layout",
+                structure="DEVICE",
+            ),
+            XStreamTranslatedStructure(
+                library="WORK_LIB",
+                cell="TOP",
+                view="layout",
+                structure="TOP",
+            ),
+        ),
+        warnings=("WARNING (XSTRM-333): Synthetic nonfatal warning.",),
+        errors=(),
+        terminal_failures=(),
+        parse_errors=(),
+        current_run_text=text,
+    )
+
+
+def test_parse_xstream_log_returns_nonzero_completion_without_raising() -> None:
+    result = parse_xstream_log(_log_case("nonzero_errors"))
+
+    assert result.completed is True
+    assert result.error_count == 2
+    assert result.warning_count == 0
+    assert result.errors == (
+        "ERROR: Synthetic first export error.",
+        "ERROR: Synthetic second export error.",
+    )
+    assert result.parse_errors == ()
+
+
+def test_parse_xstream_log_detects_terminal_fixture_without_completion() -> None:
+    terminal_line = "INFO (XSTRM-273): Translation failed."
+
+    result = parse_xstream_log(_log_case("terminal_failure"))
+
+    assert result.completed is False
+    assert result.completion_line is None
+    assert result.error_count is None
+    assert result.warning_count is None
+    assert result.terminal_failures == (terminal_line,)
+    assert result.parse_errors == ()
+
+
+@pytest.mark.parametrize(
+    "terminal_line",
+    [
+        "INFO: xstrm-273 stopped the synthetic translation.",
+        "INFO: Synthetic TRANSLATION FAILED before completion.",
+        "INFO: Synthetic open_failed while writing output.",
+    ],
+)
+def test_parse_xstream_log_detects_each_terminal_marker_independently(
+    terminal_line: str,
+) -> None:
+    result = parse_xstream_log(terminal_line)
+
+    assert result.terminal_failures == (terminal_line,)
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "INFO (XSTRM-2730): Synthetic adjacent status code.",
+        "INFO: OPEN_FAILED_RECOVERED was handled.",
+    ],
+)
+def test_parse_xstream_log_requires_terminal_marker_boundaries(line: str) -> None:
+    result = parse_xstream_log(line)
+
+    assert result.terminal_failures == ()
+
+
+def test_parse_xstream_log_does_not_treat_structure_name_as_terminal() -> None:
+    line = (
+        "INFO (XSTRM-223): 1. Translating cellview WORK_LIB/TOP/layout "
+        "as STRUCTURE OPEN_FAILED."
+    )
+
+    result = parse_xstream_log(line)
+
+    assert result.translated_structures == (
+        XStreamTranslatedStructure(
+            library="WORK_LIB",
+            cell="TOP",
+            view="layout",
+            structure="OPEN_FAILED",
+        ),
+    )
+    assert result.terminal_failures == ()
+
+
+def test_parse_xstream_log_reports_malformed_final_completion_counts() -> None:
+    completion_line = (
+        "INFO (XSTRM-234): Translation completed. unavailable error(s) and "
+        "unavailable warning(s) found."
+    )
+
+    result = parse_xstream_log(_log_case("malformed_completion"))
+
+    assert result.completed is True
+    assert result.completion_line == completion_line
+    assert result.error_count is None
+    assert result.warning_count is None
+    assert result.parse_errors == (
+        f"malformed XStream completion counts: {completion_line}",
+    )
+
+
+def test_parse_xstream_log_ignores_error_diagnostic_quoting_completion() -> None:
+    diagnostic_line = (
+        'ERROR: Synthetic diagnostic quotes "INFO (XSTRM-234): Translation '
+        'completed. 0 error(s) and 0 warning(s) found."'
+    )
+
+    result = parse_xstream_log(diagnostic_line)
+
+    assert result.completed is False
+    assert result.completion_line is None
+    assert result.error_count is None
+    assert result.warning_count is None
+    assert result.parse_errors == ()
+
+
+def test_parse_xstream_log_keeps_last_valid_full_completion_line() -> None:
+    completion_line = (
+        "INFO (XSTRM-234): Translation completed. '3' error(s) and "
+        '"4" warning(s) found.'
+    )
+    diagnostic_line = (
+        'ERROR: Later diagnostic quotes "Translation completed. 9 error(s) and '
+        '9 warning(s) found."'
+    )
+
+    result = parse_xstream_log(f"{completion_line}\n{diagnostic_line}")
+
+    assert result.completed is True
+    assert result.completion_line == completion_line
+    assert (result.error_count, result.warning_count) == (3, 4)
+    assert result.parse_errors == ()
+
+
+def test_parse_xstream_log_reports_oversized_completion_count_as_malformed() -> None:
+    completion_line = (
+        "INFO (XSTRM-234): Translation completed. "
+        f"{'9' * 5000} error(s) and 0 warning(s) found."
+    )
+
+    result = parse_xstream_log(completion_line)
+
+    assert result.completed is True
+    assert result.completion_line == completion_line
+    assert result.error_count is None
+    assert result.warning_count is None
+    assert result.parse_errors == (
+        f"malformed XStream completion counts: {completion_line}",
+    )
+
+
+def test_parse_xstream_log_keeps_prefixed_completion_with_missing_counts() -> None:
+    completion_line = (
+        "INFO (XSTRM-234): Translation completed. counts unavailable."
+    )
+
+    result = parse_xstream_log(completion_line)
+
+    assert result.completed is True
+    assert result.completion_line == completion_line
+    assert result.error_count is None
+    assert result.warning_count is None
+    assert result.parse_errors == (
+        f"malformed XStream completion counts: {completion_line}",
+    )
+
+
+def test_parse_xstream_log_treats_missing_completion_as_incomplete(
+) -> None:
+    result = parse_xstream_log(_log_case("incomplete"))
+
+    assert result.completed is False
+    assert result.completion_line is None
+    assert result.error_count is None
+    assert result.warning_count is None
+    assert result.translated_structures == (
+        XStreamTranslatedStructure("WORK_LIB", "TOP", "layout", "TOP"),
+    )
+    assert result.parse_errors == ()
+
+
+def test_parse_xstream_log_selects_newest_product_run_and_retains_headers() -> None:
+    previous_run = "\n".join(
+        [
+            "Product : Virtuoso(R) XStream Out",
+            "Started at: SANITIZED_TIME_OLD",
+            "ERROR: Old run error.",
+            "INFO (XSTRM-234): Translation completed. 1 error(s) and "
+            "0 warning(s) found.",
+        ]
+    )
+    current_run = (
+        "\n".join(
+            [
+                "Product   : Virtuoso(R) XStream Out",
+                "Synthetic current-run header.",
+                "Started at: SANITIZED_TIME_NEW",
+                "WARNING: New run warning.",
+                "INFO (XSTRM-234): Translation completed. 0 error(s) and "
+                "1 warning(s) found.",
+            ]
+        )
+        + "\n\n"
+    )
+    text = f"{previous_run}\n{current_run}"
+
+    result = parse_xstream_log(text)
+
+    assert result.error_count == 0
+    assert result.warning_count == 1
+    assert result.errors == ()
+    assert result.warnings == ("WARNING: New run warning.",)
+    assert result.current_run_text == current_run
+    assert result.current_run_text.startswith(
+        "Product   : Virtuoso(R) XStream Out\nSynthetic current-run header.\n"
+        "Started at: SANITIZED_TIME_NEW"
+    )
+    assert "Old run error" not in result.current_run_text
+
+
+@pytest.mark.parametrize(
+    "product_header",
+    [
+        "Product : Virtuoso(R) XStream Out",
+        "Product   : Virtuoso(R) XStream Out",
+        "Product\t:\tVirtuoso(R) XStream Out",
+        "Product: Virtuoso(R) XStream Out",
+    ],
+)
+def test_parse_xstream_log_accepts_product_header_whitespace(
+    product_header: str,
+) -> None:
+    expected = f"{product_header}\nStarted at: SANITIZED_TIME\n"
+    text = f"Synthetic previous content.\n{expected}"
+
+    result = parse_xstream_log(text)
+
+    assert result.current_run_text == expected
+
+
+def test_parse_xstream_log_falls_back_to_last_started_anchor() -> None:
+    previous_run = "\n".join(
+        [
+            "Started at: SANITIZED_TIME_OLD",
+            "ERROR: Old run error.",
+        ]
+    )
+    current_run = (
+        "Started at: SANITIZED_TIME_NEW\nWARNING: New run warning.\n\n"
+    )
+    text = f"{previous_run}\n{current_run}"
+
+    result = parse_xstream_log(text)
+
+    assert result.current_run_text == current_run
+    assert result.errors == ()
+    assert result.warnings == ("WARNING: New run warning.",)
+
+
+def test_started_fallback_ignores_midline_diagnostic_text() -> None:
+    previous_run = (
+        "Started at: SANITIZED_TIME_OLD\n"
+        "ERROR: Old run error.\n"
+    )
+    current_run = (
+        "sTaRtEd\tAt : SANITIZED_TIME_NEW\n"
+        "WARNING: Diagnostic mentions Started at: NOT_ANCHOR\n"
+    )
+
+    result = parse_xstream_log(f"{previous_run}{current_run}")
+
+    assert result.current_run_text == current_run
+    assert result.errors == ()
+    assert result.warnings == (
+        "WARNING: Diagnostic mentions Started at: NOT_ANCHOR",
+    )
+
+
+def test_parse_xstream_log_preserves_exact_full_text_without_run_anchor() -> None:
+    text = "\n  WARNING: Synthetic warning.  \n\nERROR: Synthetic error.\n"
+
+    result = parse_xstream_log(text)
+
+    assert result.current_run_text == text
+    assert result.warnings == ("WARNING: Synthetic warning.",)
+    assert result.errors == ("ERROR: Synthetic error.",)
+
+
+@pytest.mark.parametrize(
+    ("first_completion", "final_completion", "counts", "parse_errors"),
+    [
+        (
+            "INFO (XSTRM-234): Translation completed. unavailable error(s) "
+            "and unavailable warning(s) found.",
+            "INFO (XSTRM-234): Translation completed. '3' error(s) and "
+            '"4" warning(s) found.',
+            (3, 4),
+            (),
+        ),
+        (
+            "INFO (XSTRM-234): Translation completed. 0 error(s) and "
+            "0 warning(s) found.",
+            "INFO (XSTRM-234): Translation completed. unavailable error(s) "
+            "and unavailable warning(s) found.",
+            (None, None),
+            (
+                "malformed XStream completion counts: INFO (XSTRM-234): "
+                "Translation completed. unavailable error(s) and unavailable "
+                "warning(s) found.",
+            ),
+        ),
+    ],
+)
+def test_parse_xstream_log_uses_final_completion_marker(
+    first_completion: str,
+    final_completion: str,
+    counts: tuple[int | None, int | None],
+    parse_errors: tuple[str, ...],
+) -> None:
+    result = parse_xstream_log(f"{first_completion}\n{final_completion}")
+
+    assert result.completed is True
+    assert result.completion_line == final_completion
+    assert (result.error_count, result.warning_count) == counts
+    assert result.parse_errors == parse_errors
+
+
+def test_parse_xstream_completion_is_not_an_error_severity_line() -> None:
+    completion_line = (
+        "INFO (XSTRM-234): Translation completed. 2 error(s) and 0 warning(s) found."
+    )
+
+    result = parse_xstream_log(completion_line)
+
+    assert result.error_count == 2
+    assert result.errors == ()
+
+
+def test_parse_xstream_unmapped_and_unresolved_are_not_terminal() -> None:
+    text = "\n".join(
+        [
+            "INFO: Synthetic layer is unmapped.",
+            "WARNING: Synthetic reference is unresolved.",
+        ]
+    )
+
+    result = parse_xstream_log(text)
+
+    assert result.terminal_failures == ()
+
+
+@pytest.mark.parametrize(
+    ("line", "collection_name"),
+    [
+        ("WARNING Synthetic warning.", "warnings"),
+        ("WARNING: Synthetic warning.", "warnings"),
+        ("WARNING(XSTRM-001): Synthetic warning.", "warnings"),
+        ("*WARNING* Synthetic warning.", "warnings"),
+        ("ERROR Synthetic error.", "errors"),
+        ("ERROR: Synthetic error.", "errors"),
+        ("ERROR(XSTRM-001): Synthetic error.", "errors"),
+        ("*ERROR* Synthetic error.", "errors"),
+    ],
+)
+def test_parse_xstream_log_recognizes_supported_severity_prefixes(
+    line: str,
+    collection_name: str,
+) -> None:
+    result = parse_xstream_log(line)
+
+    assert getattr(result, collection_name) == (line,)
+
+
+def test_parse_xstream_log_preserves_structure_order_and_duplicates() -> None:
+    line = (
+        "INFO (XSTRM-223): 1. Translating cellview WORK_LIB/TOP/layout "
+        "as STRUCTURE TOP."
+    )
+
+    result = parse_xstream_log(f"{line}\n{line}")
+
+    structure = XStreamTranslatedStructure("WORK_LIB", "TOP", "layout", "TOP")
+    assert result.translated_structures == (structure, structure)
+
+
+def test_parse_xstream_log_empty_text_returns_empty_incomplete_result() -> None:
+    result = parse_xstream_log("")
+
+    assert result == XStreamLogResult(
+        completed=False,
+        completion_line=None,
+        error_count=None,
+        warning_count=None,
+        translated_structures=(),
+        warnings=(),
+        errors=(),
+        terminal_failures=(),
+        parse_errors=(),
+        current_run_text="",
+    )
+
+
+def test_parse_xstream_log_rejects_non_string_input() -> None:
+    with pytest.raises(TypeError):
+        parse_xstream_log(None)  # type: ignore[arg-type]
+
+
+def test_xstream_log_models_are_frozen_with_exact_fields_and_tuple_results() -> None:
+    assert tuple(field.name for field in fields(XStreamTranslatedStructure)) == (
+        _TRANSLATED_STRUCTURE_FIELDS
+    )
+    assert tuple(field.name for field in fields(XStreamLogResult)) == _LOG_RESULT_FIELDS
+
+    structure = XStreamTranslatedStructure("WORK_LIB", "TOP", "layout", "TOP")
+    with pytest.raises(FrozenInstanceError):
+        structure.cell = "OTHER"  # type: ignore[misc]
+
+    result = parse_xstream_log(_log_case("success_with_warning"))
+    for collection_name in (
+        "translated_structures",
+        "warnings",
+        "errors",
+        "terminal_failures",
+        "parse_errors",
+    ):
+        assert isinstance(getattr(result, collection_name), tuple)
+    with pytest.raises(FrozenInstanceError):
+        result.completed = False  # type: ignore[misc]


### PR DESCRIPTION
## Summary

- Add pure XStream request rendering, response-wire parsing, and current-run log parsing helpers.
- Add project-agnostic local and SSH-backed `export_gds()` orchestration with end-to-end deadlines, stable artifact validation, log-first/GDS-last publication, secure remote staging, and explicit cleanup/retention results.
- Expose the API through `LayoutOps`, document the high-level and pure layers, and add a parameterized smoke example.

## Why

Virtuoso Bridge had low-level SKILL execution and transfer primitives, but no reusable XStream GDS export workflow. Callers otherwise had to duplicate staging, polling, failure classification, publication, timeout, and cleanup logic, often with stale-artifact and remote-path risks.

This change keeps project-specific libraries, cells, PDK maps, and machine paths outside the package. Callers provide those values at runtime.

## Behavior

- Preflight argument errors remain exceptions; operational outcomes return `GdsExportResult` with stable status/reason values and diagnostic paths.
- Local mode uses sibling staging without upload/download calls.
- SSH mode uses private owned staging, bounded sentinel polling, content digests during finalization, and three-state remote retention reporting.
- Existing output files are preserved unless a fresh validated artifact is atomically published.
- XStream completion dialogs are disabled for each request and the previous session setting is restored afterward.
- The default flow is headless and does not depend on X11 dialog dismissal.

## Validation

- `python -m pytest -q`
- `python -m pytest tests/test_xstream_helpers.py tests/test_layout_streamout.py tests/test_ssh_control_master.py tests/test_bridge_timeout.py -q`
- `python -m compileall -q src tests examples/01_virtuoso/layout/15_export_gds.py`
- `PYTHONPATH=src python examples/01_virtuoso/layout/15_export_gds.py --help`
- `git diff --check origin/main...HEAD`
- Scans for accidentally committed logs, GDS files, map files, and internal planning documents
- IC25.1 local-mode XStream smoke: `success/completed`, zero errors, no completion dialog or socket timeout, follow-up SKILL probe returned `2`, and the prior completion-dialog setting was restored
