### PR TITLE
Add semantic symbol drawing helpers

### DIFF
--- a/examples/01_virtuoso/symbol/03_manual_symbol_semantics.py
+++ b/examples/01_virtuoso/symbol/03_manual_symbol_semantics.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Draw a symbol with native pin, instance, and logical label semantics."""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+
+from virtuoso_bridge import VirtuosoClient
+from virtuoso_bridge.virtuoso.symbol import (
+    symbol_create_instance_label,
+    symbol_create_logical_label,
+    symbol_create_pin,
+    symbol_create_polygon,
+    symbol_create_selection_box,
+    symbol_set_term_order,
+)
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"Usage: python {Path(__file__).name} <LIB>", file=sys.stderr)
+        return 1
+
+    lib = sys.argv[1]
+    cell = f"VB_MANUAL_SYMBOL_{datetime.now():%Y%m%d_%H%M%S}"
+    client = VirtuosoClient.from_env()
+
+    with client.symbol.edit(lib, cell) as symbol:
+        symbol.add(
+            symbol_create_polygon(
+                "device",
+                "drawing",
+                [(-1.0, -0.75), (-1.0, 0.75), (1.0, 0.0)],
+            )
+        )
+        symbol.add(
+            symbol_create_pin(
+                "VIN",
+                -1.5,
+                0.25,
+                direction="input",
+                label_x=-0.9,
+                label_y=0.25,
+            )
+        )
+        symbol.add(
+            symbol_create_pin(
+                "VOUT",
+                1.5,
+                0.0,
+                direction="output",
+                label_x=0.9,
+                label_y=0.0,
+                label_justification="centerRight",
+            )
+        )
+        symbol.add(symbol_create_instance_label(0.0, 1.0))
+        symbol.add(symbol_create_logical_label(0.0, -1.0))
+        symbol.add(symbol_create_selection_box(-1.5, -0.75, 1.5, 0.75))
+        symbol.add(symbol_set_term_order(["VIN", "VOUT"]))
+
+    ports = client.symbol.read_ports(lib, cell)
+    labels = {label["text"]: label for label in ports["labels"]}
+    assert labels["VIN"]["layerName"] == "pin"
+    assert labels["VIN"]["purpose"] == "label"
+    assert labels["[@instanceName]"]["labelType"] == "NLPLabel"
+    assert labels["[@instanceName]"]["layerName"] == "instance"
+    assert labels["[@partName]"]["labelType"] == "NLPLabel"
+    assert labels["[@partName]"]["layerName"] == "device"
+    assert ports["selectionBoxes"] == [[[-1.5, -0.75], [1.5, 0.75]]]
+
+    client.open_window(lib, cell, view="symbol")
+    print(f"Created and verified {lib}/{cell}/symbol")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/virtuoso/SKILL.md
+++ b/skills/virtuoso/SKILL.md
@@ -278,6 +278,11 @@ Load on demand — each contains detailed API docs and edge-case guidance:
 - `06_read_layout.py` — read layout shapes
 - `07–10` — delete/clear operations
 
+### `examples/01_virtuoso/symbol/`
+- `01_rc_create_with_symbol.py` — native schematic-to-symbol generation
+- `02_bus10_create_with_symbol.py` — native generation with 20 pins
+- `03_manual_symbol_semantics.py` — manual drawing with native pin-name, instance/logical labels, selection box, and readback verification
+
 ### `examples/01_virtuoso/maestro/`
 - `01_read_focused_maestro.py` — in-memory snapshot of the focused maestro (config + env + results + outputs + corners + variables)
 - `02_snapshot_with_metrics.py` — snapshot the focused maestro to a timestamped directory (disk artifacts)

--- a/skills/virtuoso/references/symbol-python-api.md
+++ b/skills/virtuoso/references/symbol-python-api.md
@@ -52,10 +52,16 @@ the exception identifies the retained backup view for manual recovery.
 ports = client.symbol.read_ports("demoLib", "nand2")
 ```
 
-The returned dictionary contains `terms`, `labels`, `pinOrder`, `portOrder`,
-and `termOrder`. `pinOrder` is the effective value from `schGetPinOrder()`,
-`portOrder` is the native symbol property, and `termOrder` is retained
-separately for existing callers and manually authored symbols.
+The returned dictionary contains `terms`, `labels`, `selectionBoxes`,
+`pinOrder`, `portOrder`, and `termOrder`. Each label record includes its text,
+label type, layer, purpose, position, justification, orientation, font, height,
+and bounding box. These fields matter because label type alone does not
+identify a semantic symbol label: a normal label on `pin/label` is a pin name,
+while a normal label on `annotate/drawing` is only drawing text.
+
+`pinOrder` is the effective value from `schGetPinOrder()`, `portOrder` is the
+native symbol property, and `termOrder` is retained separately for existing
+callers and manually authored symbols.
 
 ## Edit Symbol
 
@@ -66,3 +72,92 @@ symbol-specific `schSymbolToPinList()` API. Cadence rejects non-symbol
 cellviews with `SCH-1004`, while unsuccessful pin-list generation also fails
 the edit. This validation does not run schematic connectivity, SRC, or VIC;
 `schCheck()` remains schematic-only.
+
+### Drawing and semantic labels
+
+The geometric builders create ordinary database shapes:
+
+```python
+from virtuoso_bridge.virtuoso.symbol import (
+    symbol_create_ellipse,
+    symbol_create_instance_label,
+    symbol_create_label,
+    symbol_create_line,
+    symbol_create_logical_label,
+    symbol_create_pin,
+    symbol_create_pin_name,
+    symbol_create_polygon,
+    symbol_create_rect,
+    symbol_create_selection_box,
+    symbol_set_term_order,
+)
+```
+
+`symbol_create_label()` is for non-semantic drawing text. Labels that
+Virtuoso interprets on placed instances must use the dedicated builders. They
+call `schCreateSymbolLabel`, which applies the current session's
+`schSymbolLabelChoices` mapping:
+
+| Meaning | Builder | Label choice | Default text | Type | Layer/purpose |
+|---|---|---|---|---|---|
+| Pin name | `symbol_create_pin_name` | `pin name` | pin name | `normalLabel` | `pin/label` |
+| Instance name | `symbol_create_instance_label` | `instance label` | `[@instanceName]` | `NLPLabel` | `instance/label` |
+| Logical/part name | `symbol_create_logical_label` | `logical label` | `[@partName]` | `NLPLabel` | `device/label` |
+
+Do not create `[@instanceName]` or `[@partName]` as generic labels and then
+set `labelType` manually. In particular, `ILLabel` is not the native type for
+these two choices. It is normally used by analog annotation expressions such
+as `cdsName()`, `cdsTerm()`, and `cdsParam()`.
+
+`symbol_create_pin(..., label=True)` creates its visible name through the
+native `pin name` choice. Use `label=False` only when placing the name
+separately with `symbol_create_pin_name()`.
+
+### Selection box
+
+Every manually drawn symbol should contain one selection box so that placed
+instances can be selected and preselected in a schematic:
+
+```python
+symbol.add(symbol_create_selection_box(-1.5, -1.0, 1.5, 1.0))
+```
+
+The builder creates a rectangle on `instance/drawing`, matching Cadence's
+native symbol generator. Size it around the symbol pin origins and device
+shapes; instance and logical labels do not need to enlarge it. The editor does
+not infer this geometry because the caller controls the drawing.
+
+### Complete manual symbol
+
+```python
+with client.symbol.edit("demoLib", "prettyBlock") as symbol:
+    symbol.add(symbol_create_polygon(
+        "device", "drawing",
+        [(-1.0, -0.75), (-1.0, 0.75), (1.0, 0.0)],
+    ))
+
+    symbol.add(symbol_create_pin(
+        "VIN", -1.5, 0.25,
+        direction="input",
+        label_x=-0.9,
+        label_y=0.25,
+    ))
+    symbol.add(symbol_create_pin(
+        "VOUT", 1.5, 0.0,
+        direction="output",
+        label_x=0.9,
+        label_y=0.0,
+        label_justification="centerRight",
+    ))
+
+    symbol.add(symbol_create_instance_label(0.0, 1.0))
+    symbol.add(symbol_create_logical_label(0.0, -1.0))
+    symbol.add(symbol_create_selection_box(-1.5, -0.75, 1.5, 0.75))
+    symbol.add(symbol_set_term_order(["VIN", "VOUT"]))
+```
+
+After creation, inspect `client.symbol.read_ports()` rather than checking only
+the visible strings. For a correct manually drawn symbol, verify that pin-name
+labels are `pin/label + normalLabel`, the instance label is
+`instance/label + NLPLabel`, the logical label is `device/label + NLPLabel`,
+and exactly one `selectionBoxes` record is present.

--- a/src/virtuoso_bridge/virtuoso/symbol/__init__.py
+++ b/src/virtuoso_bridge/virtuoso/symbol/__init__.py
@@ -15,11 +15,15 @@ from virtuoso_bridge.virtuoso.symbol.generator import (
 from virtuoso_bridge.virtuoso.symbol.ops import (
     symbol_check,
     symbol_create_ellipse,
+    symbol_create_instance_label,
     symbol_create_label,
     symbol_create_line,
+    symbol_create_logical_label,
     symbol_create_pin,
+    symbol_create_pin_name,
     symbol_create_polygon,
     symbol_create_rect,
+    symbol_create_selection_box,
     symbol_set_term_order,
 )
 from virtuoso_bridge.virtuoso.symbol.reader import (
@@ -113,6 +117,10 @@ __all__ = [
     "symbol_create_polygon",
     "symbol_create_ellipse",
     "symbol_create_label",
+    "symbol_create_pin_name",
+    "symbol_create_instance_label",
+    "symbol_create_logical_label",
+    "symbol_create_selection_box",
     "symbol_create_pin",
     "symbol_set_term_order",
     "symbol_check",

--- a/src/virtuoso_bridge/virtuoso/symbol/ops.py
+++ b/src/virtuoso_bridge/virtuoso/symbol/ops.py
@@ -91,7 +91,11 @@ def symbol_create_label(
     cv_expr: str = "cv",
     label_type: str | None = None,
 ) -> str:
-    """Build SKILL to create a symbol label."""
+    """Build SKILL to create a non-semantic drawing label.
+
+    Use the dedicated pin-name, instance-label, and logical-label builders for
+    labels that Virtuoso must interpret on placed symbol instances.
+    """
     create_label = (
         f"dbCreateLabel({cv_expr} {_lpp_expr(layer, purpose)} {skill_point(x, y)} "
         f'"{escape_skill_string(text)}" '
@@ -106,6 +110,133 @@ def symbol_create_label(
         f"rbLabel = {create_label} "
         f'when(rbLabel rbLabel~>labelType = "{escape_skill_string(label_type)}") '
         "rbLabel)"
+    )
+
+
+def _symbol_create_semantic_label(
+    label_choice: str,
+    text: str,
+    x: float,
+    y: float,
+    *,
+    justification: str,
+    rotation: str,
+    font: str,
+    height: float,
+    label_type: str,
+    cv_expr: str,
+) -> str:
+    create_label = (
+        f"schCreateSymbolLabel({cv_expr} {skill_point(x, y)} "
+        f'"{escape_skill_string(label_choice)}" '
+        f'"{escape_skill_string(text)}" '
+        f'"{escape_skill_string(justification)}" '
+        f'"{escape_skill_string(rotation)}" '
+        f'"{escape_skill_string(font)}" {height:g} '
+        f'"{escape_skill_string(label_type)}")'
+    )
+    escaped_choice = escape_skill_string(label_choice)
+    return (
+        "let((rbSemanticLabel) "
+        f"rbSemanticLabel = {create_label} "
+        f'unless(rbSemanticLabel error("semantic label not created: {escaped_choice}")) '
+        "rbSemanticLabel)"
+    )
+
+
+def symbol_create_pin_name(
+    pin_name: str,
+    x: float,
+    y: float,
+    *,
+    justification: str = "centerLeft",
+    rotation: str = "R0",
+    font: str = "stick",
+    height: float = 0.0625,
+    cv_expr: str = "cv",
+) -> str:
+    """Build a native ``pin name`` label on ``pin/label``."""
+    return _symbol_create_semantic_label(
+        "pin name",
+        pin_name,
+        x,
+        y,
+        justification=justification,
+        rotation=rotation,
+        font=font,
+        height=height,
+        label_type="normalLabel",
+        cv_expr=cv_expr,
+    )
+
+
+def symbol_create_instance_label(
+    x: float,
+    y: float,
+    *,
+    text: str = "[@instanceName]",
+    justification: str = "centerLeft",
+    rotation: str = "R0",
+    font: str = "stick",
+    height: float = 0.0625,
+    cv_expr: str = "cv",
+) -> str:
+    """Build a native ``instance label`` using Cadence's label mapping."""
+    return _symbol_create_semantic_label(
+        "instance label",
+        text,
+        x,
+        y,
+        justification=justification,
+        rotation=rotation,
+        font=font,
+        height=height,
+        label_type="NLPLabel",
+        cv_expr=cv_expr,
+    )
+
+
+def symbol_create_logical_label(
+    x: float,
+    y: float,
+    *,
+    text: str = "[@partName]",
+    justification: str = "centerCenter",
+    rotation: str = "R0",
+    font: str = "stick",
+    height: float = 0.0625,
+    cv_expr: str = "cv",
+) -> str:
+    """Build a native ``logical label`` using Cadence's label mapping."""
+    return _symbol_create_semantic_label(
+        "logical label",
+        text,
+        x,
+        y,
+        justification=justification,
+        rotation=rotation,
+        font=font,
+        height=height,
+        label_type="NLPLabel",
+        cv_expr=cv_expr,
+    )
+
+
+def symbol_create_selection_box(
+    x0: float,
+    y0: float,
+    x1: float,
+    y1: float,
+    *,
+    cv_expr: str = "cv",
+) -> str:
+    """Build the ``instance/drawing`` rectangle used to select the symbol."""
+    return (
+        "let((rbSelectionBox) "
+        f"rbSelectionBox = dbCreateRect({cv_expr} "
+        f"{_lpp_expr('instance', 'drawing')} {_bbox_expr(x0, y0, x1, y1)}) "
+        'unless(rbSelectionBox error("selection box not created")) '
+        "rbSelectionBox)"
     )
 
 
