### PR TITLE
[codex] Add strict Spectre PSF accessors

### DIFF
--- a/src/virtuoso_bridge/spectre/psf.py
+++ b/src/virtuoso_bridge/spectre/psf.py
@@ -14,7 +14,8 @@ def read_psf_ascii(path: Path) -> dict[str, Any]:
     """Read one PSF ASCII result file or raise with its parser error."""
     result = parse_spectre_psf_ascii(path)
     if not result.ok:
-        raise ValueError("cannot parse PSF ASCII {}: {}".format(path, "; ".join(result.errors)))
+        details = "; ".join(result.errors) if result.errors else "no data parsed"
+        raise ValueError("cannot parse PSF ASCII {}: {}".format(path, details))
     return result.data
 
 

--- a/src/virtuoso_bridge/spectre/psf.py
+++ b/src/virtuoso_bridge/spectre/psf.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import math
 from collections.abc import Mapping
+from numbers import Number
 from pathlib import Path
 from typing import Any
 
@@ -23,7 +24,19 @@ def result_file(raw_psf: Path, filename: str) -> Path:
     """Return the one required result file below an explicit raw PSF root."""
     if not raw_psf.is_dir():
         raise FileNotFoundError("raw PSF directory is absent: {}".format(raw_psf))
-    matches = sorted(path for path in raw_psf.rglob(filename) if path.is_file())
+    pattern = Path(filename)
+    if pattern.is_absolute() or ".." in pattern.parts:
+        raise ValueError("result-file pattern must be relative and stay below raw PSF root: {}".format(filename))
+
+    resolved_root = raw_psf.resolve()
+    matches = []
+    for path in raw_psf.rglob(filename):
+        if not path.is_file():
+            continue
+        if not path.resolve().is_relative_to(resolved_root):
+            raise ValueError("result-file match escapes raw PSF root: {}".format(path))
+        matches.append(path)
+    matches.sort()
     if len(matches) != 1:
         raise ValueError("expected exactly one {} below {}, found {}".format(filename, raw_psf, len(matches)))
     return matches[0]
@@ -36,10 +49,9 @@ def scalar(data: Mapping[str, Any], raw_key: str) -> float:
     value = data[raw_key]
     if isinstance(value, complex) or isinstance(value, (list, tuple)):
         raise ValueError("PSF key {} must be one real scalar".format(raw_key))
-    try:
-        result = float(value)
-    except (TypeError, ValueError, OverflowError) as error:
-        raise ValueError("PSF key {} is not numeric".format(raw_key)) from error
+    if isinstance(value, bool) or not isinstance(value, Number):
+        raise ValueError("PSF key {} is not numeric".format(raw_key))
+    result = float(value)
     if not math.isfinite(result):
         raise ValueError("PSF key {} is non-finite".format(raw_key))
     return result
@@ -52,10 +64,9 @@ def vector(data: Mapping[str, Any], raw_key: str) -> list[complex]:
     value = data[raw_key]
     if not isinstance(value, list) or not value:
         raise ValueError("PSF key {} must be a non-empty vector".format(raw_key))
-    try:
-        result = [complex(item) for item in value]
-    except (TypeError, ValueError, OverflowError) as error:
-        raise ValueError("PSF key {} is not a numeric vector".format(raw_key)) from error
+    if any(isinstance(item, bool) or not isinstance(item, Number) for item in value):
+        raise ValueError("PSF key {} is not a numeric vector".format(raw_key))
+    result = [complex(item) for item in value]
     if not all(math.isfinite(item.real) and math.isfinite(item.imag) for item in result):
         raise ValueError("PSF key {} has non-finite values".format(raw_key))
     return result

