### PR TITLE
feat: add library and category management APIs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -345,6 +345,7 @@ When working on a task, check this table to find relevant skills and references.
 | **Virtuoso / SKILL** | `virtuoso` | `skills/virtuoso/SKILL.md` | `references/layout-skill-api.md`, `references/schematic-skill-api.md`, `references/maestro-skill-api.md`, `references/troubleshooting.md` |
 | **SKILL Finder** | `virtuoso` | `skills/virtuoso/SKILL.md` | `references/skill-finder-python-api.md` |
 | **Layout** | `virtuoso` | `skills/virtuoso/SKILL.md` | `references/layout-python-api.md`, `references/layout-skill-api.md` |
+| **Library management** | `virtuoso` | `skills/virtuoso/SKILL.md` | `references/library-python-api.md` |
 | **Schematic** | `virtuoso` | `skills/virtuoso/SKILL.md` | `references/schematic-python-api.md`, `references/schematic-skill-api.md`, `references/schematic-recreation.md` |
 | **Maestro / ADE** | `virtuoso` | `skills/virtuoso/SKILL.md` | `references/maestro-python-api.md`, `references/maestro-skill-api.md`, `references/simulation-flow.md` |
 | **Spectre simulation** | `spectre` | `skills/spectre/SKILL.md` | `references/netlist_syntax.md`, `references/parallel.md` |

--- a/examples/01_virtuoso/basic/08_library_management.py
+++ b/examples/01_virtuoso/basic/08_library_management.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Inspect one library and its top-level categories.
+
+Usage::
+
+    python 08_library_management.py MY_LIB
+"""
+
+from __future__ import annotations
+
+import sys
+
+from virtuoso_bridge import VirtuosoClient
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("Usage: python 08_library_management.py <library_name>")
+        return 2
+
+    client = VirtuosoClient.from_env()
+    library = sys.argv[1]
+    info = client.library.get(library)
+
+    print(f"library: {info.name}")
+    print(f"path: {info.path}")
+    print(f"technology: {info.technology_library or '(unbound)'}")
+    print("categories:")
+    for category in client.library.list_categories(library):
+        cells = client.library.list_category_cells(library, category)
+        print(f"  {category}: {', '.join(cells) if cells else '(empty)'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/virtuoso/SKILL.md
+++ b/skills/virtuoso/SKILL.md
@@ -256,6 +256,7 @@ Load on demand — each contains detailed API docs and edge-case guidance:
 - `04_list_library_cells.py` — list libraries and cells
 - `05_multiline_skill.py` — multi-line SKILL with comments, loops, procedures
 - `06_screenshot.py` — capture layout/schematic screenshots
+- `08_library_management.py` — inspect a library, technology binding, categories, and members
 
 ### `examples/01_virtuoso/schematic/`
 - `01a_create_rc_stepwise.py` — create RC schematic via operations

--- a/skills/virtuoso/SKILL.md
+++ b/skills/virtuoso/SKILL.md
@@ -42,7 +42,7 @@ Always use the highest level that works. Drop to a lower level only when needed.
 
 **Never guess function names.** If the function isn't in the examples below, read the relevant `references/` file before writing the call. Fabricating a wrong name wastes time debugging in CIW.
 
-### Four domains
+### Five domains
 
 | Domain | What it does | Python package | API docs |
 |--------|-------------|----------------|----------|
@@ -50,6 +50,7 @@ Always use the highest level that works. Drop to a lower level only when needed.
 | **Symbol** | Generate, edit, and read symbol views | `client.symbol.*` | `references/symbol-python-api.md` |
 | **Layout** | Create/edit layout, add shapes/vias/instances | `client.layout.*` | `references/layout-python-api.md`, `references/layout-skill-api.md` |
 | **Maestro** | Read/write ADE Assembler config, run simulations | `virtuoso_bridge.virtuoso.maestro` | `references/maestro-python-api.md`, `references/maestro-skill-api.md` |
+| **Library** | Read/create/rename/delete libraries, bind technology | `client.library.*` | `references/library-python-api.md` |
 | **Netlist (si)** | Batch netlist generation without Maestro | `simInitEnvWithArgs` + `si` CLI | See "Batch Netlist (si)" section below |
 | **SKILL Finder** | Search SKILL function names and get detailed docs | `client.find_skill()`, `client.get_skill_more_info()` | `references/skill-finder-python-api.md` |
 | **General** | File transfer, screenshots, raw SKILL, .il loading | `client.*` | See below |
@@ -232,6 +233,7 @@ Load on demand — each contains detailed API docs and edge-case guidance:
 | `references/schematic-python-api.md` | SchematicEditor, SchematicOps, low-level builders |
 | `references/layout-skill-api.md` | Layout SKILL API, read/query, mosaic, layer control |
 | `references/layout-python-api.md` | LayoutEditor, LayoutOps, shape/via/instance creation |
+| `references/library-python-api.md` | Library CRUD, technology binding, return/error contracts |
 | `references/maestro-skill-api.md` | mae* SKILL functions, OCEAN, corners, known blockers |
 | `references/maestro-python-api.md` | snapshot() (raw SKILL sections) + filter_*_xml + writer functions; read_results (per-point × per-output CSV) + export_waveform (OCEAN) |
 | `references/simulation-flow.md` | **Standard simulation flow** — 8-step guide, pitfalls, optimization loops |

--- a/skills/virtuoso/references/library-python-api.md
+++ b/skills/virtuoso/references/library-python-api.md
@@ -1,0 +1,75 @@
+# Library Python API
+
+Library management is attached to `VirtuosoClient` as `client.library`.
+These methods use supported Cadence SKILL APIs and verify the resulting
+Virtuoso library state before returning.
+
+## Read libraries
+
+```python
+names = client.library.list()
+info = client.library.get("MY_LIB")
+
+print(info.name)
+print(info.path)
+print(info.technology_library)  # str or None
+```
+
+`list()` reads the libraries already visible in the current Virtuoso session.
+It does not call `ddUpdateLibList()` or scan the filesystem.
+
+## Create a library
+
+The remote library path is required. The API never chooses a path from the
+local working directory.
+
+```python
+info = client.library.create(
+    "MY_LIB",
+    "/remote/work/MY_LIB",
+    technology_library="TECH_LIB",
+)
+```
+
+Creation uses `ddCreateLib`. When `technology_library` is supplied, the new
+library is bound with `techBindTechFile` and the binding is read back with
+`techGetTechLibName`.
+
+If creation succeeds but technology binding fails,
+`LibraryPartialSuccessError` is raised. Its `library` attribute contains the
+created library's verified state. The API does not silently delete that
+library.
+
+## Change technology binding
+
+```python
+current = client.library.get_technology_library("MY_LIB")
+bound = client.library.set_technology_library("MY_LIB", "OTHER_TECH_LIB")
+```
+
+An unbound library is attached with `techBindTechFile`. An existing binding is
+changed with `techSetTechLibName`. The target technology library must already
+exist; this API does not create or copy technology data.
+
+## Rename and delete
+
+```python
+renamed = client.library.rename("MY_LIB", "MY_RENAMED_LIB")
+client.library.delete("MY_RENAMED_LIB")
+```
+
+Rename uses `ccpRename` with overwrite disabled. Delete uses `ddDeleteObj`.
+There is no `force` option and no Python-side filesystem fallback. Both
+operations raise `RuntimeError` when Cadence rejects the operation or the
+post-operation state does not match.
+
+## Return and error contract
+
+- `list()` returns `list[str]`.
+- `get()`, `create()`, and `rename()` return `LibraryInfo`.
+- `get_technology_library()` returns `str | None`.
+- `set_technology_library()` returns the verified technology library name.
+- `delete()` returns `None` after verified success.
+- Empty required strings raise `ValueError`.
+- Missing objects, name conflicts, transport failures, Cadence failures, and
+  verification failures raise `RuntimeError`.

--- a/skills/virtuoso/references/library-python-api.md
+++ b/skills/virtuoso/references/library-python-api.md
@@ -63,12 +63,55 @@ There is no `force` option and no Python-side filesystem fallback. Both
 operations raise `RuntimeError` when Cadence rejects the operation or the
 post-operation state does not match.
 
+## Manage top-level categories
+
+Categories are flat in this API. `Everything` and `Uncategorized` are Library
+Manager views, not persisted categories, and are not returned.
+
+```python
+categories = client.library.list_categories("MY_LIB")
+created = client.library.create_category("MY_LIB", "ADC")
+cells = client.library.list_category_cells("MY_LIB", "ADC")
+
+client.library.add_cell_to_category("MY_LIB", "ADC", "comparator")
+client.library.remove_cell_from_category("MY_LIB", "ADC", "comparator")
+
+renamed = client.library.rename_category("MY_LIB", "ADC", "Comparators")
+client.library.delete_category("MY_LIB", "Comparators")
+```
+
+Category operations use `ddCatOpenEx`, `ddCatOpen`, `ddCatGetLibCats`,
+`ddCatGetCatMembers`, `ddCatAddItem`, `ddCatSubItem`, `ddCatSave`,
+`ddCatRemove`, and `ddCatClose`.
+
+- Empty categories are created with the `keepEmpty` flag and may remain hidden
+  in some Library Manager views until a cell is added.
+- `list_categories()` opens every returned name and filters stale entries that
+  no longer have a category file.
+- `list_category_cells()` returns only existing members whose type is `cell`.
+- Adding a cell that is already a member, or removing a cell that is not a
+  member, raises `RuntimeError` without changing the category.
+- Category deletion removes category membership data only; it never deletes
+  member cells.
+- Category rename refuses a destination that already exists. Because the
+  supported `ddCat` API has no direct rename call, the implementation copies
+  verified cell memberships to the new category and then removes the old one.
+- Categories containing subcategories cannot be renamed by this flat API.
+- No category operation edits `.Cat` or `.TopCat` files directly.
+
+If a multi-step category mutation may have persisted only part of its change,
+`CategoryPartialSuccessError` reports the affected library and category. No
+automatic rollback or filesystem fallback is attempted.
+
 ## Return and error contract
 
 - `list()` returns `list[str]`.
 - `get()`, `create()`, and `rename()` return `LibraryInfo`.
 - `get_technology_library()` returns `str | None`.
 - `set_technology_library()` returns the verified technology library name.
+- Category list methods return `list[str]`.
+- `create_category()` and `rename_category()` return the verified category name.
+- Category membership mutations and `delete_category()` return `None`.
 - `delete()` returns `None` after verified success.
 - Empty required strings raise `ValueError`.
 - Missing objects, name conflicts, transport failures, Cadence failures, and

--- a/src/virtuoso_bridge/virtuoso/basic/bridge.py
+++ b/src/virtuoso_bridge/virtuoso/basic/bridge.py
@@ -26,6 +26,7 @@ from virtuoso_bridge.virtuoso.ops import (
     save_current_cellview as op_save_current_cellview,
 )
 from virtuoso_bridge.virtuoso.layout import LayoutOps
+from virtuoso_bridge.virtuoso.library import LibraryOps
 from virtuoso_bridge.virtuoso.schematic import SchematicOps
 from virtuoso_bridge.virtuoso.symbol import SymbolOps
 
@@ -88,6 +89,7 @@ class VirtuosoClient(VirtuosoInterface):
         self._tunnel = tunnel  # SSHClient, if provided
         self._log_to_ciw = log_to_ciw
         self.layout = LayoutOps(self)
+        self.library = LibraryOps(self)
         self.schematic = SchematicOps(self)
         self.symbol = SymbolOps(self)
         self._il_upload_cache: dict[str, tuple[str, str]] = {}

--- a/src/virtuoso_bridge/virtuoso/library/__init__.py
+++ b/src/virtuoso_bridge/virtuoso/library/__init__.py
@@ -1,0 +1,87 @@
+"""Library management APIs attached to :class:`VirtuosoClient`."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from virtuoso_bridge.virtuoso.library.management import (
+    LibraryInfo,
+    LibraryPartialSuccessError,
+    create_library,
+    delete_library,
+    get_library,
+    list_libraries,
+    rename_library,
+    set_technology_library,
+)
+
+if TYPE_CHECKING:
+    from virtuoso_bridge import VirtuosoClient
+
+
+class LibraryOps:
+    """Attached to ``VirtuosoClient`` as ``client.library``."""
+
+    def __init__(self, owner: VirtuosoClient) -> None:
+        self._owner = owner
+
+    def list(self, *, timeout: int = 30) -> list[str]:
+        """Return libraries visible in the current Virtuoso session."""
+        return list_libraries(self._owner, timeout=timeout)
+
+    def get(self, name: str, *, timeout: int = 30) -> LibraryInfo:
+        """Return a library's path and technology binding."""
+        return get_library(self._owner, name, timeout=timeout)
+
+    def create(
+        self,
+        name: str,
+        path: str,
+        *,
+        technology_library: str | None = None,
+        timeout: int = 60,
+    ) -> LibraryInfo:
+        """Create a library and optionally bind existing technology."""
+        return create_library(
+            self._owner,
+            name,
+            path,
+            technology_library=technology_library,
+            timeout=timeout,
+        )
+
+    def delete(self, name: str, *, timeout: int = 60) -> None:
+        """Delete a library through Cadence's supported API."""
+        delete_library(self._owner, name, timeout=timeout)
+
+    def rename(
+        self,
+        name: str,
+        new_name: str,
+        *,
+        timeout: int = 120,
+    ) -> LibraryInfo:
+        """Rename a library without overwrite or force behavior."""
+        return rename_library(self._owner, name, new_name, timeout=timeout)
+
+    def get_technology_library(self, name: str, *, timeout: int = 30) -> str | None:
+        """Return the technology library currently bound to a library."""
+        return self.get(name, timeout=timeout).technology_library
+
+    def set_technology_library(
+        self,
+        name: str,
+        technology_library: str,
+        *,
+        timeout: int = 60,
+    ) -> str:
+        """Bind or change a library's technology library."""
+        return set_technology_library(
+            self._owner,
+            name,
+            technology_library,
+            timeout=timeout,
+        )
+
+
+__all__ = ["LibraryInfo", "LibraryOps", "LibraryPartialSuccessError"]