@@ -128,7 +259,8 @@ def symbol_create_pin(
     """Build SKILL to create a symbol terminal pin.
 
     The pin is represented as a terminal/net pair plus a small rectangle on
-    ``pin/drawing``. An optional text label is placed on the same layer.
+    ``pin/drawing``. When requested, its name is created through Cadence's
+    native ``pin name`` label choice, which produces ``pin/label``.
     """
     escaped_pin = escape_skill_string(pin_name)
     escaped_direction = escape_skill_string(direction)
@@ -143,13 +275,18 @@ def symbol_create_pin(
     label_decl = ""
     if label:
         label_decl = " rbLabel"
+        create_pin_name = symbol_create_pin_name(
+            pin_name,
+            effective_label_x,
+            effective_label_y,
+            justification=label_justification,
+            rotation=label_rotation,
+            font=label_font,
+            height=label_height,
+            cv_expr=cv_expr,
+        )
         label_expr = (
-            f"rbLabel = dbCreateLabel({cv_expr} {_lpp_expr('pin', 'drawing')} "
-            f"{skill_point(effective_label_x, effective_label_y)} "
-            f'"{escaped_pin}" '
-            f'"{escape_skill_string(label_justification)}" '
-            f'"{escape_skill_string(label_rotation)}" '
-            f'"{escape_skill_string(label_font)}" {label_height:g}) '
+            f"rbLabel = {create_pin_name} "
             'unless(rbLabel error("pin label not created")) '
         )
 

--- a/src/virtuoso_bridge/virtuoso/symbol/reader.py
+++ b/src/virtuoso_bridge/virtuoso/symbol/reader.py
@@ -52,8 +52,25 @@ def symbol_read_ports_skill(
         'when(label~>objType == "label" '
         "xy = nil "
         "when(label~>xy xy = list(xCoord(label~>xy) yCoord(label~>xy))) "
+        "bbox = nil "
+        "when(label~>bBox "
+        "bbox = list(list(xCoord(car(label~>bBox)) yCoord(car(label~>bBox))) "
+        "list(xCoord(cadr(label~>bBox)) yCoord(cadr(label~>bBox))))) "
         'result = cons(list("label" if(label~>theLabel label~>theLabel "") '
-        'if(label~>labelType label~>labelType "") xy) result))) '
+        'if(label~>labelType label~>labelType "") xy '
+        'if(label~>layerName label~>layerName "") '
+        'if(label~>purpose label~>purpose "") '
+        'if(label~>justify label~>justify "") '
+        'if(label~>orient label~>orient "") '
+        'if(label~>font label~>font "") '
+        "if(label~>height label~>height 0) bbox) result)) "
+        'when(label~>objType == "rect" && '
+        'label~>layerName == "instance" && label~>purpose == "drawing" '
+        "bbox = nil "
+        "when(label~>bBox "
+        "bbox = list(list(xCoord(car(label~>bBox)) yCoord(car(label~>bBox))) "
+        "list(xCoord(cadr(label~>bBox)) yCoord(cadr(label~>bBox))))) "
+        'result = cons(list("selectionBox" bbox) result))) '
         'result = cons(list("pinOrder" schGetPinOrder(cv)) result) '
         'result = cons(list("portOrder" cv~>portOrder) result) '
         'result = cons(list("termOrder" cv~>termOrder) result) '
@@ -92,6 +109,7 @@ def _parse_symbol_ports_records(parsed: Any) -> dict[str, Any]:
         "pinOrder": [],
         "portOrder": [],
         "termOrder": [],
+        "selectionBoxes": [],
     }
     if not isinstance(parsed, list):
         return result
@@ -110,13 +128,26 @@ def _parse_symbol_ports_records(parsed: Any) -> dict[str, Any]:
                 }
             )
         elif kind == "label" and len(record) >= 4:
