### PR TITLE
feat: support session-scoped corner netlist export

### DIFF
--- a/skills/virtuoso/references/maestro-python-api.md
+++ b/skills/virtuoso/references/maestro-python-api.md
@@ -350,12 +350,17 @@ history, status = client.maestro.run_and_wait(session=session, timeout=600)
 
 | Python | SKILL | Description |
 |--------|-------|-------------|
-| `client.maestro.create_netlist_for_corner(test, corner, output_dir)` | `maeCreateNetlistForCorner` | Export netlist for one corner |
+| `client.maestro.create_netlist_for_corner(test, corner, output_dir, *, session="")` | `maeCreateNetlistForCorner` | Export netlist for one corner, optionally from an explicit session |
 | `client.maestro.export_output_view(filepath, *, view="Detail")` | `maeExportOutputView` | Export results to CSV |
 | `client.maestro.write_script(filepath)` | `maeWriteScript` | Export setup as SKILL script |
 
 ```python
-client.maestro.create_netlist_for_corner("TRAN2", "myCorner_2", "./myNetlistDir")
+client.maestro.create_netlist_for_corner(
+    "TRAN2",
+    "myCorner_2",
+    "./myNetlistDir",
+    session=session,
+)
 client.maestro.export_output_view("./results.csv")
 client.maestro.write_script("mySetupScript.il")
 ```

--- a/src/virtuoso_bridge/virtuoso/maestro/writer.py
+++ b/src/virtuoso_bridge/virtuoso/maestro/writer.py
@@ -548,10 +548,15 @@ procedure(_vb_sim_done_{nonce}(session runID)
 # ---------------------------------------------------------------------------
 
 def create_netlist_for_corner(client: VirtuosoClient, test: str,
-                              corner: str, output_dir: str) -> str:
-    """maeCreateNetlistForCorner — export standalone netlist for a corner."""
+                              corner: str, output_dir: str, *,
+                              session: str = "") -> str:
+    """maeCreateNetlistForCorner — export standalone netlist for a corner.
+
+    If *session* is omitted, Cadence uses the current Maestro session.
+    """
+    s = f' ?session "{session}"' if session else ""
     return _q(client,
-        f'maeCreateNetlistForCorner("{test}" "{corner}" "{output_dir}")')
+        f'maeCreateNetlistForCorner("{test}" "{corner}" "{output_dir}"{s})')
 
 
 def export_output_view(client: VirtuosoClient, filepath: str, *,

--- a/tests/test_maestro_writer.py
+++ b/tests/test_maestro_writer.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from virtuoso_bridge.virtuoso.maestro import create_netlist_for_corner
+from virtuoso_bridge.virtuoso.maestro import MaestroOps
+
+
+class _RecordingClient:
+    def __init__(self) -> None:
+        self.expressions: list[str] = []
+
+    def execute_skill(self, expression: str, **_kwargs):
+        self.expressions.append(expression)
+        return SimpleNamespace(errors=[], output="t")
+
+
+def test_create_netlist_for_corner_uses_current_session_by_default() -> None:
+    client = _RecordingClient()
+
+    result = create_netlist_for_corner(
+        client,
+        "tran_test",
+        "tt",
+        "/tmp/tran_tt",
+    )
+
+    assert result == "t"
+    assert client.expressions == [
+        'maeCreateNetlistForCorner("tran_test" "tt" "/tmp/tran_tt")'
+    ]
+
+
+def test_create_netlist_for_corner_passes_explicit_session() -> None:
+    client = _RecordingClient()
+
+    create_netlist_for_corner(
+        client,
+        "tran_test",
+        "tt",
+        "/tmp/tran_tt",
+        session="session3",
+    )
+
+    assert client.expressions == [
+        'maeCreateNetlistForCorner("tran_test" "tt" "/tmp/tran_tt" '
+        '?session "session3")'
+    ]
+
+
+def test_create_netlist_for_corner_session_is_keyword_only() -> None:
+    client = _RecordingClient()
+
+    with pytest.raises(TypeError):
+        create_netlist_for_corner(
+            client,
+            "tran_test",
+            "tt",
+            "/tmp/tran_tt",
+            "session3",
+        )
+
+
+def test_maestro_ops_passes_explicit_session_to_corner_netlist_export() -> None:
+    client = _RecordingClient()
+
+    MaestroOps(client).create_netlist_for_corner(
+        "tran_test",
+        "tt",
+        "/tmp/tran_tt",
+        session="session3",
+    )
+
+    assert client.expressions == [
+        'maeCreateNetlistForCorner("tran_test" "tt" "/tmp/tran_tt" '
+        '?session "session3")'
+    ]


### PR DESCRIPTION
## Summary

- add an optional keyword-only `session` argument to `create_netlist_for_corner()`
- pass the explicit session to Cadence as `?session "..."`
- preserve the existing three-argument SKILL call when `session` is omitted
- document and test both the legacy function API and the new `client.maestro.*` facade

## Why

`maeCreateNetlistForCorner` supports an explicit Maestro session (Cadence recommened behavior), but the bridge helper previously omitted that argument and therefore depended on whichever session Cadence considered current. With multiple Maestro sessions open, that could export a netlist from unintended session state.

## Compatibility

Existing calls remain source- and behavior-compatible:

```python
create_netlist_for_corner(client, test, corner, output_dir)
```

The new argument is keyword-only and the return value remains the raw SKILL output string.

## Validation

- `33 passed` across Maestro writer, facade, results, snapshot-filter, and waveform-viewer tests
- live IC23.1 validation exported `TOP_SMOKE` at `tt_1p0_27` from explicit session `fnxSession56`
- Cadence returned `t` and generated a 72,166-byte `input.scs`