### PR TITLE
fix: close named schematic reader cellviews

### DIFF
--- a/src/virtuoso_bridge/virtuoso/schematic/reader.py
+++ b/src/virtuoso_bridge/virtuoso/schematic/reader.py
@@ -62,7 +62,8 @@ _SKILL_TOPOLOGY = r'''
 let((cv result)
   {owned_read_start}
   cv = {cv_expr}
-  unless(cv return("ERROR"))
+  if(cv
+    then progn(
   result = "INSTANCES\n"
   foreach(inst cv~>instances
     when(inst~>purpose != "pin"
@@ -107,7 +108,8 @@ let((cv result)
       if(term~>numBits term~>numBits 1))))
   {notes_section}
   result = strcat(result "END\n")
-  result
+  result)
+    else "ERROR")
   {owned_read_cleanup})
 '''
 
@@ -128,17 +130,19 @@ def _build_cellview_read_skill(
     cell: str | None,
 ) -> str:
     """Bind a read template to either an owned named CV or the current CV."""
-    if lib and cell:
+    if lib is None and cell is None:
+        cv_expr = "geGetEditCellView()"
+        owned_read_start = ""
+        owned_read_cleanup = ""
+    elif not lib or not cell:
+        raise ValueError("lib and cell must both be non-empty when provided")
+    else:
         cv_expr = (
             f'dbOpenCellViewByType("{escape_skill_string(lib)}" '
             f'"{escape_skill_string(cell)}" "schematic" "schematic" "r")'
         )
         owned_read_start = _OWNED_READ_START
         owned_read_cleanup = _OWNED_READ_CLEANUP