--- a/src/virtuoso_bridge/virtuoso/library/__init__.py
+++ b/src/virtuoso_bridge/virtuoso/library/__init__.py
@@ -4,6 +4,16 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from virtuoso_bridge.virtuoso.library.category import (
+    CategoryPartialSuccessError,
+    add_cell_to_category,
+    create_category,
+    delete_category,
+    list_categories,
+    list_category_cells,
+    remove_cell_from_category,
+    rename_category,
+)
 from virtuoso_bridge.virtuoso.library.management import (
     LibraryInfo,
     LibraryPartialSuccessError,
@@ -83,5 +93,95 @@ class LibraryOps:
             timeout=timeout,
         )
 
+    def list_categories(self, library: str, *, timeout: int = 30) -> list[str]:
+        """Return existing top-level categories in a library."""
+        return list_categories(self._owner, library, timeout=timeout)
 
-__all__ = ["LibraryInfo", "LibraryOps", "LibraryPartialSuccessError"]
+    def create_category(
+        self,
+        library: str,
+        category: str,
+        *,
+        timeout: int = 30,
+    ) -> str:
+        """Create an empty persistent top-level category."""
+        return create_category(self._owner, library, category, timeout=timeout)
+
+    def rename_category(
+        self,
+        library: str,
+        category: str,
+        new_name: str,
+        *,
+        timeout: int = 60,
+    ) -> str:
+        """Rename a flat category without overwrite or merge behavior."""
+        return rename_category(
+            self._owner,
+            library,
+            category,
+            new_name,
+            timeout=timeout,
+        )
+
+    def delete_category(
+        self,
+        library: str,
+        category: str,
+        *,
+        timeout: int = 30,
+    ) -> None:
+        """Delete a category and memberships without deleting cells."""
+        delete_category(self._owner, library, category, timeout=timeout)
+
+    def list_category_cells(
+        self,
+        library: str,
+        category: str,
+        *,
+        timeout: int = 30,
+    ) -> list[str]:
+        """Return existing cell members of a category."""
+        return list_category_cells(self._owner, library, category, timeout=timeout)
+
+    def add_cell_to_category(
+        self,
+        library: str,
+        category: str,
+        cell: str,
+        *,
+        timeout: int = 30,
+    ) -> None:
+        """Add one existing cell to a category."""
+        add_cell_to_category(
+            self._owner,
+            library,
+            category,
+            cell,
+            timeout=timeout,
+        )
+
+    def remove_cell_from_category(
+        self,
+        library: str,
+        category: str,
+        cell: str,
+        *,
+        timeout: int = 30,
+    ) -> None:
+        """Remove one existing cell from a category."""
+        remove_cell_from_category(
+            self._owner,
+            library,
+            category,
+            cell,
+            timeout=timeout,
+        )
+
+
+__all__ = [
+    "CategoryPartialSuccessError",
+    "LibraryInfo",
+    "LibraryOps",
+    "LibraryPartialSuccessError",
+]

