### PR TITLE
fix: isolate parallel simulation work directories

### DIFF
--- a/examples/02_spectre/05_parallel_sweep.py
+++ b/examples/02_spectre/05_parallel_sweep.py
@@ -160,11 +160,10 @@ def main(argv: list[str] | None = None) -> int:
     print(f"[Parallel] {len(tasks)} simulations, {max_workers} workers, mode '{mode}'")
 
     # --- Run all sweep points in parallel via SpectreSimulator's pool ----
-    # One SpectreSimulator instance manages the worker pool; each task gets
-    # its own remote uuid-based directory automatically, and locally each
-    # task writes ``<netlist.stem>.raw`` next to its netlist, so the
-    # distinct sweep filenames (inv_cload_5.0f.scs / inv_cload_10.0f.scs /
-    # ...) keep results from colliding without per-task work_dir setup.
+    # One SpectreSimulator instance manages the worker pool. Each task gets
+    # its own ``<netlist.stem>__<run-id>`` local work directory and a remote
+    # uuid-based directory automatically, so PSF and auxiliary files cannot
+    # collide even when the same netlist is submitted more than once.
     sim = SpectreSimulator.from_env(
         spectre_cmd=os.getenv("SPECTRE_CMD", "spectre"),
         spectre_args=spectre_mode_args(mode),

--- a/skills/spectre/SKILL.md
+++ b/skills/spectre/SKILL.md
@@ -90,7 +90,11 @@ These are silent or near-silent foot-guns from real lab runs:
 
 ## Parallel simulation
 
-Submit simulations that run concurrently — each gets its own remote directory, no conflicts. For full API and multi-server setup, read `references/parallel.md`.
+Submit simulations that run concurrently. Each task gets a unique
+`<netlist-stem>__<run-id>/` directory below `work_dir`, plus its own remote
+directory when applicable, so even repeated submissions of the same deck do
+not overwrite PSF data or auxiliary files. For full API and multi-server
+setup, read `references/parallel.md`.
 
 ```python
 t1 = sim.submit(Path("tb_comp.scs"))    # returns Future immediately

--- a/skills/spectre/references/parallel.md
+++ b/skills/spectre/references/parallel.md
@@ -55,7 +55,11 @@ sim.set_max_workers(4)  # default is 8, adjust for license/CPU limits
 sim.shutdown()           # tear down pool, new one created on next submit
 ```
 
-Each simulation gets its own remote directory (uuid-based) — no file conflicts.
+Each task gets a unique `<netlist-stem>__<run-id>/` directory below the
+configured local `work_dir`, as well as its own remote directory when
+applicable. This isolates PSF data, logs, initial-condition files, and other
+auxiliary files even when the same deck is submitted more than once. The
+synchronous `run_simulation()` path continues to use `work_dir` directly.
 SSH ControlMaster is shared automatically across threads.
 
 ## Multi-server simulation

--- a/src/virtuoso_bridge/spectre/runner.py
+++ b/src/virtuoso_bridge/spectre/runner.py
@@ -636,14 +636,32 @@ class SpectreSimulator:
         """Run a Spectre simulation on *netlist* synchronously."""
         netlist = Path(netlist).resolve()
         params = params or {}
+        return self._run_in_work_dir(netlist, params, self._work_dir)
+
+    def _run_in_work_dir(
+        self,
+        netlist: Path,
+        params: dict,
+        work_dir: Path | None,
+    ) -> SimulationResult:
+        """Run one resolved netlist using the provided local work directory."""
         if not netlist.exists():
             return SimulationResult(
                 status=ExecutionStatus.ERROR,
                 errors=[f"Netlist file not found: {netlist}"],
             )
         if self._remote_host:
-            return self._run_remote(netlist, params)
-        return self._run_local(netlist, params)
+            return self._run_remote(netlist, params, work_dir=work_dir)
+        return self._run_local(netlist, params, work_dir=work_dir)
+
+    def _new_parallel_work_dir(self, netlist: Path) -> Path:
+        """Reserve a collision-free local workspace path for one parallel task."""
+        base_dir = (
+            Path(self._work_dir)
+            if self._work_dir is not None
+            else artifact_dir("spectre")
+        )
+        return base_dir / f"{netlist.stem}__{uuid.uuid4().hex[:8]}"
 
     # -- parallel simulation API ---------------------------------------------
 
@@ -670,9 +688,10 @@ class SpectreSimulator:
         """Submit a simulation to run in the background.
 
         Returns a :class:`~concurrent.futures.Future` immediately.  The
-        simulation runs in a worker thread — each gets its own remote
-        directory (uuid-based), so there are no file conflicts.  The SSH
-        ControlMaster connection is shared automatically.
+        simulation runs in a worker thread. Each task gets its own local
+        work directory and remote directory (when applicable), so repeated
+        submissions of the same netlist cannot overwrite one another. The
+        SSH ControlMaster connection is shared automatically.
 
         Example::
 
@@ -686,7 +705,8 @@ class SpectreSimulator:
         pool = self._ensure_pool()
         netlist = Path(netlist).resolve()
         params = params or {}
-        return pool.submit(self.run_simulation, netlist, params)
+        work_dir = self._new_parallel_work_dir(netlist)
+        return pool.submit(self._run_in_work_dir, netlist, params, work_dir)
 
     def run_parallel(
         self,
@@ -847,7 +867,13 @@ class SpectreSimulator:
 
     # -- private helpers ----------------------------------------------------
 
-    def _run_local(self, netlist: Path, params: dict) -> SimulationResult:
+    def _run_local(
+        self,
+        netlist: Path,
+        params: dict,
+        *,
+        work_dir: Path | None,
+    ) -> SimulationResult:
         suffix = f"_{self._profile}" if self._profile else ""
         cadence_cshrc = (
             os.environ.get(f"VB_CADENCE_CSHRC{suffix}", "").strip()
@@ -859,7 +885,7 @@ class SpectreSimulator:
             spectre_cmd=self._spectre_cmd,
             spectre_args=self._spectre_args,
             timeout=self._timeout,
-            work_dir=self._work_dir,
+            work_dir=work_dir,
             output_format=self._output_format,
             cadence_cshrc=cadence_cshrc or None,
         )
@@ -885,7 +911,13 @@ class SpectreSimulator:
             )
         return self._ssh_runner
 
-    def _run_remote(self, netlist: Path, params: dict) -> SimulationResult:
+    def _run_remote(
+        self,
+        netlist: Path,
+        params: dict,
+        *,
+        work_dir: Path | None,
+    ) -> SimulationResult:
         runner = self._get_ssh_runner()
         timings: dict[str, float] = {}
         overall_started = time.perf_counter()
@@ -906,7 +938,11 @@ class SpectreSimulator:
                 errors=["Remote work dir is not configured"],
             )
 
-        base_output_dir = Path(self._work_dir) if self._work_dir is not None else artifact_dir("spectre", netlist.stem)
+        base_output_dir = (
+            Path(work_dir)
+            if work_dir is not None
+            else artifact_dir("spectre", netlist.stem)
+        )
         base_output_dir.mkdir(parents=True, exist_ok=True)
         run_result = _run_spectre_remote(
             netlist=netlist,

--- a/tests/test_spectre_runtime_paths.py
+++ b/tests/test_spectre_runtime_paths.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+from pathlib import Path
 from types import SimpleNamespace
 
 from virtuoso_bridge.spectre import runner
@@ -71,3 +73,96 @@ def test_local_spectre_sources_configured_cadence_environment(monkeypatch, tmp_p
 
     assert calls[0][0][:2] == ["csh", "-fc"]
     assert "source /eda/cadence.cshrc" in calls[0][0][2]
+
+
+def _successful_run(output_dir: Path) -> runner._SpectreRunResult:
+    output_dir.mkdir(parents=True)
+    return runner._SpectreRunResult(
+        success=True,
+        output_dir=output_dir,
+        returncode=0,
+        stdout="",
+        stderr="",
+        error=None,
+        metadata={},
+    )
+
+
+def test_synchronous_simulation_keeps_configured_work_dir(monkeypatch, tmp_path) -> None:
+    netlist = tmp_path / "tb_amp.scs"
+    netlist.write_text("simulator lang=spectre\n", encoding="utf-8")
+    work_dir = tmp_path / "run"
+    calls = []
+
+    def fake_run_spectre_local(**kwargs):
+        calls.append(kwargs)
+        return _successful_run(kwargs["work_dir"] / "tb_amp.raw")
+
+    monkeypatch.setattr(runner, "_run_spectre_local", fake_run_spectre_local)
+    simulator = runner.SpectreSimulator.local(work_dir=work_dir)
+
+    result = simulator.run_simulation(netlist)
+
+    assert result.ok
+    assert calls[0]["work_dir"] == work_dir
+
+
+def test_parallel_local_runs_use_unique_work_dirs(monkeypatch, tmp_path) -> None:
+    netlist = tmp_path / "tb_amp.scs"
+    netlist.write_text("simulator lang=spectre\n", encoding="utf-8")
+    work_dir = tmp_path / "runs"
+    task_work_dirs = []
+
+    def fake_run_spectre_local(**kwargs):
+        task_work_dir = kwargs["work_dir"]
+        task_work_dirs.append(task_work_dir)
+        return _successful_run(task_work_dir / "tb_amp.raw")
+
+    monkeypatch.setattr(runner, "_run_spectre_local", fake_run_spectre_local)
+    simulator = runner.SpectreSimulator.local(work_dir=work_dir)
+
+    try:
+        results = simulator.run_parallel(
+            [(netlist, {}), (netlist, {})],
+            max_workers=2,
+        )
+    finally:
+        simulator.shutdown()
+
+    assert all(result.ok for result in results)
+    assert len(set(task_work_dirs)) == 2
+    assert all(path.parent == work_dir for path in task_work_dirs)
+    assert all(re.fullmatch(r"tb_amp__[0-9a-f]{8}", path.name) for path in task_work_dirs)
+
+
+def test_parallel_remote_downloads_use_unique_local_work_dirs(monkeypatch, tmp_path) -> None:
+    netlist = tmp_path / "tb_amp.scs"
+    netlist.write_text("simulator lang=spectre\n", encoding="utf-8")
+    work_dir = tmp_path / "downloads"
+    task_work_dirs = []
+
+    def fake_run_spectre_remote(**kwargs):
+        task_work_dir = kwargs["base_output_dir"]
+        task_work_dirs.append(task_work_dir)
+        return _successful_run(task_work_dir / "tb_amp.raw")
+
+    monkeypatch.setattr(runner, "_run_spectre_remote", fake_run_spectre_remote)
+    simulator = runner.SpectreSimulator(
+        remote_host="compute-host",
+        remote_work_dir="/tmp/spectre-runs",
+        work_dir=work_dir,
+        ssh_runner=object(),
+    )
+
+    try:
+        results = simulator.run_parallel(
+            [(netlist, {}), (netlist, {})],
+            max_workers=2,
+        )
+    finally:
+        simulator.shutdown()
+
+    assert all(result.ok for result in results)
+    assert len(set(task_work_dirs)) == 2
+    assert all(path.parent == work_dir for path in task_work_dirs)
+    assert all(re.fullmatch(r"tb_amp__[0-9a-f]{8}", path.name) for path in task_work_dirs)


### PR DESCRIPTION
## Summary

- allocate a unique `<netlist-stem>__<run-id>/` local workspace for every `submit()` task
- use that isolated directory for both local Spectre execution and remote-result downloads
- preserve the synchronous `run_simulation()` work-directory behavior
- update the parallel simulation documentation and example

## Root cause

Remote Spectre execution already used a UUID-based remote directory, but concurrent tasks downloaded into one shared local `work_dir`. Fixed auxiliary names such as `spectre.out`, `spectre.fc`, and `spectre.ic` could overwrite one another, while recursive downloads could compete for temporary sibling directories. Repeated submissions of the same deck could also target the same `.raw` directory.

## Compatibility

The public signatures and result types of `run_simulation()`, `submit()`, and `run_parallel()` are unchanged. The intentional behavior change is the artifact layout for asynchronous tasks. Callers that hard-code paths directly below `work_dir` should use `result.metadata["output_dir"]` instead.

## Validation

- `21 passed` across Spectre runtime-path and parser tests
- unit coverage verifies synchronous directory behavior remains unchanged
- unit coverage verifies local and remote same-deck parallel tasks receive distinct directories
- live remote Spectre validation submitted the same RC deck twice concurrently; both runs completed with independent logs and 407 samples per signal, with no `.vbtmp-*` or `.vbbak-*` residue