-            result["labels"].append(
-                {
-                    "text": _string_value(record[1]),
-                    "labelType": _string_value(record[2]),
-                    "xy": _point_value(record[3]),
-                }
-            )
+            label = {
+                "text": _string_value(record[1]),
+                "labelType": _string_value(record[2]),
+                "xy": _point_value(record[3]),
+            }
+            if len(record) >= 11:
+                label.update(
+                    {
+                        "layerName": _string_value(record[4]),
+                        "purpose": _string_value(record[5]),
+                        "justify": _string_value(record[6]),
+                        "orient": _string_value(record[7]),
+                        "font": _string_value(record[8]),
+                        "height": _float_value(record[9]),
+                        "bbox": _bbox_value(record[10]),
+                    }
+                )
+            result["labels"].append(label)
+        elif kind == "selectionBox" and len(record) >= 2:
+            result["selectionBoxes"].append(_bbox_value(record[1]))
         elif kind in {"pinOrder", "portOrder", "termOrder"} and len(record) >= 2:
             order = record[1] if isinstance(record[1], list) else []
             result[kind] = [_string_value(item) for item in order]

--- a/tests/test_symbol_ops.py
+++ b/tests/test_symbol_ops.py
@@ -9,11 +9,15 @@ from virtuoso_bridge.virtuoso.symbol.editor import SymbolEditor
 from virtuoso_bridge.virtuoso.symbol.ops import (
     symbol_check,
     symbol_create_ellipse,
+    symbol_create_instance_label,
     symbol_create_label,
     symbol_create_line,
+    symbol_create_logical_label,
     symbol_create_pin,
+    symbol_create_pin_name,
     symbol_create_polygon,
     symbol_create_rect,
+    symbol_create_selection_box,
     symbol_set_term_order,
 )
 