--- a/src/virtuoso_bridge/virtuoso/library/category.py
+++ b/src/virtuoso_bridge/virtuoso/library/category.py
@@ -1,0 +1,564 @@
+"""Flat library category management through the supported ``ddCat`` API."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from virtuoso_bridge.virtuoso.library.management import (
+    _execute_record,
+    _record_value,
+    _require_text,
+)
+from virtuoso_bridge.virtuoso.ops import q
+
+
+class CategoryPartialSuccessError(RuntimeError):
+    """Raised when a category mutation may have changed persisted state."""
+
+    def __init__(self, message: str, *, library: str, category: str) -> None:
+        self.library = library
+        self.category = category
+        super().__init__(message)
+
+
+def category_list_skill(library: str) -> str:
+    """Build SKILL that returns existing top-level category names."""
+    library = _require_text("library", library)
+    return (
+        "let((vbLib vbName vbCat vbClosed vbResult) "
+        f"vbLib = ddGetObj({q(library)}) "
+        "if(!vbLib "
+        'then list("error" "libraryNotFound") '
+        "else progn("
+        "vbResult = nil "
+        "foreach(vbName ddCatGetLibCats(vbLib) "
+        'vbCat = ddCatOpen(vbLib vbName "r") '
+        "when(vbCat "
+        "vbResult = cons(vbName vbResult) "
+        "vbClosed = ddCatClose(vbCat) "
+        'unless(vbClosed error("category close failed")))) '
+        'list("ok" reverse(vbResult)))))'
+    )
+
+
+def category_create_skill(library: str, category: str) -> str:
+    """Build SKILL that creates and verifies an empty persistent category."""
+    library = _require_text("library", library)
+    category = _require_text("category", category)
+    return f"""
+let((vbLib vbExisting vbCat vbSaved vbClosed vbVerify)
+  vbLib = ddGetObj({q(library)})
+  if(!vbLib
+    then list("error" "libraryNotFound")
+    else progn(
+      vbExisting = ddCatOpen(vbLib {q(category)} "r")
+      if(vbExisting
+        then progn(
+          vbClosed = ddCatClose(vbExisting)
+          if(vbClosed
+            then list("error" "categoryExists")
+            else list("error" "categoryCloseFailed")
+          )
+        )
+        else progn(
+          vbCat = ddCatOpenEx(vbLib {q(category)} "w" 1)
+          if(!vbCat
+            then list("error" "categoryCreateFailed")
+            else progn(
+              vbSaved = ddCatSave(vbCat)
+              vbClosed = ddCatClose(vbCat)
+              if(!vbSaved || !vbClosed
+                then list("partial" "categoryCreateFailed")
+                else progn(
+                  vbVerify = ddCatOpen(vbLib {q(category)} "r")
+                  if(!vbVerify
+                    then list("partial" "categoryCreateVerificationFailed")
+                    else progn(
+                      vbClosed = ddCatClose(vbVerify)
+                      if(vbClosed
+                        then list("ok" {q(category)})
+                        else list("partial" "categoryCloseFailed")
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+""".strip()
+
+
+def category_delete_skill(library: str, category: str) -> str:
+    """Build SKILL that removes only a category and its memberships."""
+    library = _require_text("library", library)
+    category = _require_text("category", category)
+    return f"""
+let((vbLib vbExisting vbCat vbRemoved vbClosed vbVerify)
+  vbLib = ddGetObj({q(library)})
+  if(!vbLib
+    then list("error" "libraryNotFound")
+    else progn(
+      vbExisting = ddCatOpen(vbLib {q(category)} "r")
+      if(!vbExisting
+        then list("error" "categoryNotFound")
+        else progn(
+          vbClosed = ddCatClose(vbExisting)
+          if(!vbClosed
+            then list("error" "categoryCloseFailed")
+            else progn(
+              vbCat = ddCatOpen(vbLib {q(category)} "a")
+              if(!vbCat
+                then list("error" "categoryReopenFailed")
+                else progn(
+                  vbRemoved = ddCatRemove(vbCat)
+                  if(!vbRemoved
+                    then progn(
+                      vbClosed = ddCatClose(vbCat)
+                      if(vbClosed
+                        then list("error" "categoryDeleteFailed")
+                        else list("error" "categoryCloseFailed")
+                      )
+                    )
+                    else progn(
+                      vbVerify = ddCatOpen(vbLib {q(category)} "r")
+                      if(vbVerify
+                        then progn(
+                          vbClosed = ddCatClose(vbVerify)
+                          if(vbClosed
+                            then list("partial" "categoryDeleteVerificationFailed")
+                            else list("partial" "categoryCloseFailed")
+                          )
+                        )
+                        else list("ok")
+                      )
+                    )
+                  )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+  )
+)
+""".strip()
+
+
+def category_list_cells_skill(library: str, category: str) -> str:
+    """Build SKILL that returns existing cell members of one category."""
+    library = _require_text("library", library)
+    category = _require_text("category", category)
+    return f"""
+let((vbLib vbCat vbMember vbCells vbClosed)
+  vbLib = ddGetObj({q(library)})
+  if(!vbLib
+    then list("error" "libraryNotFound")
+    else progn(
+      vbCat = ddCatOpen(vbLib {q(category)} "r")
+      if(!vbCat
+        then list("error" "categoryNotFound")
+        else progn(
+          vbCells = nil
+          foreach(vbMember ddCatGetCatMembers(vbCat)
+            when(cadr(vbMember) == "cell"
+              vbCells = cons(car(vbMember) vbCells)
+            )
+          )
+          vbClosed = ddCatClose(vbCat)
+          if(vbClosed
+            then list("ok" reverse(vbCells))
+            else list("error" "categoryCloseFailed")
+          )
+        )
+      )
+    )
+  )
+)
+""".strip()
+
+
+def category_add_cell_skill(library: str, category: str, cell: str) -> str:
+    """Build SKILL that adds and verifies one cell membership."""
+    return _category_change_cell_skill(library, category, cell, add=True)
+
+
+def category_remove_cell_skill(library: str, category: str, cell: str) -> str:
+    """Build SKILL that removes and verifies one cell membership."""
+    return _category_change_cell_skill(library, category, cell, add=False)
+
+
+def category_rename_skill(library: str, category: str, new_name: str) -> str:
+    """Build SKILL that renames a flat category while preserving cells."""
+    library = _require_text("library", library)
+    category = _require_text("category", category)
+    new_name = _require_text("new_name", new_name)
+    return f"""
+let((vbLib vbSource vbDestination vbExisting vbMember vbMembers vbDestinationMembers
+     vbUnsupported vbAdded vbSaved vbClosed vbMatch vbRemoved vbVerify)
+  vbLib = ddGetObj({q(library)})
+  if(!vbLib
+    then list("error" "libraryNotFound")
+    else progn(
+      vbSource = ddCatOpen(vbLib {q(category)} "r")
+      if(!vbSource
+        then list("error" "categoryNotFound")
+        else progn(
+          vbMembers = ddCatGetCatMembers(vbSource)
+          vbUnsupported = nil
+          foreach(vbMember vbMembers
+            unless(cadr(vbMember) == "cell" vbUnsupported = t)
+          )
+          vbClosed = ddCatClose(vbSource)
+          if(!vbClosed
+            then list("error" "categoryCloseFailed")
+            else if(vbUnsupported
+              then list("error" "categoryContainsSubcategories")
+              else progn(
+                vbExisting = ddCatOpen(vbLib {q(new_name)} "r")
+                if(vbExisting
+                  then progn(
+                    vbClosed = ddCatClose(vbExisting)
+                    if(vbClosed
+                      then list("error" "destinationCategoryExists")
+                      else list("error" "categoryCloseFailed")
+                    )
+                  )
+                  else progn(
+                    vbDestination = ddCatOpenEx(vbLib {q(new_name)} "w" 1)
+                    if(!vbDestination
+                      then list("error" "categoryRenameCreateFailed")
+                      else progn(
+                        vbAdded = t
+                        foreach(vbMember vbMembers
+                          unless(ddCatAddItem(
+                              vbDestination car(vbMember) cadr(vbMember))
+                            vbAdded = nil
+                          )
+                        )
+                        vbSaved = if(vbAdded
+                          then ddCatSave(vbDestination)
+                          else nil
+                        )
+                        vbClosed = ddCatClose(vbDestination)
+                        if(!vbAdded || !vbSaved || !vbClosed
+                          then list("partial" "categoryRenameDestinationFailed")
+                          else progn(
+                            vbVerify = ddCatOpen(vbLib {q(new_name)} "r")
+                            if(!vbVerify
+                              then list("partial" "categoryRenameVerificationFailed")
+                              else progn(
+                                vbDestinationMembers = ddCatGetCatMembers(vbVerify)
+                                vbMatch = length(vbMembers) == length(vbDestinationMembers)
+                                foreach(vbMember vbMembers
+                                  unless(member(vbMember vbDestinationMembers)
+                                    vbMatch = nil
+                                  )
+                                )
+                                vbClosed = ddCatClose(vbVerify)
+                                if(!vbMatch || !vbClosed
+                                  then list("partial" "categoryRenameVerificationFailed")
+                                  else progn(
+                                    vbSource = ddCatOpen(vbLib {q(category)} "a")
+                                    if(!vbSource
+                                      then list("partial" "categoryRenameSourceReopenFailed")
+                                      else progn(
+                                        vbRemoved = ddCatRemove(vbSource)
+                                        if(!vbRemoved
+                                          then progn(
+                                            vbClosed = ddCatClose(vbSource)
+                                            list("partial" "categoryRenameSourceRemovalFailed")
+                                          )
+                                          else progn(
+                                            vbVerify = ddCatOpen(vbLib {q(category)} "r")
+                                            if(vbVerify
+                                              then progn(
+                                                vbClosed = ddCatClose(vbVerify)
+                                                list("partial" "categoryRenameSourceVerificationFailed")
+                                              )
+                                              else list("ok" {q(new_name)})
+                                            )
+                                          )
+                                        )
+                                      )
+                                    )
+                                  )
+                                )
+                              )
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+""".strip()
+
+
+def list_categories(client: Any, library: str, *, timeout: int = 30) -> list[str]:
+    """Return existing top-level categories, filtering stale list entries."""
+    operation = f"list categories in {library}"
+    record = _execute_record(client, category_list_skill(library), timeout, operation)
+    _raise_category_error(record, operation, library=library)
+    return _string_list(_record_value(record, operation), operation)
+
+
+def create_category(
+    client: Any,
+    library: str,
+    category: str,
+    *,
+    timeout: int = 30,
+) -> str:
+    """Create and verify an empty persistent top-level category."""
+    operation = f"create category {library}/{category}"
+    record = _execute_record(client, category_create_skill(library, category), timeout, operation)
+    _raise_category_error(record, operation, library=library, category=category)
+    value = _record_value(record, operation)
+    if not isinstance(value, str):
+        raise RuntimeError(f"{operation} returned malformed category name")
+    return value
+
+
+def delete_category(
+    client: Any,
+    library: str,
+    category: str,
+    *,
+    timeout: int = 30,
+) -> None:
+    """Delete a category and memberships without touching member cells."""
+    operation = f"delete category {library}/{category}"
+    record = _execute_record(client, category_delete_skill(library, category), timeout, operation)
+    _raise_category_error(record, operation, library=library, category=category)
+
+
+def list_category_cells(
+    client: Any,
+    library: str,
+    category: str,
+    *,
+    timeout: int = 30,
+) -> list[str]:
+    """Return existing cell members of a top-level category."""
+    operation = f"list category cells for {library}/{category}"
+    record = _execute_record(
+        client,
+        category_list_cells_skill(library, category),
+        timeout,
+        operation,
+    )
+    _raise_category_error(record, operation, library=library, category=category)
+    return _string_list(_record_value(record, operation), operation)
+
+
+def add_cell_to_category(
+    client: Any,
+    library: str,
+    category: str,
+    cell: str,
+    *,
+    timeout: int = 30,
+) -> None:
+    """Add and verify one existing cell's category membership."""
+    operation = f"add cell {library}/{cell} to category {category}"
+    record = _execute_record(
+        client,
+        category_add_cell_skill(library, category, cell),
+        timeout,
+        operation,
+    )
+    _raise_category_error(record, operation, library=library, category=category)
+
+
+def remove_cell_from_category(
+    client: Any,
+    library: str,
+    category: str,
+    cell: str,
+    *,
+    timeout: int = 30,
+) -> None:
+    """Remove and verify one existing cell's category membership."""
+    operation = f"remove cell {library}/{cell} from category {category}"
+    record = _execute_record(
+        client,
+        category_remove_cell_skill(library, category, cell),
+        timeout,
+        operation,
+    )
+    _raise_category_error(record, operation, library=library, category=category)
+
+
+def rename_category(
+    client: Any,
+    library: str,
+    category: str,
+    new_name: str,
+    *,
+    timeout: int = 60,
+) -> str:
+    """Rename a flat category without merging or overwriting."""
+    operation = f"rename category {library}/{category} to {new_name}"
+    record = _execute_record(
+        client,
+        category_rename_skill(library, category, new_name),
+        timeout,
+        operation,
+    )
+    _raise_category_error(record, operation, library=library, category=category)
+    value = _record_value(record, operation)
+    if not isinstance(value, str):
+        raise RuntimeError(f"{operation} returned malformed category name")
+    return value
+
+
+def _category_change_cell_skill(
+    library: str,
+    category: str,
+    cell: str,
+    *,
+    add: bool,
+) -> str:
+    library = _require_text("library", library)
+    category = _require_text("category", category)
+    cell = _require_text("cell", cell)
+    present_error = "cellAlreadyInCategory" if add else "cellNotInCategory"
+    change = (
+        f'ddCatAddItem(vbCat {q(cell)} "cell")'
+        if add
+        else f"ddCatSubItem(vbCat {q(cell)})"
+    )
+    expected = "t" if add else "nil"
+    return f"""
+let((vbLib vbCell vbCat vbMembers vbPresent vbChanged vbSaved vbClosed vbVerify)
+  vbLib = ddGetObj({q(library)})
+  if(!vbLib
+    then list("error" "libraryNotFound")
+    else progn(
+      vbCell = member({q(cell)} vbLib~>cells~>name)
+      if(!vbCell
+        then list("error" "cellNotFound")
+        else progn(
+          vbCat = ddCatOpen(vbLib {q(category)} "r")
+          if(!vbCat
+            then list("error" "categoryNotFound")
+            else progn(
+              vbMembers = ddCatGetCatMembers(vbCat)
+              vbPresent = if(member(list({q(cell)} "cell") vbMembers) t nil)
+              vbClosed = ddCatClose(vbCat)
+              if(!vbClosed
+                then list("error" "categoryCloseFailed")
+                else if(vbPresent == {expected}
+                  then list("error" "{present_error}")
+                  else progn(
+                    vbCat = ddCatOpen(vbLib {q(category)} "a")
+                    if(!vbCat
+                      then list("error" "categoryReopenFailed")
+                      else progn(
+                        vbChanged = {change}
+                        vbSaved = if(vbChanged then ddCatSave(vbCat) else nil)
+                        vbClosed = ddCatClose(vbCat)
+                        if(!vbChanged || !vbSaved || !vbClosed
+                          then list("partial" "categoryMembershipChangeFailed")
+                          else progn(
+                            vbVerify = ddCatOpen(vbLib {q(category)} "r")
+                            if(!vbVerify
+                              then list("partial" "categoryMembershipVerificationFailed")
+                              else progn(
+                                vbMembers = ddCatGetCatMembers(vbVerify)
+                                vbPresent = if(member(list({q(cell)} "cell") vbMembers) t nil)
+                                vbClosed = ddCatClose(vbVerify)
+                                if(vbClosed && vbPresent == {expected}
+                                  then list("ok")
+                                  else list("partial" "categoryMembershipVerificationFailed")
+                                )
+                              )
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+""".strip()
+
+
+def _raise_category_error(
+    record: list[Any],
+    operation: str,
+    *,
+    library: str,
+    category: str = "",
+) -> None:
+    if record[0] == "ok":
+        return
+    if record[0] == "partial":
+        code = record[1] if len(record) > 1 else "unknownPartialFailure"
+        raise CategoryPartialSuccessError(
+            f"{operation} partially succeeded: {code}",
+            library=library,
+            category=category,
+        )
+    if record[0] != "error" or len(record) < 2 or not isinstance(record[1], str):
+        raise RuntimeError(f"{operation} returned malformed operation status")
+    code = record[1]
+    messages = {
+        "libraryNotFound": "library does not exist",
+        "categoryNotFound": "category does not exist",
+        "categoryExists": "category already exists",
+        "destinationCategoryExists": "destination category already exists",
+        "categoryContainsSubcategories": "category contains unsupported subcategories",
+        "cellNotFound": "cell does not exist",
+        "cellAlreadyInCategory": "cell is already in category",
+        "cellNotInCategory": "cell is not in category",
+    }
+    raise RuntimeError(f"{operation} failed: {messages.get(code, code)}")
+
+
+def _string_list(value: Any, operation: str) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+        raise RuntimeError(f"{operation} returned malformed names")
+    return value
+
+
+__all__ = [
+    "CategoryPartialSuccessError",
+    "add_cell_to_category",
+    "category_add_cell_skill",
+    "category_create_skill",
+    "category_delete_skill",
+    "category_list_cells_skill",
+    "category_list_skill",
+    "category_remove_cell_skill",
+    "category_rename_skill",
+    "create_category",
+    "delete_category",
+    "list_categories",
+    "list_category_cells",
+    "remove_cell_from_category",
+    "rename_category",
+]

--- a/src/virtuoso_bridge/virtuoso/library/management.py
+++ b/src/virtuoso_bridge/virtuoso/library/management.py
@@ -1,0 +1,348 @@
+"""Library management through supported Cadence SKILL APIs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from virtuoso_bridge.virtuoso.ops import q
+from virtuoso_bridge.virtuoso.response import response_fields
+from virtuoso_bridge.virtuoso.skill_output import (
+    is_single_complete_skill_list,
+    parse_sexpr,
+)
+
+
+@dataclass(frozen=True)
+class LibraryInfo:
+    """Verified Virtuoso library identity and technology binding."""
+
+    name: str
+    path: str
+    technology_library: str | None
+
+
+class LibraryPartialSuccessError(RuntimeError):
+    """Raised when a library was created but a requested binding failed."""
+
+    def __init__(self, message: str, library: LibraryInfo) -> None:
+        self.library = library
+        super().__init__(message)
+
+
+def library_list_skill() -> str:
+    """Build SKILL that lists libraries visible in the current session."""
+    return 'list("ok" mapcar(lambda((vbLib) vbLib~>name) ddGetLibList()))'
+
+
+def library_get_skill(name: str) -> str:
+    """Build SKILL that returns one library's path and technology binding."""
+    name = _require_text("name", name)
+    return (
+        "let((vbLib) "
+        f"vbLib = ddGetObj({q(name)}) "
+        "if(vbLib "
+        f"then list(\"ok\" {_library_info_expr('vbLib')}) "
+        'else list("error" "libraryNotFound")))'
+    )
+
+
+def library_create_skill(
+    name: str,
+    path: str,
+    *,
+    technology_library: str | None = None,
+) -> str:
+    """Build SKILL that creates a library and optionally binds technology."""
+    name = _require_text("name", name)
+    path = _require_text("path", path)
+    technology = (
+        "nil"
+        if technology_library is None
+        else q(_require_text("technology_library", technology_library))
+    )
+    info = _library_info_expr("vbLib")
+    return f"""
+let((vbLib vbTechName vbBound)
+  vbTechName = {technology}
+  if(ddGetObj({q(name)})
+    then list("error" "libraryExists")
+    else if(vbTechName && !ddGetObj(vbTechName)
+      then list("error" "technologyLibraryNotFound")
+      else progn(
+        vbLib = ddCreateLib({q(name)} {q(path)})
+        if(!vbLib
+          then list("error" "createFailed")
+          else if(!vbTechName
+            then list("ok" {info})
+            else progn(
+              vbBound = techBindTechFile(vbLib vbTechName)
+              if(vbBound && techGetTechLibName(vbLib) == vbTechName
+                then list("ok" {info})
+                else list("partial" "technologyBindingFailed" {info})
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+""".strip()
+
+
+def library_delete_skill(name: str) -> str:
+    """Build SKILL that deletes a library through ``ddDeleteObj``."""
+    name = _require_text("name", name)
+    return (
+        "let((vbLib vbDeleted) "
+        f"vbLib = ddGetObj({q(name)}) "
+        "if(!vbLib "
+        'then list("error" "libraryNotFound") '
+        "else progn("
+        "vbDeleted = ddDeleteObj(vbLib) "
+        f"if(vbDeleted && !ddGetObj({q(name)}) "
+        'then list("ok") '
+        'else list("error" "deleteFailed")))))'
+    )
+
+
+def library_rename_skill(name: str, new_name: str) -> str:
+    """Build SKILL that renames a library through ``ccpRename``."""
+    name = _require_text("name", name)
+    new_name = _require_text("new_name", new_name)
+    return f"""
+let((vbSource vbDestination vbRenamed vbLib)
+  if(!ddGetObj({q(name)})
+    then list("error" "libraryNotFound")
+    else if(ddGetObj({q(new_name)})
+      then list("error" "destinationExists")
+      else progn(
+        vbSource = gdmCreateSpec({q(name)} "" "" "" "CDBA")
+        vbDestination = gdmCreateSpec({q(new_name)} "" "" "" "CDBA")
+        if(!vbSource || !vbDestination
+          then list("error" "renameSpecFailed")
+          else progn(
+            vbRenamed = ccpRename(vbSource vbDestination nil)
+            vbLib = ddGetObj({q(new_name)})
+            if(vbRenamed && vbLib && !ddGetObj({q(name)})
+              then list("ok" {_library_info_expr("vbLib")})
+              else list("error" "renameFailed")
+            )
+          )
+        )
+      )
+    )
+  )
+)
+""".strip()
+
+
+def library_set_technology_skill(name: str, technology_library: str) -> str:
+    """Build SKILL that binds or changes a library's technology library."""
+    name = _require_text("name", name)
+    technology_library = _require_text("technology_library", technology_library)
+    return f"""
+let((vbLib vbTechLib vbCurrent vbChanged)
+  vbLib = ddGetObj({q(name)})
+  vbTechLib = ddGetObj({q(technology_library)})
+  if(!vbLib
+    then list("error" "libraryNotFound")
+    else if(!vbTechLib
+      then list("error" "technologyLibraryNotFound")
+      else progn(
+        vbCurrent = techGetTechLibName(vbLib)
+        vbChanged = if(vbCurrent
+          then techSetTechLibName(vbLib {q(technology_library)})
+          else techBindTechFile(vbLib {q(technology_library)})
+        )
+        if(vbChanged && techGetTechLibName(vbLib) == {q(technology_library)}
+          then list("ok" {_library_info_expr("vbLib")})
+          else list("error" "technologyBindingFailed")
+        )
+      )
+    )
+  )
+)
+""".strip()
+
+
+def list_libraries(client: Any, *, timeout: int = 30) -> list[str]:
+    """Return library names visible in the current Virtuoso session."""
+    record = _execute_record(client, library_list_skill(), timeout, "list libraries")
+    _raise_record_error(record, "list libraries")
+    values = record[1] if len(record) > 1 else []
+    if values is None:
+        return []
+    if not isinstance(values, list) or any(not isinstance(item, str) for item in values):
+        raise RuntimeError("list libraries returned malformed library names")
+    return values
+
+
+def get_library(client: Any, name: str, *, timeout: int = 30) -> LibraryInfo:
+    """Return verified information for one Virtuoso library."""
+    record = _execute_record(client, library_get_skill(name), timeout, f"get library {name}")
+    _raise_record_error(record, f"get library {name}", name=name)
+    return _library_info_from_record(_record_value(record, f"get library {name}"))
+
+
+def create_library(
+    client: Any,
+    name: str,
+    path: str,
+    *,
+    technology_library: str | None = None,
+    timeout: int = 60,
+) -> LibraryInfo:
+    """Create and verify a library, optionally binding existing technology."""
+    record = _execute_record(
+        client,
+        library_create_skill(name, path, technology_library=technology_library),
+        timeout,
+        f"create library {name}",
+    )
+    if record and record[0] == "partial":
+        info = _library_info_from_record(_record_value(record, f"create library {name}", 2))
+        raise LibraryPartialSuccessError(
+            f"library {name!r} was created but technology binding failed",
+            info,
+        )
+    _raise_record_error(record, f"create library {name}", name=name)
+    return _library_info_from_record(_record_value(record, f"create library {name}"))
+
+
+def delete_library(client: Any, name: str, *, timeout: int = 60) -> None:
+    """Delete and verify a library through Cadence's supported API."""
+    record = _execute_record(client, library_delete_skill(name), timeout, f"delete library {name}")
+    _raise_record_error(record, f"delete library {name}", name=name)
+
+
+def rename_library(
+    client: Any,
+    name: str,
+    new_name: str,
+    *,
+    timeout: int = 120,
+) -> LibraryInfo:
+    """Rename and verify a library without overwrite semantics."""
+    record = _execute_record(
+        client,
+        library_rename_skill(name, new_name),
+        timeout,
+        f"rename library {name} to {new_name}",
+    )
+    _raise_record_error(record, f"rename library {name} to {new_name}", name=name)
+    return _library_info_from_record(
+        _record_value(record, f"rename library {name} to {new_name}")
+    )
+
+
+def set_technology_library(
+    client: Any,
+    name: str,
+    technology_library: str,
+    *,
+    timeout: int = 60,
+) -> str:
+    """Bind or change a library's technology library and verify the result."""
+    record = _execute_record(
+        client,
+        library_set_technology_skill(name, technology_library),
+        timeout,
+        f"set technology library for {name}",
+    )
+    _raise_record_error(record, f"set technology library for {name}", name=name)
+    info = _library_info_from_record(
+        _record_value(record, f"set technology library for {name}")
+    )
+    if info.technology_library is None:
+        raise RuntimeError(f"set technology library for {name} returned no binding")
+    return info.technology_library
+
+
+def _execute_record(client: Any, skill: str, timeout: int, operation: str) -> list[Any]:
+    response = client.execute_skill(skill, timeout=timeout)
+    errors, status, output = response_fields(response)
+    if errors:
+        raise RuntimeError(f"{operation} SKILL error: {errors[0]}")
+    status_value = getattr(status, "value", status)
+    if status_value is not None and str(status_value).lower() not in {"success", "ok"}:
+        detail = output or f"status={status_value}"
+        raise RuntimeError(f"{operation} SKILL error: {detail}")
+    text = (output or "").strip()
+    if not text or not is_single_complete_skill_list(text):
+        raise RuntimeError(f"{operation} returned malformed structured output")
+    try:
+        parsed = parse_sexpr(text)
+    except ValueError as exc:
+        raise RuntimeError(f"{operation} returned malformed structured output") from exc
+    if not isinstance(parsed, list) or not parsed or not isinstance(parsed[0], str):
+        raise RuntimeError(f"{operation} returned malformed structured output")
+    return parsed
+
+
+def _raise_record_error(record: list[Any], operation: str, *, name: str = "") -> None:
+    if record[0] == "ok":
+        return
+    if record[0] != "error" or len(record) < 2 or not isinstance(record[1], str):
+        raise RuntimeError(f"{operation} returned malformed operation status")
+    code = record[1]
+    if code == "libraryNotFound":
+        raise RuntimeError(f"library {name!r} does not exist")
+    if code == "libraryExists":
+        raise RuntimeError(f"library {name!r} already exists")
+    if code == "destinationExists":
+        raise RuntimeError(f"{operation} failed: destination library already exists")
+    if code == "technologyLibraryNotFound":
+        raise RuntimeError(f"{operation} failed: technology library does not exist")
+    raise RuntimeError(f"{operation} failed: {code}")
+
+
+def _record_value(record: list[Any], operation: str, index: int = 1) -> Any:
+    if len(record) <= index:
+        raise RuntimeError(f"{operation} returned no result value")
+    return record[index]
+
+
+def _library_info_from_record(record: Any) -> LibraryInfo:
+    if (
+        not isinstance(record, list)
+        or len(record) != 4
+        or record[0] != "library"
+        or not isinstance(record[1], str)
+        or not isinstance(record[2], str)
+        or (record[3] is not None and not isinstance(record[3], str))
+    ):
+        raise RuntimeError("library operation returned malformed library information")
+    return LibraryInfo(record[1], record[2], record[3])
+
+
+def _library_info_expr(variable: str) -> str:
+    return (
+        f'list("library" {variable}~>name {variable}~>readPath '
+        f"techGetTechLibName({variable}))"
+    )
+
+
+def _require_text(field: str, value: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field} must be a non-empty string")
+    return value
+
+
+__all__ = [
+    "LibraryInfo",
+    "LibraryPartialSuccessError",
+    "create_library",
+    "delete_library",
+    "get_library",
+    "library_create_skill",
+    "library_delete_skill",
+    "library_get_skill",
+    "library_list_skill",
+    "library_rename_skill",
+    "library_set_technology_skill",
+    "list_libraries",
+    "rename_library",
+    "set_technology_library",
+]

--- a/tests/test_library_category.py
+++ b/tests/test_library_category.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import pytest
+
+from virtuoso_bridge.models import ExecutionStatus, VirtuosoResult
+from virtuoso_bridge.virtuoso.library import LibraryOps
+from virtuoso_bridge.virtuoso.library.category import (
+    CategoryPartialSuccessError,
+    add_cell_to_category,
+    category_add_cell_skill,
+    category_create_skill,
+    category_delete_skill,
+    category_list_cells_skill,
+    category_list_skill,
+    category_remove_cell_skill,
+    category_rename_skill,
+    create_category,
+    delete_category,
+    list_categories,
+    list_category_cells,
+    remove_cell_from_category,
+    rename_category,
+)
+
+
+class _Client:
+    def __init__(self, output: str, *, errors=None) -> None:
+        self.output = output
+        self.errors = errors or []
+        self.skill: str | None = None
+        self.timeout: int | None = None
+
+    def execute_skill(self, skill: str, *, timeout: int):
+        self.skill = skill
+        self.timeout = timeout
+        return VirtuosoResult(
+            status=(ExecutionStatus.ERROR if self.errors else ExecutionStatus.SUCCESS),
+            output=self.output,
+            errors=self.errors,
+        )
+
+
+def test_category_list_filters_stale_entries_by_opening_each_category() -> None:
+    skill = category_list_skill("demoLib")
+
+    assert "ddCatGetLibCats(vbLib)" in skill
+    assert 'ddCatOpen(vbLib vbName "r")' in skill
+    assert "when(vbCat" in skill
+    assert "ddCatClose(vbCat)" in skill
+    assert "Everything" not in skill
+    assert "Uncategorized" not in skill
+
+
+def test_category_create_keeps_empty_category_and_verifies_it() -> None:
+    skill = category_create_skill("demoLib", "ADC")
+
+    assert 'ddCatOpenEx(vbLib "ADC" "w" 1)' in skill
+    assert "vbSaved = ddCatSave(vbCat)" in skill
+    assert 'vbVerify = ddCatOpen(vbLib "ADC" "r")' in skill
+    assert "ddCatAddItem" not in skill
+
+
+def test_category_delete_uses_ddcat_remove_and_never_deletes_cells() -> None:
+    skill = category_delete_skill("demoLib", "ADC")
+
+    assert 'ddCatOpen(vbLib "ADC" "r")' in skill
+    assert 'ddCatOpen(vbLib "ADC" "a")' in skill
+    assert "vbRemoved = ddCatRemove(vbCat)" in skill
+    assert 'vbVerify = ddCatOpen(vbLib "ADC" "r")' in skill
+    assert "ddDeleteObj" not in skill
+    assert "deleteFile" not in skill
+    assert "system(" not in skill
+
+
+def test_category_list_cells_filters_member_type() -> None:
+    skill = category_list_cells_skill("demoLib", "ADC")
+
+    assert "ddCatGetCatMembers(vbCat)" in skill
+    assert 'cadr(vbMember) == "cell"' in skill
+    assert "reverse(vbCells)" in skill
+
+
+def test_category_add_cell_uses_ddcat_add_save_close_and_verification() -> None:
+    skill = category_add_cell_skill("demoLib", "ADC", "comparator")
+
+    assert 'member("comparator" vbLib~>cells~>name)' in skill
+    assert 'ddGetObj("demoLib" "comparator")' not in skill
+    assert 'ddCatOpen(vbLib "ADC" "r")' in skill
+    assert 'ddCatOpen(vbLib "ADC" "a")' in skill
+    assert 'ddCatAddItem(vbCat "comparator" "cell")' in skill
+    assert "ddCatSave(vbCat)" in skill
+    assert 'member(list("comparator" "cell") vbMembers)' in skill
+
+
+def test_category_remove_cell_uses_ddcat_subitem_and_verification() -> None:
+    skill = category_remove_cell_skill("demoLib", "ADC", "comparator")
+
+    assert 'ddCatSubItem(vbCat "comparator")' in skill
+    assert 'ddCatOpen(vbLib "ADC" "r")' in skill
+    assert "ddCatSave(vbCat)" in skill
+    assert 'member(list("comparator" "cell") vbMembers)' in skill
+    assert "ddDeleteObj" not in skill
+
+
+def test_category_rename_preserves_cells_without_merge_or_overwrite() -> None:
+    skill = category_rename_skill("demoLib", "ADC", "Comparators")
+
+    assert 'ddCatOpen(vbLib "ADC" "r")' in skill
+    assert 'ddCatOpen(vbLib "Comparators" "r")' in skill
+    assert 'ddCatOpenEx(vbLib "Comparators" "w" 1)' in skill
+    assert "ddCatGetCatMembers(vbSource)" in skill
+    assert "ddCatAddItem(" in skill
+    assert "vbDestination car(vbMember) cadr(vbMember))" in skill
+    assert "ddCatRemove(vbSource)" in skill
+    assert 'categoryContainsSubcategories' in skill
+    assert "ccpRename" not in skill
+
+
+@pytest.mark.parametrize(
+    ("builder", "args", "field"),
+    [
+        (category_list_skill, ("",), "library"),
+        (category_create_skill, ("demoLib", ""), "category"),
+        (category_delete_skill, ("demoLib", " "), "category"),
+        (category_list_cells_skill, ("", "ADC"), "library"),
+        (category_add_cell_skill, ("demoLib", "ADC", ""), "cell"),
+        (category_rename_skill, ("demoLib", "ADC", ""), "new_name"),
+    ],
+)
+def test_category_builders_reject_empty_required_values(builder, args, field) -> None:
+    with pytest.raises(ValueError, match=field):
+        builder(*args)
+
+
+def test_list_categories_returns_only_verified_names() -> None:
+    client = _Client('("ok" ("ADC" "DAC"))')
+
+    result = list_categories(client, "demoLib", timeout=19)
+
+    assert result == ["ADC", "DAC"]
+    assert client.timeout == 19
+
+
+def test_create_category_returns_verified_name() -> None:
+    client = _Client('("ok" "ADC")')
+
+    assert create_category(client, "demoLib", "ADC") == "ADC"
+
+
+def test_delete_category_returns_none() -> None:
+    client = _Client('("ok")')
+
+    assert delete_category(client, "demoLib", "ADC") is None
+
+
+def test_list_category_cells_returns_cell_names() -> None:
+    client = _Client('("ok" ("comparator" "strongarm"))')
+
+    result = list_category_cells(client, "demoLib", "ADC")
+
+    assert result == ["comparator", "strongarm"]
+
+
+def test_add_and_remove_cell_return_none() -> None:
+    assert add_cell_to_category(_Client('("ok")'), "demoLib", "ADC", "comparator") is None
+    assert (
+        remove_cell_from_category(
+            _Client('("ok")'),
+            "demoLib",
+            "ADC",
+            "comparator",
+        )
+        is None
+    )
+
+
+def test_rename_category_returns_destination_name() -> None:
+    client = _Client('("ok" "Comparators")')
+
+    assert rename_category(client, "demoLib", "ADC", "Comparators") == "Comparators"
+
+
+@pytest.mark.parametrize(
+    ("code", "message"),
+    [
+        ("libraryNotFound", "library does not exist"),
+        ("categoryNotFound", "category does not exist"),
+        ("categoryExists", "category already exists"),
+        ("destinationCategoryExists", "destination category already exists"),
+        ("categoryContainsSubcategories", "unsupported subcategories"),
+        ("cellNotFound", "cell does not exist"),
+        ("cellAlreadyInCategory", "already in category"),
+        ("cellNotInCategory", "not in category"),
+    ],
+)
+def test_category_operations_raise_explicit_errors(code: str, message: str) -> None:
+    client = _Client(f'("error" "{code}")')
+
+    with pytest.raises(RuntimeError, match=message):
+        list_category_cells(client, "demoLib", "ADC")
+
+
+def test_category_partial_success_error_preserves_context() -> None:
+    client = _Client('("partial" "categoryRenameSourceRemovalFailed")')
+
+    with pytest.raises(CategoryPartialSuccessError) as exc_info:
+        rename_category(client, "demoLib", "ADC", "Comparators")
+
+    assert exc_info.value.library == "demoLib"
+    assert exc_info.value.category == "ADC"
+    assert "partially succeeded" in str(exc_info.value)
+
+
+def test_category_operations_raise_transport_errors() -> None:
+    client = _Client("", errors=["category lock failed"])
+
+    with pytest.raises(RuntimeError, match="SKILL error: category lock failed"):
+        list_categories(client, "demoLib")
+
+
+def test_library_ops_exposes_category_methods() -> None:
+    client = _Client('("ok" ("ADC"))')
+    ops = LibraryOps(client)  # type: ignore[arg-type]
+
+    assert ops.list_categories("demoLib") == ["ADC"]
+    assert client.skill is not None
+    assert "ddCatGetLibCats" in client.skill

--- a/tests/test_library_management.py
+++ b/tests/test_library_management.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import pytest
+
+from virtuoso_bridge import VirtuosoClient
+from virtuoso_bridge.models import ExecutionStatus, VirtuosoResult
+from virtuoso_bridge.virtuoso.library import LibraryInfo, LibraryOps
+from virtuoso_bridge.virtuoso.library.management import (
+    LibraryPartialSuccessError,
+    create_library,
+    delete_library,
+    get_library,
+    library_create_skill,
+    library_delete_skill,
+    library_get_skill,
+    library_list_skill,
+    library_rename_skill,
+    library_set_technology_skill,
+    list_libraries,
+    rename_library,
+    set_technology_library,
+)
+
+
+class _Client:
+    def __init__(self, output: str, *, status: object = None, errors=None) -> None:
+        self.output = output
+        self.status = status
+        self.errors = errors or []
+        self.skill: str | None = None
+        self.timeout: int | None = None
+
+    def execute_skill(self, skill: str, *, timeout: int):
+        self.skill = skill
+        self.timeout = timeout
+        return VirtuosoResult(
+            status=self.status or ExecutionStatus.SUCCESS,
+            output=self.output,
+            errors=self.errors,
+        )
+
+
+def test_virtuoso_client_attaches_library_ops() -> None:
+    client = VirtuosoClient.local()
+
+    assert isinstance(client.library, LibraryOps)
+
+
+def test_library_list_skill_uses_visible_library_database() -> None:
+    skill = library_list_skill()
+
+    assert "ddGetLibList()" in skill
+    assert "ddUpdateLibList" not in skill
+    assert "getDirFiles" not in skill
+
+
+def test_library_get_skill_reads_path_and_technology_binding() -> None:
+    skill = library_get_skill('demo"lib')
+
+    assert 'ddGetObj("demo\\"lib")' in skill
+    assert "vbLib~>readPath" in skill
+    assert "techGetTechLibName(vbLib)" in skill
+    assert 'list("error" "libraryNotFound")' in skill
+
+
+def test_library_create_skill_requires_explicit_path_and_uses_supported_apis() -> None:
+    skill = library_create_skill(
+        "demoLib",
+        "/tmp/demo lib",
+        technology_library="gpdk045",
+    )
+
+    assert 'ddCreateLib("demoLib" "/tmp/demo lib")' in skill
+    assert 'vbTechName = "gpdk045"' in skill
+    assert "techBindTechFile(vbLib vbTechName)" in skill
+    assert "techGetTechLibName(vbLib) == vbTechName" in skill
+    assert 'list("partial" "technologyBindingFailed"' in skill
+    assert "system(" not in skill
+    assert "renameFile(" not in skill
+
+
+def test_library_create_skill_without_technology_does_not_invent_binding() -> None:
+    skill = library_create_skill("demoLib", "/tmp/demoLib")
+
+    assert "vbTechName = nil" in skill
+    assert "cdsDefTechLib" not in skill
+
+
+def test_library_delete_skill_uses_dd_delete_obj_without_force_fallback() -> None:
+    skill = library_delete_skill("demoLib")
+
+    assert "vbDeleted = ddDeleteObj(vbLib)" in skill
+    assert '!ddGetObj("demoLib")' in skill
+    assert "deleteDir" not in skill
+    assert "system(" not in skill
+
+
+def test_library_rename_skill_uses_ccp_rename_without_overwrite() -> None:
+    skill = library_rename_skill("demoLib", "renamedLib")
+
+    assert 'gdmCreateSpec("demoLib" "" "" "" "CDBA")' in skill
+    assert 'gdmCreateSpec("renamedLib" "" "" "" "CDBA")' in skill
+    assert "ccpRename(vbSource vbDestination nil)" in skill
+    assert 'ddGetObj("renamedLib")' in skill
+    assert '!ddGetObj("demoLib")' in skill
+    assert "renameFile(" not in skill
+
+
+def test_library_set_technology_uses_bind_for_new_and_set_for_existing() -> None:
+    skill = library_set_technology_skill("demoLib", "gpdk045")
+
+    assert "vbCurrent = techGetTechLibName(vbLib)" in skill
+    assert 'techSetTechLibName(vbLib "gpdk045")' in skill
+    assert 'techBindTechFile(vbLib "gpdk045")' in skill
+    assert 'techGetTechLibName(vbLib) == "gpdk045"' in skill
+
+
+@pytest.mark.parametrize(
+    ("builder", "args", "field"),
+    [
+        (library_get_skill, ("",), "name"),
+        (library_create_skill, ("demo", ""), "path"),
+        (library_delete_skill, (" ",), "name"),
+        (library_rename_skill, ("demo", ""), "new_name"),
+        (library_set_technology_skill, ("demo", ""), "technology_library"),
+    ],
+)
+def test_library_skill_builders_reject_empty_required_values(builder, args, field) -> None:
+    with pytest.raises(ValueError, match=field):
+        builder(*args)
+
+
+def test_list_libraries_returns_names_and_forwards_timeout() -> None:
+    client = _Client('("ok" ("analogLib" "basic" "demoLib"))')
+
+    result = list_libraries(client, timeout=17)
+
+    assert result == ["analogLib", "basic", "demoLib"]
+    assert client.timeout == 17
+
+
+def test_get_library_returns_structured_info() -> None:
+    client = _Client('("ok" ("library" "demoLib" "/work/demoLib" "gpdk045"))')
+
+    info = get_library(client, "demoLib")
+
+    assert info == LibraryInfo("demoLib", "/work/demoLib", "gpdk045")
+
+
+def test_get_library_preserves_unbound_technology_as_none() -> None:
+    client = _Client('("ok" ("library" "demoLib" "/work/demoLib" nil))')
+
+    info = get_library(client, "demoLib")
+
+    assert info.technology_library is None
+
+
+def test_create_library_returns_verified_info() -> None:
+    client = _Client('("ok" ("library" "demoLib" "/tmp/demoLib" "gpdk045"))')
+
+    info = create_library(
+        client,
+        "demoLib",
+        "/tmp/demoLib",
+        technology_library="gpdk045",
+    )
+
+    assert info == LibraryInfo("demoLib", "/tmp/demoLib", "gpdk045")
+    assert client.skill is not None
+    assert 'ddCreateLib("demoLib" "/tmp/demoLib")' in client.skill
+
+
+def test_create_library_reports_partial_technology_binding() -> None:
+    client = _Client(
+        '("partial" "technologyBindingFailed" '
+        '("library" "demoLib" "/tmp/demoLib" nil))'
+    )
+
+    with pytest.raises(LibraryPartialSuccessError) as exc_info:
+        create_library(
+            client,
+            "demoLib",
+            "/tmp/demoLib",
+            technology_library="gpdk045",
+        )
+
+    assert exc_info.value.library == LibraryInfo("demoLib", "/tmp/demoLib", None)
+    assert "was created" in str(exc_info.value)
+
+
+def test_delete_library_returns_none_on_verified_success() -> None:
+    client = _Client('("ok")')
+
+    assert delete_library(client, "demoLib") is None
+
+
+def test_rename_library_returns_destination_info() -> None:
+    client = _Client('("ok" ("library" "newLib" "/work/newLib" "gpdk045"))')
+
+    info = rename_library(client, "oldLib", "newLib")
+
+    assert info.name == "newLib"
+    assert info.path == "/work/newLib"
+
+
+def test_set_technology_library_returns_verified_name() -> None:
+    client = _Client('("ok" ("library" "demoLib" "/work/demoLib" "gpdk045"))')
+
+    result = set_technology_library(client, "demoLib", "gpdk045")
+
+    assert result == "gpdk045"
+
+
+@pytest.mark.parametrize(
+    ("output", "message"),
+    [
+        ('("error" "libraryNotFound")', "does not exist"),
+        ('("error" "libraryExists")', "already exists"),
+        ('("error" "destinationExists")', "destination library already exists"),
+        ('("error" "technologyLibraryNotFound")', "technology library does not exist"),
+        ('("error" "renameFailed")', "renameFailed"),
+    ],
+)
+def test_library_operations_raise_explicit_operation_errors(output: str, message: str) -> None:
+    client = _Client(output)
+
+    with pytest.raises(RuntimeError, match=message):
+        get_library(client, "demoLib")
+
+
+@pytest.mark.parametrize("output", ["", "t", '("ok"', '("ok") trailing'])
+def test_library_operations_reject_malformed_structured_output(output: str) -> None:
+    with pytest.raises(RuntimeError, match="malformed structured output"):
+        list_libraries(_Client(output))
+
+
+def test_library_operations_raise_transport_errors() -> None:
+    client = _Client("", status=ExecutionStatus.ERROR, errors=["daemon failed"])
+
+    with pytest.raises(RuntimeError, match="SKILL error: daemon failed"):
+        list_libraries(client)
+
+
+def test_library_ops_methods_delegate_to_owner() -> None:
+    client = _Client('("ok" ("library" "demoLib" "/work/demoLib" "gpdk045"))')
+    ops = LibraryOps(client)  # type: ignore[arg-type]
+
+    assert ops.get_technology_library("demoLib") == "gpdk045"
+    assert client.skill is not None
+    assert 'ddGetObj("demoLib")' in client.skill


### PR DESCRIPTION
## Summary

- add `client.library` APIs for listing, inspecting, creating, renaming, and deleting Virtuoso libraries
- support optional technology binding at creation time and verified technology-library rebinding
- add manual top-level category CRUD and cell membership management
- document the Python API and provide a runnable example

## Design

The implementation uses supported Cadence SKILL APIs and verifies the resulting Virtuoso state after mutations. Library delete and rename do not expose force, overwrite, recursive filesystem operations, or filesystem fallbacks. Category operations do not edit `.Cat` or `.TopCat` files directly, and deleting a category never deletes its member cells.

## Validation

- focused unit tests: 62 passed
- remote Virtuoso integration flow: 9 steps passed, covering library creation, technology binding and rebinding, category CRUD and membership, library rename, and library deletion
- generated SKILL expressions: balanced parentheses
- `git diff --check`: passed
- full-suite failures match the upstream `main` baseline exactly (31 existing failures)