-    else:
-        cv_expr = "geGetEditCellView()"
-        owned_read_start = ""
-        owned_read_cleanup = ""
 
     return (
         template.replace("{owned_read_start}", owned_read_start)
@@ -386,7 +390,8 @@ _READ_PLACEMENT_SKILL = '''
 let((cv instList pinList labelList wireList)
   {owned_read_start}
   cv = {cv_expr}
-  unless(cv return("ERROR"))
+  if(cv
+    then progn(
   instList = ""
   foreach(inst cv~>instances
     instList = strcat(instList sprintf(nil "%s|%s|%s|%L|%s\\n"
@@ -402,7 +407,8 @@ let((cv instList pinList labelList wireList)
   foreach(shape cv~>shapes
     when(shape~>objType == "line"
       wireList = strcat(wireList sprintf(nil "%L\\n" shape~>points))))
-  sprintf(nil "INSTANCES\\n%sPINS\\n%sLABELS\\n%sWIRES\\n%sEND" instList pinList labelList wireList)
+  sprintf(nil "INSTANCES\\n%sPINS\\n%sLABELS\\n%sWIRES\\n%sEND" instList pinList labelList wireList))
+    else "ERROR")
   {owned_read_cleanup})
 '''
 
@@ -418,6 +424,11 @@ def read_placement(
     if getattr(r, "errors", None):
         raise RuntimeError(f"read_placement SKILL error: {r.errors[0]}")
     raw = decode_skill_output(r.output)
+    if raw.strip() == "ERROR":
+        raise RuntimeError(
+            f"read_placement could not open schematic "
+            f"{lib or '(current)'}/{cell or '(current)'}"
+        )
 
     result: dict = {"instances": [], "pins": [], "labels": [], "wires": []}
     section = None
@@ -451,7 +462,8 @@ _READ_CONNECTIVITY_SKILL = '''
 let((cv instList netList pinList)
   {owned_read_start}
   cv = {cv_expr}
-  unless(cv return("ERROR"))
+  if(cv
+    then progn(
   instList = ""
   foreach(inst cv~>instances
     instList = strcat(instList sprintf(nil "%s|%s|%s\\n"
@@ -465,7 +477,8 @@ let((cv instList netList pinList)
   pinList = ""
   foreach(term cv~>terminals
     pinList = strcat(pinList sprintf(nil "%s|%s\\n" term~>name term~>direction)))
-  sprintf(nil "INSTANCES\\n%sNETS\\n%sPINS\\n%sEND" instList netList pinList)
+  sprintf(nil "INSTANCES\\n%sNETS\\n%sPINS\\n%sEND" instList netList pinList))
+    else "ERROR")
   {owned_read_cleanup})
 '''
 
@@ -481,6 +494,11 @@ def read_connectivity(
     if getattr(r, "errors", None):
         raise RuntimeError(f"read_connectivity SKILL error: {r.errors[0]}")
     raw = decode_skill_output(r.output)
+    if raw.strip() == "ERROR":
+        raise RuntimeError(
+            f"read_connectivity could not open schematic "
+            f"{lib or '(current)'}/{cell or '(current)'}"
+        )
 
     result: dict = {"instances": [], "nets": [], "pins": []}
     section = None
@@ -513,7 +531,8 @@ _READ_PARAMS_SKILL = '''
 let((cv result)
   {owned_read_start}
   cv = {cv_expr}
-  unless(cv return("ERROR"))
+  if(cv
+    then progn(
   result = ""
   foreach(inst cv~>instances
     let((cdf paramStr)
@@ -526,7 +545,8 @@ let((cv result)
             paramStr = strcat(paramStr sprintf(nil "|%s=%L" p~>name p~>value)))))
       result = strcat(result sprintf(nil "%s|%s|%s%s\\n"
         inst~>name inst~>libName inst~>cellName paramStr))))
-  result
+  result)
+    else "ERROR")
   {owned_read_cleanup})
 '''
 
@@ -543,6 +563,11 @@ def read_instance_params(
     if getattr(r, "errors", None):
         raise RuntimeError(f"read_instance_params SKILL error: {r.errors[0]}")
     raw = decode_skill_output(r.output)
+    if raw.strip() == "ERROR":
+        raise RuntimeError(
+            f"read_instance_params could not open schematic "
+            f"{lib or '(current)'}/{cell or '(current)'}"
+        )
 
     result = []
     for line in raw.splitlines():

--- a/src/virtuoso_bridge/virtuoso/schematic/reader.py
+++ b/src/virtuoso_bridge/virtuoso/schematic/reader.py
@@ -28,6 +28,7 @@ from typing import Any
 import yaml
 
 from virtuoso_bridge import VirtuosoClient, decode_skill_output
+from virtuoso_bridge.virtuoso.ops import escape_skill_string
 
 _DEFAULT_FILTERS_PATH = Path(__file__).parent / "cdf_param_filters.yaml"
 _DEFAULT_TIMEOUT_S = 300
@@ -59,6 +60,7 @@ def _match_filter(config: dict, lib: str, cell: str) -> list[str] | None:
 
 _SKILL_TOPOLOGY = r'''
 let((cv result)
+  {owned_read_start}
   cv = {cv_expr}
   unless(cv return("ERROR"))
   result = "INSTANCES\n"
@@ -105,8 +107,45 @@ let((cv result)
       if(term~>numBits term~>numBits 1))))
   {notes_section}
   result = strcat(result "END\n")
-  result)
+  result
+  {owned_read_cleanup})
 '''
+
+_OWNED_READ_START = r'''unwindProtect(
+    progn('''
+
+_OWNED_READ_CLEANUP = r''')
+    progn(
+      when(cv
+        unless(dbClose(cv)
+          error("schematic reader close failed"))
+        cv = nil)))'''
+
+
+def _build_cellview_read_skill(
+    template: str,
+    lib: str | None,
+    cell: str | None,
+) -> str:
+    """Bind a read template to either an owned named CV or the current CV."""
+    if lib and cell:
+        cv_expr = (
+            f'dbOpenCellViewByType("{escape_skill_string(lib)}" '
+            f'"{escape_skill_string(cell)}" "schematic" "schematic" "r")'
+        )
+        owned_read_start = _OWNED_READ_START
+        owned_read_cleanup = _OWNED_READ_CLEANUP
+    else:
+        cv_expr = "geGetEditCellView()"
+        owned_read_start = ""
+        owned_read_cleanup = ""
+
+    return (
+        template.replace("{owned_read_start}", owned_read_start)
+        .replace("{owned_read_cleanup}", owned_read_cleanup)
+        .replace("{cv_expr}", cv_expr)
+    )
+
 
 _GEOMETRY_INST_EXPR = r'''
       result = strcat(result sprintf(nil "|%L|%s|%L|%d|%s"
@@ -147,10 +186,11 @@ def read_schematic(
     """Read a schematic in one SKILL call.
 
     Args:
-        lib, cell: library and cell name.  If omitted, uses the currently
-            open cellview (geGetEditCellView).
-        include_positions: if True (default), include xy/orient/bBox/numInst/view
-            on each instance.  False = pure topology + params only.
+        lib, cell: library and cell name. A named read closes the cellview
+            reference it opens. If omitted, uses the caller-owned current
+            cellview (geGetEditCellView) and leaves it open.
+        include_positions: if True, include xy/orient/bBox/numInst/view on each
+            instance. False = pure topology + params only.
             Notes are always returned regardless of this flag.
         param_filters: path to a YAML filter config.  Default uses the
             built-in cdf_param_filters.yaml.  Pass None to return all
@@ -166,15 +206,12 @@ def read_schematic(
         ``"ignore"`` when the designer shift+deleted the instance in the
         schematic editor to exclude it from netlisting.  Absent key = normal.
     """
-    if lib and cell:
-        cv_expr = f'dbOpenCellViewByType("{lib}" "{cell}" "schematic" "schematic" "r")'
-    else:
-        cv_expr = "geGetEditCellView()"
-
-    skill = _SKILL_TOPOLOGY.replace("{cv_expr}", cv_expr)
-    skill = skill.replace("{geometry_inst}", _GEOMETRY_INST_EXPR if include_positions else "")
+    skill = _SKILL_TOPOLOGY.replace(
+        "{geometry_inst}", _GEOMETRY_INST_EXPR if include_positions else ""
+    )
     # Notes are always included
     skill = skill.replace("{notes_section}", _NOTES_SECTION_EXPR)
+    skill = _build_cellview_read_skill(skill, lib, cell)
 
     r = client.execute_skill(skill, timeout=timeout)
     if getattr(r, "errors", None):
@@ -347,6 +384,7 @@ def _parse_bbox(s: str) -> list[list[float]]:
 
 _READ_PLACEMENT_SKILL = '''
 let((cv instList pinList labelList wireList)
+  {owned_read_start}
   cv = {cv_expr}
   unless(cv return("ERROR"))
   instList = ""
@@ -364,7 +402,8 @@ let((cv instList pinList labelList wireList)
   foreach(shape cv~>shapes
     when(shape~>objType == "line"
       wireList = strcat(wireList sprintf(nil "%L\\n" shape~>points))))
-  sprintf(nil "INSTANCES\\n%sPINS\\n%sLABELS\\n%sWIRES\\n%sEND" instList pinList labelList wireList))
+  sprintf(nil "INSTANCES\\n%sPINS\\n%sLABELS\\n%sWIRES\\n%sEND" instList pinList labelList wireList)
+  {owned_read_cleanup})
 '''
 
 
@@ -374,13 +413,10 @@ def read_placement(
     cell: str | None = None,
 ) -> dict:
     """Read placement: instance positions, pins, labels, wires."""
-    if lib and cell:
-        cv_expr = f'dbOpenCellViewByType("{lib}" "{cell}" "schematic" "schematic" "r")'
-    else:
-        cv_expr = "geGetEditCellView()"
-
-    skill = _READ_PLACEMENT_SKILL.replace("{cv_expr}", cv_expr)
+    skill = _build_cellview_read_skill(_READ_PLACEMENT_SKILL, lib, cell)
     r = client.execute_skill(skill, timeout=30)
+    if getattr(r, "errors", None):
+        raise RuntimeError(f"read_placement SKILL error: {r.errors[0]}")
     raw = decode_skill_output(r.output)
 
     result: dict = {"instances": [], "pins": [], "labels": [], "wires": []}
@@ -413,6 +449,7 @@ def read_placement(
 
 _READ_CONNECTIVITY_SKILL = '''
 let((cv instList netList pinList)
+  {owned_read_start}
   cv = {cv_expr}
   unless(cv return("ERROR"))
   instList = ""
@@ -428,7 +465,8 @@ let((cv instList netList pinList)
   pinList = ""
   foreach(term cv~>terminals
     pinList = strcat(pinList sprintf(nil "%s|%s\\n" term~>name term~>direction)))
-  sprintf(nil "INSTANCES\\n%sNETS\\n%sPINS\\n%sEND" instList netList pinList))
+  sprintf(nil "INSTANCES\\n%sNETS\\n%sPINS\\n%sEND" instList netList pinList)
+  {owned_read_cleanup})
 '''
 
 
@@ -438,13 +476,10 @@ def read_connectivity(
     cell: str | None = None,
 ) -> dict:
     """Read electrical connectivity: instances, nets, pins."""
-    if lib and cell:
-        cv_expr = f'dbOpenCellViewByType("{lib}" "{cell}" "schematic" "schematic" "r")'
-    else:
-        cv_expr = "geGetEditCellView()"
-
-    skill = _READ_CONNECTIVITY_SKILL.replace("{cv_expr}", cv_expr)
+    skill = _build_cellview_read_skill(_READ_CONNECTIVITY_SKILL, lib, cell)
     r = client.execute_skill(skill, timeout=30)
+    if getattr(r, "errors", None):
+        raise RuntimeError(f"read_connectivity SKILL error: {r.errors[0]}")
     raw = decode_skill_output(r.output)
 
     result: dict = {"instances": [], "nets": [], "pins": []}
@@ -476,6 +511,7 @@ def read_connectivity(
 
 _READ_PARAMS_SKILL = '''
 let((cv result)
+  {owned_read_start}
   cv = {cv_expr}
   unless(cv return("ERROR"))
   result = ""
@@ -490,7 +526,8 @@ let((cv result)
             paramStr = strcat(paramStr sprintf(nil "|%s=%L" p~>name p~>value)))))
       result = strcat(result sprintf(nil "%s|%s|%s%s\\n"
         inst~>name inst~>libName inst~>cellName paramStr))))
-  result)
+  result
+  {owned_read_cleanup})
 '''
 
 
@@ -501,13 +538,10 @@ def read_instance_params(
     filter_params: list[str] | None = None,
 ) -> list[dict]:
     """Read CDF parameters for all instances."""
-    if lib and cell:
-        cv_expr = f'dbOpenCellViewByType("{lib}" "{cell}" "schematic" "schematic" "r")'
-    else:
-        cv_expr = "geGetEditCellView()"
-
-    skill = _READ_PARAMS_SKILL.replace("{cv_expr}", cv_expr)
+    skill = _build_cellview_read_skill(_READ_PARAMS_SKILL, lib, cell)
     r = client.execute_skill(skill, timeout=30)
+    if getattr(r, "errors", None):
+        raise RuntimeError(f"read_instance_params SKILL error: {r.errors[0]}")
     raw = decode_skill_output(r.output)
 
     result = []

--- a/tests/test_schematic_reader.py
+++ b/tests/test_schematic_reader.py
@@ -165,6 +165,56 @@ def test_legacy_readers_surface_skill_cleanup_errors(
         reader(Client(), "LIB", "CELL")
 
 
+@pytest.mark.parametrize(
+    ("reader", "operation"),
+    [
+        (read_placement, "read_placement"),
+        (read_connectivity, "read_connectivity"),
+        (read_instance_params, "read_instance_params"),
+    ],
+)
+def test_legacy_readers_reject_open_failure_sentinel(
+    reader: Callable[..., object],
+    operation: str,
+) -> None:
+    class Client:
+        def execute_skill(self, skill: str, timeout: int = 30):
+            return SimpleNamespace(output='"ERROR"', errors=[])
+
+    with pytest.raises(RuntimeError, match=rf"{operation} could not open schematic"):
+        reader(Client(), "LIB", "MISSING")
+
+
+@pytest.mark.parametrize(
+    "reader",
+    [read_schematic, read_placement, read_connectivity, read_instance_params],
+)
+@pytest.mark.parametrize(
+    ("lib", "cell"),
+    [
+        ("LIB_ONLY", None),
+        (None, "CELL_ONLY"),
+        ("", "CELL_ONLY"),
+        ("LIB_ONLY", ""),
+        ("", ""),
+    ],
+)
+def test_readers_reject_incomplete_named_target(
+    reader: Callable[..., object],
+    lib: str | None,
+    cell: str | None,
+) -> None:
+    class Client:
+        def execute_skill(self, skill: str, timeout: int = 300):
+            raise AssertionError("partial targets must fail before SKILL execution")
+
+    with pytest.raises(
+        ValueError,
+        match="lib and cell must both be non-empty when provided",
+    ):
+        reader(Client(), lib, cell)
+
+
 def test_client_bound_read_delegates_to_unified_reader(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, object] = {}
     owner = object()

--- a/tests/test_schematic_reader.py
+++ b/tests/test_schematic_reader.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from types import SimpleNamespace
 
 import pytest
 
-from virtuoso_bridge.virtuoso.schematic.reader import _parse_schematic, read_schematic
+from virtuoso_bridge.virtuoso.schematic.reader import (
+    _parse_schematic,
+    read_connectivity,
+    read_instance_params,
+    read_placement,
+    read_schematic,
+)
 from virtuoso_bridge.virtuoso.schematic import SchematicOps
 
 
@@ -30,6 +37,132 @@ def test_read_schematic_forwards_timeout() -> None:
     read_schematic(client, "LIB", "CELL", param_filters=None, timeout=123)
 
     assert client.timeout == 123
+
+
+def test_named_read_closes_its_cellview_in_unwind_cleanup() -> None:
+    class Client:
+        skill: str | None = None
+
+        def execute_skill(self, skill: str, timeout: int = 300):
+            self.skill = skill
+            return SimpleNamespace(output="INSTANCES\nNETS\nPINS\nEND\n", errors=[])
+
+    client = Client()
+
+    read_schematic(client, "LIB", "CELL", param_filters=None)
+
+    assert client.skill is not None
+    assert 'dbOpenCellViewByType("LIB" "CELL" "schematic" "schematic" "r")' in client.skill
+    assert "unwindProtect(" in client.skill
+    assert "when(cv" in client.skill
+    assert "dbClose(cv)" in client.skill
+    assert client.skill.index("unwindProtect(") < client.skill.index(
+        "dbOpenCellViewByType("
+    )
+    assert client.skill.index('result = strcat(result "END\\n")') < client.skill.index(
+        "dbClose(cv)"
+    )
+
+
+def test_current_cellview_read_does_not_close_caller_owned_cellview() -> None:
+    class Client:
+        skill: str | None = None
+
+        def execute_skill(self, skill: str, timeout: int = 300):
+            self.skill = skill
+            return SimpleNamespace(output="INSTANCES\nNETS\nPINS\nEND\n", errors=[])
+
+    client = Client()
+
+    read_schematic(client, param_filters=None)
+
+    assert client.skill is not None
+    assert "cv = geGetEditCellView()" in client.skill
+    assert "unwindProtect(" not in client.skill
+    assert "dbClose(cv)" not in client.skill
+
+
+@pytest.mark.parametrize(
+    ("reader", "output"),
+    [
+        (read_placement, "INSTANCES\nPINS\nLABELS\nWIRES\nEND\n"),
+        (read_connectivity, "INSTANCES\nNETS\nPINS\nEND\n"),
+        (read_instance_params, ""),
+    ],
+)
+def test_legacy_named_readers_close_their_cellview_in_unwind_cleanup(
+    reader: Callable[..., object],
+    output: str,
+) -> None:
+    class Client:
+        skill: str | None = None
+
+        def execute_skill(self, skill: str, timeout: int = 30):
+            self.skill = skill
+            return SimpleNamespace(output=output, errors=[])
+
+    client = Client()
+
+    reader(client, "LIB", "CELL")
+
+    assert client.skill is not None
+    assert 'dbOpenCellViewByType("LIB" "CELL" "schematic" "schematic" "r")' in client.skill
+    assert "unwindProtect(" in client.skill
+    assert "when(cv" in client.skill
+    assert "dbClose(cv)" in client.skill
+    assert client.skill.index("unwindProtect(") < client.skill.index(
+        "dbOpenCellViewByType("
+    )
+    assert client.skill.index("dbOpenCellViewByType(") < client.skill.index("dbClose(cv)")
+
+
+@pytest.mark.parametrize(
+    ("reader", "output"),
+    [
+        (read_placement, "INSTANCES\nPINS\nLABELS\nWIRES\nEND\n"),
+        (read_connectivity, "INSTANCES\nNETS\nPINS\nEND\n"),
+        (read_instance_params, ""),
+    ],
+)
+def test_legacy_current_cellview_readers_do_not_close_caller_owned_cellview(
+    reader: Callable[..., object],
+    output: str,
+) -> None:
+    class Client:
+        skill: str | None = None
+
+        def execute_skill(self, skill: str, timeout: int = 30):
+            self.skill = skill
+            return SimpleNamespace(output=output, errors=[])
+
+    client = Client()
+
+    reader(client)
+
+    assert client.skill is not None
+    assert "cv = geGetEditCellView()" in client.skill
+    assert "unwindProtect(" not in client.skill
+    assert "dbClose(cv)" not in client.skill
+
+
+@pytest.mark.parametrize(
+    ("reader", "operation"),
+    [
+        (read_placement, "read_placement"),
+        (read_connectivity, "read_connectivity"),
+        (read_instance_params, "read_instance_params"),
+    ],
+)
+def test_legacy_readers_surface_skill_cleanup_errors(
+    reader: Callable[..., object],
+    operation: str,
+) -> None:
+    class Client:
+        def execute_skill(self, skill: str, timeout: int = 30):
+            return SimpleNamespace(output="", errors=["schematic reader close failed"])
+
+    with pytest.raises(RuntimeError, match=rf"{operation} SKILL error"):
+        reader(Client(), "LIB", "CELL")
 
 
 def test_client_bound_read_delegates_to_unified_reader(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

- close the cellview reference opened by named `read_schematic` calls in an `unwindProtect` cleanup
- apply the same ownership rule to the legacy `read_placement`, `read_connectivity`, and `read_instance_params` readers
- leave caller-owned `geGetEditCellView()` cellviews open for focused/current reads
- reject partial or empty `lib`/`cell` targets and surface named-open and cleanup failures explicitly

## Root cause

Named schematic reads called `dbOpenCellViewByType(... "r")` without a matching `dbClose`. The retained reference kept the database object cached after the read. A later `schCheck` could mark that cached object modified; opening it in Schematic Editor then showed a trailing `*` and prompted to save despite no user edit.

The readers now wrap the named open and serialization in `unwindProtect` and close exactly the reference acquired by that read. The focused/current path still uses the caller-owned cellview without closing it.

## User impact

Read-only schematic audits no longer leave named cellviews cached. Subsequent checks and editor opens start from clean disk-backed state, while already-open editor windows remain open and clean.

## Validation

- `58 passed` across `test_schematic_reader.py`, `test_schematic_ops.py`, and `test_editor_modes.py`
- live Virtuoso regression on `prime-voyager_ciw01` using TEST cells:
  - named reads leave no entry in `dbGetOpenCellViews()`
  - cleanup runs after a forced serialization failure
  - `read -> schCheck -> editor open` remains clean with no title `*`
  - named reads preserve an existing editor-owned cellview
  - current/focused reads preserve the caller-owned window
  - all four readers report missing named cellviews explicitly and reject incomplete targets before SKILL execution
- two independent final code audits reported no P0-P3 findings
- full local Windows run: `804 passed, 31 failed, 10 skipped`; the failures are confined to untouched docs-search, streamout, runtime-path, and schematic-netlist platform tests