@@ -59,6 +63,56 @@ def test_symbol_create_label_sets_optional_label_type_and_escapes_text() -> None
     assert skill.endswith("rbLabel)")
 
 
+def test_symbol_create_semantic_labels_use_native_label_choices() -> None:
+    pin_name = symbol_create_pin_name("A", 1, 2)
+    instance_name = symbol_create_instance_label(0, 1)
+    logical_name = symbol_create_logical_label(0, -1)
+
+    assert (
+        'schCreateSymbolLabel(cv \'(1.000 2.000) "pin name" "A" '
+        '"centerLeft" "R0" "stick" 0.0625 "normalLabel")'
+    ) in pin_name
+    assert 'error("semantic label not created: pin name")' in pin_name
+    assert (
+        'schCreateSymbolLabel(cv \'(0.000 1.000) "instance label" '
+        '"[@instanceName]" "centerLeft" "R0" "stick" 0.0625 "NLPLabel")'
+    ) in instance_name
+    assert 'error("semantic label not created: instance label")' in instance_name
+    assert (
+        'schCreateSymbolLabel(cv \'(0.000 -1.000) "logical label" '
+        '"[@partName]" "centerCenter" "R0" "stick" 0.0625 "NLPLabel")'
+    ) in logical_name
+    assert 'error("semantic label not created: logical label")' in logical_name
+
+
+def test_symbol_create_semantic_labels_escape_custom_text_and_attributes() -> None:
+    skill = symbol_create_instance_label(
+        1,
+        2,
+        text='[@foo:"x"]',
+        justification='center"Left',
+        rotation="R90",
+        font="fixed",
+        height=0.125,
+        cv_expr="symbolCv",
+    )
+
+    assert (
+        'schCreateSymbolLabel(symbolCv \'(1.000 2.000) "instance label" '
+        '"[@foo:\\"x\\"]" "center\\"Left" "R90" "fixed" 0.125 "NLPLabel")'
+    ) in skill
+
+
+def test_symbol_create_selection_box_uses_instance_drawing() -> None:
+    skill = symbol_create_selection_box(-1, -0.5, 2, 0.5)
+
+    assert (
+        'dbCreateRect(cv list("instance" "drawing") '
+        "list(list(-1 -0.5) list(2 0.5)))"
+    ) in skill
+    assert 'error("selection box not created")' in skill
+
+
 def test_symbol_create_pin_creates_net_term_pin_rect_and_label() -> None:
     skill = symbol_create_pin(
         "A",
@@ -82,9 +136,10 @@ def test_symbol_create_pin_creates_net_term_pin_rect_and_label() -> None:
     ) in skill
     assert 'rbPin = dbCreatePin(rbNet rbRect "A" rbTerm)' in skill
     assert (
-        'rbLabel = dbCreateLabel(cv list("pin" "drawing") \'(1.250 2.000) '
-        '"A" "centerLeft" "R0" "stick" 0.0625)'
+        'schCreateSymbolLabel(cv \'(1.250 2.000) "pin name" "A" '
+        '"centerLeft" "R0" "stick" 0.0625 "normalLabel")'
     ) in skill