--- a/src/virtuoso_bridge/spectre/psf.py
+++ b/src/virtuoso_bridge/spectre/psf.py
@@ -1,0 +1,71 @@
+"""Small, analysis-agnostic helpers for parsed Spectre PSF ASCII data."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from .parsers import parse_spectre_psf_ascii
+
+
+def read_psf_ascii(path: Path) -> dict[str, Any]:
+    """Read one PSF ASCII result file or raise with its parser error."""
+    result = parse_spectre_psf_ascii(path)
+    if not result.ok:
+        raise ValueError("cannot parse PSF ASCII {}: {}".format(path, "; ".join(result.errors)))
+    return result.data
+
+
+def result_file(raw_psf: Path, filename: str) -> Path:
+    """Return the one required result file below an explicit raw PSF root."""
+    if not raw_psf.is_dir():
+        raise FileNotFoundError("raw PSF directory is absent: {}".format(raw_psf))
+    matches = sorted(path for path in raw_psf.rglob(filename) if path.is_file())
+    if len(matches) != 1:
+        raise ValueError("expected exactly one {} below {}, found {}".format(filename, raw_psf, len(matches)))
+    return matches[0]
+
+
+def scalar(data: Mapping[str, Any], raw_key: str) -> float:
+    """Return one exact, finite real scalar PSF value."""
+    if raw_key not in data:
+        raise ValueError("PSF lacks required raw key: {}".format(raw_key))
+    value = data[raw_key]
+    if isinstance(value, complex) or isinstance(value, (list, tuple)):
+        raise ValueError("PSF key {} must be one real scalar".format(raw_key))
+    try:
+        result = float(value)
+    except (TypeError, ValueError, OverflowError) as error:
+        raise ValueError("PSF key {} is not numeric".format(raw_key)) from error
+    if not math.isfinite(result):
+        raise ValueError("PSF key {} is non-finite".format(raw_key))
+    return result
+
+
+def vector(data: Mapping[str, Any], raw_key: str) -> list[complex]:
+    """Return one exact, non-empty finite complex PSF vector."""
+    if raw_key not in data:
+        raise ValueError("PSF lacks required raw key: {}".format(raw_key))
+    value = data[raw_key]
+    if not isinstance(value, list) or not value:
+        raise ValueError("PSF key {} must be a non-empty vector".format(raw_key))
+    try:
+        result = [complex(item) for item in value]
+    except (TypeError, ValueError, OverflowError) as error:
+        raise ValueError("PSF key {} is not a numeric vector".format(raw_key)) from error
+    if not all(math.isfinite(item.real) and math.isfinite(item.imag) for item in result):
+        raise ValueError("PSF key {} has non-finite values".format(raw_key))
+    return result
+
+
+def frequency_hz(data: Mapping[str, Any], raw_key: str = "freq") -> list[float]:
+    """Return one exact, strictly increasing real frequency vector in Hz."""
+    frequencies_complex = vector(data, raw_key)
+    if any(value.imag != 0.0 for value in frequencies_complex):
+        raise ValueError("PSF frequency key {} must be real".format(raw_key))
+    frequencies = [value.real for value in frequencies_complex]
+    if any(right <= left for left, right in zip(frequencies, frequencies[1:])):
+        raise ValueError("PSF frequency key {} is not strictly increasing".format(raw_key))
+    return frequencies

--- a/tests/test_spectre_psf.py
+++ b/tests/test_spectre_psf.py
@@ -1,0 +1,52 @@
+"""Tests for small typed accessors over parsed Spectre PSF data."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from virtuoso_bridge.spectre.psf import frequency_hz, result_file, scalar, vector
+
+
+def test_scalar_requires_one_finite_real_value() -> None:
+    assert scalar({"vout": 1.25}, "vout") == pytest.approx(1.25)
+
+    with pytest.raises(ValueError, match="required raw key"):
+        scalar({}, "vout")
+    with pytest.raises(ValueError, match="real scalar"):
+        scalar({"vout": 1 + 2j}, "vout")
+    with pytest.raises(ValueError, match="real scalar"):
+        scalar({"vout": [1.25]}, "vout")
+    with pytest.raises(ValueError, match="non-finite"):
+        scalar({"vout": float("nan")}, "vout")
+
+
+def test_vector_and_frequency_hz_validate_shape_and_values() -> None:
+    data = {"freq": [1.0e9, 2.0e9], "vout": [1.0, 1 + 2j]}
+
+    assert vector(data, "vout") == [1 + 0j, 1 + 2j]
+    assert frequency_hz(data) == [1.0e9, 2.0e9]
+
+    with pytest.raises(ValueError, match="non-empty vector"):
+        vector({"vout": []}, "vout")
+    with pytest.raises(ValueError, match="non-finite"):
+        vector({"vout": [complex(float("nan"), 0.0)]}, "vout")
+    with pytest.raises(ValueError, match="must be real"):
+        frequency_hz({"freq": [1.0e9 + 1j]})
+    with pytest.raises(ValueError, match="strictly increasing"):
+        frequency_hz({"freq": [2.0e9, 1.0e9]})
+
+
+def test_result_file_requires_one_exact_match(tmp_path: Path) -> None:
+    raw = tmp_path / "raw"
+    nested = raw / "psf"
+    nested.mkdir(parents=True)
+    target = nested / "ac.ac"
+    target.write_text("fixture", encoding="ascii")
+
+    assert result_file(raw, "ac.ac") == target
+
+    (raw / "another.ac").write_text("fixture", encoding="ascii")
+    with pytest.raises(ValueError, match="expected exactly one"):
+        result_file(raw, "*.ac")

