### PR TITLE
[codex] make remote docs index ordering deterministic

### DIFF
--- a/src/virtuoso_bridge/virtuoso/docs_search.py
+++ b/src/virtuoso_bridge/virtuoso/docs_search.py
@@ -1368,41 +1368,43 @@ def emit(out, record):
     out.write((json.dumps(record, ensure_ascii=True) + "\n").encode("ascii"))
 
 
+def iter_document_paths():
+    for dirpath, dirnames, filenames in os.walk(ROOT):
+        dirnames.sort()
+        for filename in sorted(filenames):
+            if os.path.splitext(filename)[1].lower() in CONTENT_SUFFIXES:
+                yield os.path.join(dirpath, filename)
+
+
 fd, out_path = tempfile.mkstemp(prefix="vb_doc_index_", suffix=".jsonl.gz")
 os.close(fd)
 documents = 0
 topics = 0
 
 with gzip.open(out_path, "wb") as out:
-    for dirpath, _dirnames, filenames in os.walk(ROOT):
-        for filename in filenames:
-            path = os.path.join(dirpath, filename)
-            suffix = os.path.splitext(filename)[1].lower()
-            if suffix not in SEARCH_SUFFIXES:
-                continue
-            relative = relpath(path)
-            if suffix == ".tgf":
-                if relative == CANONICAL_TGF:
-                    for record in iter_tgf_records(path):
-                        emit(out, record)
-                        topics += 1
-                continue
-            if suffix not in CONTENT_SUFFIXES:
-                continue
-            try:
-                raw = read_preview(path)
-                title, text = extract_text(path, raw)
-            except Exception:
-                continue
-            emit(out, {
-                "kind": "document",
-                "path": path,
-                "relative_path": relative,
-                "suffix": suffix,
-                "title": title or os.path.splitext(filename)[0],
-                "text": text,
-            })
-            documents += 1
+    for path in iter_document_paths():
+        filename = os.path.basename(path)
+        suffix = os.path.splitext(filename)[1].lower()
+        try:
+            raw = read_preview(path)
+            title, text = extract_text(path, raw)
+        except Exception:
+            continue
+        emit(out, {
+            "kind": "document",
+            "path": path,
+            "relative_path": relpath(path),
+            "suffix": suffix,
+            "title": title or os.path.splitext(filename)[0],
+            "text": text,
+        })
+        documents += 1
+
+    canonical_tgf_path = os.path.join(ROOT, CANONICAL_TGF)
+    if os.path.isfile(canonical_tgf_path):
+        for record in iter_tgf_records(canonical_tgf_path):
+            emit(out, record)
+            topics += 1
 
 print(json.dumps({"path": out_path, "documents": documents, "topics": topics}))
 '''

--- a/tests/test_docs_search.py
+++ b/tests/test_docs_search.py
@@ -508,6 +508,50 @@ def test_remote_doc_index_command_extracts_records(tmp_path: Path) -> None:
     assert records[0]["relative_path"] == "skdfref/dbOpenCellViewByType.html"
 
 
+def test_remote_doc_index_command_orders_records_deterministically(tmp_path: Path) -> None:
+    doc_root = tmp_path / "doc"
+    for relative_path, title in (
+        ("zref/zeta.html", "Zeta"),
+        ("aref/alpha.html", "Alpha"),
+    ):
+        html_path = doc_root / relative_path
+        html_path.parent.mkdir(parents=True)
+        html_path.write_text(
+            f"<html><title>{title}</title><body>{title} docs.</body></html>",
+            encoding="utf-8",
+        )
+
+    tgf_path = doc_root / "api_more_info" / "api_more_info.tgf"
+    tgf_path.parent.mkdir()
+    tgf_path.write_text(
+        "alpha $aref/alpha.html NULL HTML\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ["bash", "-lc", _remote_doc_index_command(str(doc_root))],
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    summary = json.loads(result.stdout.strip().splitlines()[-1])
+    records_path = Path(summary["path"])
+    try:
+        with gzip.open(records_path, "rt", encoding="utf-8") as fh:
+            records = [json.loads(line) for line in fh if line.strip()]
+    finally:
+        records_path.unlink(missing_ok=True)
+
+    assert [record["relative_path"] for record in records] == [
+        "aref/alpha.html",
+        "zref/zeta.html",
+        "api_more_info/api_more_info.tgf",
+    ]
+
+
 def test_remote_doc_index_command_skips_broken_cadence_python(tmp_path: Path) -> None:
     install_root = tmp_path / "IC618"
     doc_root = install_root / "doc"


### PR DESCRIPTION
## Summary

- sort remote documentation directories and files before indexing
- emit document records before canonical TGF topic records
- add a regression test with reverse-created paths to verify stable output

## Why

The remote indexer streamed records in the order returned by `os.walk()`. That
order is filesystem-dependent, so identical documentation trees could produce
different gzip record order and the existing extraction test failed on systems
that visited `api_more_info` before `skdfref`.

The new traversal keeps streaming document contents, but sorts path components
and handles the canonical TGF after documents. This makes output reproducible
without loading the complete documentation corpus into memory.

## Impact

Remote documentation indexes now have deterministic record ordering across
filesystems. Document and topic counts and supported file types are unchanged.

## Test plan

- `python -m pytest tests/test_docs_search.py`
- `python -m pytest` (`755 passed, 1 skipped`)