+    assert 'error("semantic label not created: pin name")' in skill
     assert skill.endswith("rbPin)")
 
 

--- a/tests/test_symbol_reader.py
+++ b/tests/test_symbol_reader.py
@@ -23,6 +23,13 @@ def test_symbol_read_ports_skill_opens_symbol_and_reports_terms_labels_and_order
     assert "list(xCoord(cadr(fig~>bBox)) yCoord(cadr(fig~>bBox))))" in skill
     assert 'result = cons(list("label"' in skill
     assert "xy = list(xCoord(label~>xy) yCoord(label~>xy))" in skill
+    assert "if(label~>layerName label~>layerName \"\")" in skill
+    assert "if(label~>purpose label~>purpose \"\")" in skill
+    assert "if(label~>justify label~>justify \"\")" in skill
+    assert "if(label~>orient label~>orient \"\")" in skill
+    assert "if(label~>font label~>font \"\")" in skill
+    assert "if(label~>height label~>height 0) bbox" in skill
+    assert 'result = cons(list("selectionBox" bbox) result)' in skill
     assert "unwindProtect(" in skill
     assert 'result = cons(list("pinOrder" schGetPinOrder(cv)) result)' in skill
     assert 'result = cons(list("portOrder" cv~>portOrder) result)' in skill