--- a/tests/test_spectre_psf.py
+++ b/tests/test_spectre_psf.py
@@ -6,7 +6,13 @@ from pathlib import Path
 
 import pytest
 
-from virtuoso_bridge.spectre.psf import frequency_hz, result_file, scalar, vector
+from virtuoso_bridge.spectre.psf import (
+    frequency_hz,
+    read_psf_ascii,
+    result_file,
+    scalar,
+    vector,
+)
 
 
 def test_scalar_requires_one_finite_real_value() -> None:
@@ -20,6 +26,10 @@ def test_scalar_requires_one_finite_real_value() -> None:
         scalar({"vout": [1.25]}, "vout")
     with pytest.raises(ValueError, match="non-finite"):
         scalar({"vout": float("nan")}, "vout")
+    with pytest.raises(ValueError, match="not numeric"):
+        scalar({"vout": True}, "vout")
+    with pytest.raises(ValueError, match="not numeric"):
+        scalar({"vout": "1.25"}, "vout")
 
 
 def test_vector_and_frequency_hz_validate_shape_and_values() -> None:
@@ -36,6 +46,12 @@ def test_vector_and_frequency_hz_validate_shape_and_values() -> None:
         frequency_hz({"freq": [1.0e9 + 1j]})
     with pytest.raises(ValueError, match="strictly increasing"):
         frequency_hz({"freq": [2.0e9, 1.0e9]})
+    with pytest.raises(ValueError, match="numeric vector"):
+        vector({"vout": [True]}, "vout")
+    with pytest.raises(ValueError, match="numeric vector"):
+        vector({"vout": ["2+3j"]}, "vout")
+    with pytest.raises(ValueError, match="numeric vector"):
+        frequency_hz({"freq": ["1.0e9"]})
 
 
 def test_result_file_requires_one_exact_match(tmp_path: Path) -> None:
@@ -50,3 +66,36 @@ def test_result_file_requires_one_exact_match(tmp_path: Path) -> None:
     (raw / "another.ac").write_text("fixture", encoding="ascii")
     with pytest.raises(ValueError, match="expected exactly one"):
         result_file(raw, "*.ac")
+
+
+def test_result_file_rejects_escaping_patterns_and_symlinks(tmp_path: Path) -> None:
+    raw = tmp_path / "raw"
+    raw.mkdir()
+    outside = tmp_path / "outside.ac"
+    outside.write_text("fixture", encoding="ascii")
+
+    with pytest.raises(ValueError, match="must be relative"):
+        result_file(raw, str(outside))
+    with pytest.raises(ValueError, match="must be relative"):
+        result_file(raw, "../outside.ac")
+
+    link = raw / "external.ac"
+    link.symlink_to(outside)
+    with pytest.raises(ValueError, match="escapes raw PSF root"):
+        result_file(raw, "*.ac")
+
+
+def test_read_psf_ascii_returns_data_and_explains_failures(tmp_path: Path) -> None:
+    psf_file = tmp_path / "tran.tran"
+    psf_file.write_text(
+        "HEADER\nPROPERTIES\nSWEEP\n\"time\" 1\nTRACE\n\"vout\" \"V\"\n"
+        "VALUE\n\"time\" 0.0\n\"vout\" 1.25\nEND\n",
+        encoding="ascii",
+    )
+
+    assert read_psf_ascii(psf_file) == {"time": [0.0], "vout": [1.25]}
+
+    invalid = tmp_path / "invalid.psf"
+    invalid.write_text("HEADER\nEND\n", encoding="ascii")
+    with pytest.raises(ValueError, match="no data parsed"):
+        read_psf_ascii(invalid)


### PR DESCRIPTION
## What changed

Add small typed helpers for parsed Spectre PSF ASCII results:

- locate one expected result file below an explicit raw PSF root
- read a parsed PSF ASCII file
- require exact raw keys for finite real scalars and finite complex vectors
- validate a real, strictly increasing frequency vector in Hz

## Why

Task-specific extractors need reusable PSF syntax and data-shape checks while retaining exact raw-key selection and circuit formulas in task code.

## Impact

Consumers receive strict failures for absent keys, non-numeric values, non-finite values, invalid vector shapes, and ambiguous result-file locations. No raw-key alias guessing or circuit metric calculation is added.

## Validation

- `/home/hz168/projects/virtuoso-bridge-lite/.venv/bin/python -m pytest -q tests/test_spectre_psf.py tests/test_spectre_parsers.py`
- Result: 18 passed

Pytest reports existing cleanup warnings for deliberate symlink/special-file fixtures under `/tmp`; there are no test failures.