### PR TITLE
Fix Spectre result handling and OP parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,19 @@ Virtuoso SKILL execution and Spectre simulation are independent. You can run
 Spectre without the SKILL bridge, and you can use the SKILL bridge without
 Spectre.
 
+### Python environment selection
+
+Python entry points discover the nearest parent `.env` containing
+`VB_REMOTE_HOST` or `VB_LOCAL_PORT`, then load it with `override=True`; this can
+change a long-lived process from local to remote mode. Pin the intended file
+before constructing a client when embedding the bridge:
+
+```python
+from virtuoso_bridge.env import set_runtime_env_file
+
+set_runtime_env_file("/path/to/virtuoso-bridge.env")
+```
+
 ## Quick Start
 
 ```bash

--- a/src/virtuoso_bridge/spectre/parsers.py
+++ b/src/virtuoso_bridge/spectre/parsers.py
@@ -478,6 +478,12 @@ def _parse_psf_non_swept_data(
     """Parse non-swept PSF ASCII data (e.g. operating-point info files)."""
     data: dict[str, Any] = {}
 
+    struct_fields = _parse_psf_struct_types(
+        lines,
+        sections.get("TYPE", 0) + 1,
+        sections.get("VALUE", n),
+    )
+
     value_start = sections["VALUE"] + 1
     value_end = sections.get("END", n)
 
@@ -485,6 +491,23 @@ def _parse_psf_non_swept_data(
         stripped = lines[i].strip()
         if not stripped or stripped == "END":
             break
+
+        # Per-instance operating-point values use a type-defined STRUCT:
+        #   "M0" "mos" ( <gm> <vth> ... ) PROP(...)
+        # Keep the public result flat so callers can use ``M0:gm`` directly.
+        m_struct = re.match(r'^"([^"]+)"\s+"([^"]+)"\s+\($', stripped)
+        if m_struct and m_struct.group(2) in struct_fields:
+            instance, type_name = m_struct.groups()
+            values: list[Any] = []
+            for j in range(i + 1, value_end):
+                value_line = lines[j].strip()
+                if value_line == ")" or value_line.startswith(") PROP("):
+                    break
+                if value_line:
+                    values.append(_parse_psf_scalar(value_line))
+            for field, value in zip(struct_fields[type_name], values):
+                data[f"{instance}:{field}"] = value
+            continue
 
         # DC OP lines: "M0:gm" "S" 1.906e-04 PROP( ... )
         m_typed = re.match(
@@ -518,3 +541,43 @@ def _parse_psf_non_swept_data(
                 data[name] = raw_value.strip('"')
 
     return data
+
+
+def _parse_psf_struct_types(lines: list[str], start: int, end: int) -> dict[str, list[str]]:
+    """Return ordered member names for each STRUCT declared in a TYPE section."""
+    structs: dict[str, list[str]] = {}
+    current_type: str | None = None
+    depth = 0
+
+    for line in lines[start:end]:
+        stripped = line.strip()
+        if current_type is None:
+            match = re.match(r'^"([^"]+)"\s+STRUCT\($', stripped)
+            if match:
+                current_type = match.group(1)
+                structs[current_type] = []
+                depth = 1
+            continue
+
+        # Members appear one level inside STRUCT; PROP metadata is deeper.
+        member = re.match(r'^"([^"]+)"\s+[A-Z]+(?:\s+[A-Z]+)?(?:\s+PROP\()?$', stripped)
+        if depth == 1 and member:
+            structs[current_type].append(member.group(1))
+
+        depth += stripped.count("(") - stripped.count(")")
+        if depth <= 0:
+            current_type = None
+            depth = 0
+
+    return structs
+
+
+def _parse_psf_scalar(raw_value: str) -> Any:
+    """Parse one scalar from a STRUCT value while preserving non-numeric fields."""
+    value = raw_value.strip()
+    if len(value) >= 2 and value[0] == value[-1] == '"':
+        return value[1:-1]
+    try:
+        return float(value)
+    except ValueError:
+        return value

--- a/src/virtuoso_bridge/spectre/runner.py
+++ b/src/virtuoso_bridge/spectre/runner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.resources
 import logging
 import os
+import re
 import shlex
 import shutil
 import subprocess
@@ -122,31 +123,43 @@ def _build_spectre_argv(
 def _run_spectre_local(
     *,
     netlist: Path,
+    params: dict | None = None,
     spectre_cmd: str = "spectre",
     spectre_args: list[str] | tuple[str, ...] | None = None,
     timeout: int = 600,
     work_dir: Path | None = None,
     output_format: str | None = "psfascii",
+    cadence_cshrc: str | None = None,
 ) -> _SpectreRunResult:
     """Run Spectre as a local subprocess."""
+    params = params or {}
     cwd = Path(work_dir) if work_dir is not None else artifact_dir("spectre", netlist.stem)
     cwd.mkdir(parents=True, exist_ok=True)
+    for include_file in params.get("include_files", []):
+        include_path = Path(include_file).resolve()
+        if include_path.exists():
+            destination = cwd / include_path.name
+            if include_path != destination.resolve():
+                shutil.copy2(include_path, destination)
     raw_dir = str((Path(cwd) / f"{netlist.stem}.raw").resolve())
     log_file = str((Path(cwd) / f"{netlist.stem}.log").resolve())
     cmd = _build_spectre_argv(
         spectre_cmd=spectre_cmd,
-        spectre_args=spectre_args,
+        spectre_args=list(spectre_args or []) + list(params.get("spectre_args", [])),
         output_format=output_format,
         netlist_path=str(netlist),
         raw_dir=raw_dir,
         log_file=log_file,
     )
     spectre_command = " ".join(shlex.quote(part) for part in cmd)
+    command = cmd
+    if cadence_cshrc:
+        command = ["csh", "-fc", f"source {shlex.quote(cadence_cshrc)}; exec {spectre_command}"]
     logger.debug("Running Spectre locally: %s (cwd=%s)", spectre_command, cwd)
 
     try:
         proc = subprocess.run(
-            cmd,
+            command,
             capture_output=True,
             text=True,
             timeout=timeout,
@@ -379,7 +392,7 @@ def _build_simulation_result(
         errors.append("netlist read error (missing include or syntax)")
     elif "license" in combined_lower and ("error" in combined_lower or "denied" in combined_lower):
         errors.append("license error")
-    elif "convergence" in combined_lower:
+    elif _has_convergence_failure(combined):
         errors.append("convergence failure")
     elif "no such file" in combined_lower or "cannot open" in combined_lower:
         errors.append("file not found")
@@ -409,10 +422,19 @@ def _build_simulation_result(
         else []
     )
 
-    if run_result.returncode != 0:
+    has_execution_failure = (
+        has_readin_error
+        or _has_convergence_failure(combined)
+        or _has_fatal_spectre_error(combined)
+    )
+    if run_result.returncode != 0 or has_execution_failure:
         status = ExecutionStatus.PARTIAL if output_files else ExecutionStatus.FAILURE
         if not errors:
-            errors.append(f"exit code {run_result.returncode}")
+            errors.append(
+                f"exit code {run_result.returncode}"
+                if run_result.returncode != 0
+                else "Spectre reported a fatal error"
+            )
     else:
         status = ExecutionStatus.SUCCESS
 
@@ -442,6 +464,27 @@ def _build_simulation_result(
         errors=errors,
         warnings=warnings,
         metadata=metadata,
+    )
+
+
+def _has_convergence_failure(output: str) -> bool:
+    """Match explicit convergence failures, not normal convergence chatter."""
+    lower = output.lower()
+    return (
+        "spcrtrf-15044" in lower
+        or "failed to converge" in lower
+        or "convergence failed" in lower
+        or "convergence failure" in lower
+    )
+
+
+def _has_fatal_spectre_error(output: str) -> bool:
+    """Identify fatal Spectre output even when a wrapper returns zero."""
+    lower = output.lower()
+    return (
+        "spectre terminated prematurely due to fatal error" in lower
+        or "fatal error" in lower
+        or bool(re.search(r"(?m)^\s*error\s*\(", output, re.IGNORECASE))
     )
 
 # ---------------------------------------------------------------------------
@@ -589,9 +632,10 @@ class SpectreSimulator:
 
     # -- public API ---------------------------------------------------------
 
-    def run_simulation(self, netlist: Path, params: dict) -> SimulationResult:
+    def run_simulation(self, netlist: Path, params: dict | None = None) -> SimulationResult:
         """Run a Spectre simulation on *netlist* synchronously."""
         netlist = Path(netlist).resolve()
+        params = params or {}
         if not netlist.exists():
             return SimulationResult(
                 status=ExecutionStatus.ERROR,
@@ -599,7 +643,7 @@ class SpectreSimulator:
             )
         if self._remote_host:
             return self._run_remote(netlist, params)
-        return self._run_local(netlist)
+        return self._run_local(netlist, params)
 
     # -- parallel simulation API ---------------------------------------------
 
@@ -803,14 +847,21 @@ class SpectreSimulator:
 
     # -- private helpers ----------------------------------------------------
 
-    def _run_local(self, netlist: Path) -> SimulationResult:
+    def _run_local(self, netlist: Path, params: dict) -> SimulationResult:
+        suffix = f"_{self._profile}" if self._profile else ""
+        cadence_cshrc = (
+            os.environ.get(f"VB_CADENCE_CSHRC{suffix}", "").strip()
+            or os.environ.get("VB_CADENCE_CSHRC", "").strip()
+        )
         run_result = _run_spectre_local(
             netlist=netlist,
+            params=params,
             spectre_cmd=self._spectre_cmd,
             spectre_args=self._spectre_args,
             timeout=self._timeout,
             work_dir=self._work_dir,
             output_format=self._output_format,
+            cadence_cshrc=cadence_cshrc or None,
         )
         if not run_result.success:
             return SimulationResult(

--- a/tests/test_spectre_parsers.py
+++ b/tests/test_spectre_parsers.py
@@ -24,6 +24,7 @@ import pytest
 
 from virtuoso_bridge.spectre.parsers import (
     _parse_psf_swept_data,
+    parse_spectre_psf_ascii,
     parse_sweep_psf_directory,
 )
 from virtuoso_bridge.spectre.runner import _build_simulation_result
@@ -200,6 +201,48 @@ def test_sweep_dir_no_layout_returns_empty(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# parse_spectre_psf_ascii — STRUCT operating-point values
+# ---------------------------------------------------------------------------
+
+def test_non_swept_struct_values_are_flattened_by_instance_and_member(tmp_path):
+    """Operating-point info stores device scalars as ordered STRUCT members."""
+    psf_file = tmp_path / "finalTimeOP.info"
+    psf_file.write_text("""\
+HEADER
+"analysis type" "info"
+TYPE
+"nmos" STRUCT(
+"gm" FLOAT DOUBLE PROP(
+"units" "S"
+)
+"vth" FLOAT DOUBLE PROP(
+"units" "V"
+)
+"region" STRING PROP(
+)
+) PROP(
+"key" "inst"
+)
+VALUE
+"M0" "nmos" (
+1.906e-04
+4.500e-01
+"saturation"
+) PROP(
+"model" "nmos"
+)
+END
+""", encoding="utf-8")
+
+    result = parse_spectre_psf_ascii(psf_file)
+
+    assert result.ok
+    assert result.data["M0:gm"] == pytest.approx(1.906e-04)
+    assert result.data["M0:vth"] == pytest.approx(0.45)
+    assert result.data["M0:region"] == "saturation"
+
+
+# ---------------------------------------------------------------------------
 # _build_simulation_result — runner.py wiring
 # ---------------------------------------------------------------------------
 
@@ -254,3 +297,40 @@ def test_build_result_actual_readin_error_still_flagged(tmp_path):
     )
     err_text = " ".join(result.errors).lower()
     assert "netlist read error" in err_text
+
+
+def test_build_result_ignores_successful_convergence_chatter(tmp_path):
+    run = _fake_run_result(
+        tmp_path,
+        stdout="No convergence difficulties encountered.\nsimulation completed.\n",
+    )
+
+    result = _build_simulation_result(run, output_format="psfascii")
+
+    assert result.ok
+    assert "convergence failure" not in result.errors
+
+
+def test_build_result_marks_fatal_output_as_failure_even_with_zero_exit(tmp_path):
+    run = _fake_run_result(
+        tmp_path,
+        stdout="ERROR (SFE-23): instance M0 is invalid\n",
+    )
+
+    result = _build_simulation_result(run, output_format="psfascii")
+
+    assert not result.ok
+    assert result.status.value == "failure"
+    assert result.errors
+
+
+def test_build_result_marks_pss_convergence_failure_with_zero_exit(tmp_path):
+    run = _fake_run_result(
+        tmp_path,
+        stdout="SPCRTRF-15044: PSS analysis failed to converge\n",
+    )
+
+    result = _build_simulation_result(run, output_format="psfascii")
+
+    assert not result.ok
+    assert "convergence failure" in result.errors

--- a/tests/test_spectre_runtime_paths.py
+++ b/tests/test_spectre_runtime_paths.py
@@ -26,3 +26,48 @@ def test_local_spectre_defaults_to_artifact_dir(monkeypatch, tmp_path) -> None:
     assert result.output_dir == expected_cwd
     assert expected_cwd.is_dir()
     assert not (netlist_dir / "tb_amp.raw").exists()
+
+
+def test_local_spectre_honors_per_run_args_and_stages_includes(monkeypatch, tmp_path) -> None:
+    netlist = tmp_path / "tb_amp.scs"
+    netlist.write_text('include "model.va"\n', encoding="utf-8")
+    include = tmp_path / "model.va"
+    include.write_text("module model; endmodule\n", encoding="utf-8")
+    work_dir = tmp_path / "run"
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_run)
+
+    runner._run_spectre_local(
+        netlist=netlist,
+        params={"include_files": [include], "spectre_args": ["+aps"]},
+        work_dir=work_dir,
+    )
+
+    assert "+aps" in calls[0][0]
+    assert (work_dir / "model.va").read_text(encoding="utf-8") == "module model; endmodule\n"
+
+
+def test_local_spectre_sources_configured_cadence_environment(monkeypatch, tmp_path) -> None:
+    netlist = tmp_path / "tb_amp.scs"
+    netlist.write_text("simulator lang=spectre\n", encoding="utf-8")
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_run)
+
+    runner._run_spectre_local(
+        netlist=netlist,
+        work_dir=tmp_path / "run",
+        cadence_cshrc="/eda/cadence.cshrc",
+    )
+
+    assert calls[0][0][:2] == ["csh", "-fc"]
+    assert "source /eda/cadence.cshrc" in calls[0][0][2]


### PR DESCRIPTION
Fixes #132

- flatten PSF ASCII STRUCT operating-point values into instance/member keys
- classify only explicit convergence failures and surface fatal zero-exit output as failed results
- align local mode with remote per-run include/argument handling and Cadence cshrc setup
- document Python .env selection behavior

Tests: `python -m pytest` (735 passed, 1 skipped)