@@ -93,6 +100,32 @@ def test_parse_symbol_ports_output_preserves_label_delimiters_from_sexpr() -> No
     assert parsed["pinOrder"] == ["A", "Y"]
     assert parsed["portOrder"] == ["Y", "A"]
     assert parsed["termOrder"] == ["A", "Y"]
+
+
+def test_parse_symbol_ports_output_reports_label_semantics_and_selection_box() -> None:
+    parsed = parse_symbol_ports_output(
+        '(("label" "[@instanceName]" "NLPLabel" (0 1) '
+        '"instance" "label" "centerLeft" "R0" "stick" 0.0625 '
+        '((-0.1 0.9) (0.8 1.1))) '
+        '("selectionBox" ((-1 -0.5) (2 0.5))) '
+        '("termOrder" ("A")))'
+    )
+
+    assert parsed["labels"] == [
+        {
+            "text": "[@instanceName]",
+            "labelType": "NLPLabel",
+            "xy": [0.0, 1.0],
+            "layerName": "instance",
+            "purpose": "label",
+            "justify": "centerLeft",
+            "orient": "R0",
+            "font": "stick",
+            "height": 0.0625,
+            "bbox": [[-0.1, 0.9], [0.8, 1.1]],
+        }
+    ]
+    assert parsed["selectionBoxes"] == [[[-1.0, -0.5], [2.0, 0.5]]]
 
 
 def test_read_symbol_ports_executes_skill() -> None:

--- a/tests/test_symbol_semantics_live.py
+++ b/tests/test_symbol_semantics_live.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from virtuoso_bridge import VirtuosoClient
+from virtuoso_bridge.env import set_runtime_env_file
+from virtuoso_bridge.models import ExecutionStatus
+from virtuoso_bridge.virtuoso.symbol import (
+    symbol_create_instance_label,
+    symbol_create_logical_label,
+    symbol_create_pin,
+    symbol_create_rect,
+    symbol_create_selection_box,
+    symbol_set_term_order,
+)
+
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("VB_RUN_LIVE_TESTS") != "1",
+    reason="set VB_RUN_LIVE_TESTS=1 to run against a live Virtuoso session",
+)
+
+
+def _semantic_labels(labels: list[dict[str, object]]) -> dict[str, dict[str, object]]:
+    return {
+        str(label["text"]): label
+        for label in labels
+        if label.get("text") in {"IN", "OUT", "[@instanceName]", "[@partName]"}
+    }
+
+
+def test_manual_symbol_semantics_round_trip_in_virtuoso() -> None:
+    env_file = os.getenv("VB_TEST_ENV_FILE")
+    if env_file:
+        set_runtime_env_file(env_file)
+    lib = os.getenv("VB_TEST_LIB")
+    if not lib:
+        pytest.fail("VB_TEST_LIB is required for live symbol tests")
+
+    cell = f"VB_SYMBOL_SEMANTICS_{uuid.uuid4().hex[:10]}"
+    client = VirtuosoClient.from_env(timeout=60)
+
+    try:
+        with client.symbol.edit(lib, cell, mode="w", timeout=60) as symbol:
+            symbol.add(symbol_create_rect("device", "drawing", -0.5, -0.5, 0.5, 0.5))
+            symbol.add(
+                symbol_create_pin(
+                    "IN",
+                    -1.0,
+                    0.0,
+                    direction="input",
+                    label_x=-0.45,
+                    label_y=0.0,
+                )
+            )
+            symbol.add(
+                symbol_create_pin(
+                    "OUT",
+                    1.0,
+                    0.0,
+                    direction="output",
+                    label_x=0.45,
+                    label_y=0.0,
+                    label_justification="centerRight",
+                )
+            )
+            symbol.add(symbol_create_instance_label(0.0, 0.75))
+            symbol.add(symbol_create_logical_label(0.0, -0.75))
+            symbol.add(symbol_create_selection_box(-1.0, -0.5, 1.0, 0.5))
+            symbol.add(symbol_set_term_order(["IN", "OUT"]))
+
+        ports = client.symbol.read_ports(lib, cell, timeout=60)
+        labels = _semantic_labels(ports["labels"])
+
+        assert set(labels) == {"IN", "OUT", "[@instanceName]", "[@partName]"}
+        assert labels["IN"]["labelType"] == "normalLabel"
+        assert labels["IN"]["layerName"] == "pin"
+        assert labels["IN"]["purpose"] == "label"
+        assert labels["OUT"]["labelType"] == "normalLabel"
+        assert labels["OUT"]["layerName"] == "pin"
+        assert labels["OUT"]["purpose"] == "label"
+        assert labels["[@instanceName]"]["labelType"] == "NLPLabel"
+        assert labels["[@instanceName]"]["layerName"] == "instance"
+        assert labels["[@instanceName]"]["purpose"] == "label"
+        assert labels["[@partName]"]["labelType"] == "NLPLabel"
+        assert labels["[@partName]"]["layerName"] == "device"
+        assert labels["[@partName]"]["purpose"] == "label"
+        assert ports["selectionBoxes"] == [[[-1.0, -0.5], [1.0, 0.5]]]
+        assert ports["termOrder"] == ["IN", "OUT"]
+        assert {term["name"] for term in ports["terms"]} == {"IN", "OUT"}
+    finally:
+        cleanup = client.execute_skill(
+            f'let((openCv obj) '
+            f'openCv = dbFindOpenCellViewByName("{lib}" "{cell}" "symbol") '
+            'when(openCv unless(dbClose(openCv) error("live test close failed"))) '
+            f'obj = ddGetObj("{lib}" "{cell}" "symbol") '
+            'if(obj then ddDeleteObj(obj) else t))',
+            timeout=60,
+        )
+        assert cleanup.status == ExecutionStatus.SUCCESS
+        assert (cleanup.output or "").strip() == "t"


### PR DESCRIPTION
## Summary

- Add low-level semantic symbol label builders backed by
  `schCreateSymbolLabel()`:
  - `symbol_create_pin_name()`
  - `symbol_create_instance_label()`
  - `symbol_create_logical_label()`
- Add `symbol_create_selection_box()` for the native
  `instance/drawing` selection rectangle.
- Change `symbol_create_pin(label=True)` to create a native pin-name
  label instead of decorative text on `pin/drawing`.
- Extend `symbol.read_ports()` with label layer, purpose, orientation,
  justification, font, height, bounding box, and selection-box readback.
- Document the manual symbol-drawing workflow and add a complete example.
- Add focused unit tests and a live Virtuoso round-trip integration test.

## Motivation

The generic `symbol_create_label()` API uses `dbCreateLabel()`. This is
appropriate for decorative symbol text, but it does not apply Cadence
Symbol Editor Label Choice semantics.

As a result, manually generated symbols could look correct while containing
the wrong database objects. In particular, pin names and `[@instanceName]` /
`[@partName]` labels could be stored as ordinary text rather than native
semantic labels.

This change keeps symbol construction low-level and agent-controlled while
providing explicit APIs for the Cadence-native mappings:

| Label Choice | Layer/Purpose | Label Type |
| --- | --- | --- |
| `pin name` | `pin/label` | `normalLabel` |
| `instance label` | `instance/label` | `NLPLabel` |
| `logical label` | `device/label` | `NLPLabel` |

`symbol_create_label()` remains available and is now explicitly documented
as a non-semantic drawing-label API.

## Validation

- `74 passed, 1 skipped` across all Symbol unit and integration-test modules
  with live tests disabled.
- Live round-trip test passed against Virtuoso IC23.1 using a temporary
  symbol in `RECONFIGURABLE_ADC`.
- The live test verified pin-name, instance-label, logical-label,
  selection-box, terminal-order, and terminal readback semantics, then
  deleted the temporary cellview.
- Changed Python modules and examples pass `compileall`.
- `git diff --check` passes.
