### PR TITLE
feat: add SOCKS5 proxy support to Paramiko backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ jump-host socket and Paramiko reaches the target through that SSH transport.
 Proxy failures are reported directly; the bridge does not fall back to a direct
 or OpenSSH command connection. The local `-L` tunnel managed by
 `virtuoso-bridge start` remains an OpenSSH port forward.
+While the proxy is active, SSH config lookup forces `CanonicalizeHostname=no`
+so OpenSSH cannot resolve the proxied first-hop hostname locally before
+Paramiko opens the SOCKS5 connection.
 
 The Paramiko backend reads `VB_SSH_CONFIG` when set, otherwise the normal user
 and system SSH config files. It honors `Include`, host aliases,

--- a/README.md
+++ b/README.md
@@ -118,14 +118,16 @@ Waiting work queues at the gate
 instead of opening another command connection. There is no automatic fallback
 to independent SSH connections.
 
-`VB_SSH_PROXY` is optional and only affects the Paramiko backend. It accepts an
-explicit `socks5://host:port` URL without credentials and asks the proxy to
-resolve the proxied first-hop hostname. For direct connections the proxy opens
-the target SSH socket. With `VB_JUMP_HOST` or one `ProxyJump` hop, it opens the
-jump-host socket and Paramiko reaches the target through that SSH transport.
-Proxy failures are reported directly; the bridge does not fall back to a direct
-or OpenSSH command connection. The local `-L` tunnel managed by
-`virtuoso-bridge start` remains an OpenSSH port forward.
+`VB_SSH_PROXY` is optional and applies only to Paramiko-backed commands and file
+transfers, including SFTP. It does not affect the OpenSSH `-L` tunnel created by
+`virtuoso-bridge start`; environments that also need this tunnel to traverse
+SOCKS5 must configure an OpenSSH `ProxyCommand` in the SSH config used by the
+bridge. `VB_SSH_PROXY` accepts an explicit `socks5://host:port` URL without
+credentials and asks the proxy to resolve the proxied first-hop hostname. For
+direct connections the proxy opens the target SSH socket. With `VB_JUMP_HOST`
+or one `ProxyJump` hop, it opens the jump-host socket and Paramiko reaches the
+target through that SSH transport. Proxy failures are reported directly; the
+bridge does not fall back to a direct or OpenSSH command connection.
 While the proxy is active, SSH config lookup forces `CanonicalizeHostname=no`
 so OpenSSH cannot resolve the proxied first-hop hostname locally before
 Paramiko opens the SOCKS5 connection.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ uv pip install -e '.[ssh]'
 ```dotenv
 VB_SSH_BACKEND=paramiko
 VB_SSH_MAX_SESSIONS=10
+# Optional: route the first SSH hop through an unauthenticated SOCKS5 proxy.
+VB_SSH_PROXY=socks5://127.0.0.1:10800
 ```
 
 Commands and file transfers then share one authenticated target SSH Transport;
@@ -116,12 +118,22 @@ Waiting work queues at the gate
 instead of opening another command connection. There is no automatic fallback
 to independent SSH connections.
 
+`VB_SSH_PROXY` is optional and only affects the Paramiko backend. It accepts an
+explicit `socks5://host:port` URL without credentials and asks the proxy to
+resolve the proxied first-hop hostname. For direct connections the proxy opens
+the target SSH socket. With `VB_JUMP_HOST` or one `ProxyJump` hop, it opens the
+jump-host socket and Paramiko reaches the target through that SSH transport.
+Proxy failures are reported directly; the bridge does not fall back to a direct
+or OpenSSH command connection. The local `-L` tunnel managed by
+`virtuoso-bridge start` remains an OpenSSH port forward.
+
 The Paramiko backend reads `VB_SSH_CONFIG` when set, otherwise the normal user
 and system SSH config files. It honors `Include`, host aliases,
 `HostName`/`User`/`Port`, `IdentityFile`, `IdentitiesOnly`, and one `ProxyJump`
 hop. Explicit `VB_REMOTE_*`, `VB_JUMP_*`, and key arguments take precedence.
-`ProxyCommand`, chained `ProxyJump` routes, and a missing explicit
-`VB_SSH_CONFIG` fail during initialization instead of being silently ignored.
+`ProxyCommand` fails during initialization unless an explicit `VB_SSH_PROXY`
+overrides it. Chained `ProxyJump` routes and a missing explicit `VB_SSH_CONFIG`
+also fail instead of being silently ignored.
 Both the target and jump host must already have keys in the applicable user or
 system `known_hosts` files; unknown and changed keys are rejected. The backend
 honors `UserKnownHostsFile`, `GlobalKnownHostsFile`, and `HostKeyAlias`. Run the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,10 +22,10 @@ dependencies = [
 visio = ["pywin32; sys_platform == 'win32'"]
 # Persistent SSH transport with real multi-session multiplexing. This avoids
 # Windows OpenSSH ControlMaster limitations while keeping local mode lightweight.
-ssh = ["paramiko>=3.5"]
+ssh = ["paramiko>=3.5", "PySocks>=1.7.1"]
 # Complete test environment, including the optional SSH backend exercised by
 # the transport suite.
-dev = ["pytest>=7.0", "paramiko>=3.5"]
+dev = ["pytest>=7.0", "paramiko>=3.5", "PySocks>=1.7.1"]
 
 [project.scripts]
 virtuoso-bridge = "virtuoso_bridge.cli:main"

--- a/src/virtuoso_bridge/cli.py
+++ b/src/virtuoso_bridge/cli.py
@@ -835,6 +835,7 @@ def _make_ssh_runner() -> tuple["SSHRunner | None", str]:
         jump_user=jump_user,
         backend=backend_env.backend,
         max_sessions=backend_env.max_sessions,
+        proxy_url=backend_env.proxy_url,
     ), remote_user
 
 

--- a/src/virtuoso_bridge/cli.py
+++ b/src/virtuoso_bridge/cli.py
@@ -17,6 +17,7 @@ from virtuoso_bridge.transport.ssh import (
     SSHRunner,
     remote_ssh_env_from_os,
     ssh_backend_env_from_os,
+    ssh_proxy_url_from_os,
 )
 
 
@@ -828,6 +829,7 @@ def _make_ssh_runner() -> tuple["SSHRunner | None", str]:
     if _is_localhost(remote_host):
         return None, remote_user
     backend_env = ssh_backend_env_from_os(profile)
+    proxy_url = ssh_proxy_url_from_os(profile)
     return SSHRunner(
         host=remote_host,
         user=remote_user,
@@ -835,7 +837,7 @@ def _make_ssh_runner() -> tuple["SSHRunner | None", str]:
         jump_user=jump_user,
         backend=backend_env.backend,
         max_sessions=backend_env.max_sessions,
-        proxy_url=backend_env.proxy_url,
+        proxy_url=proxy_url,
     ), remote_user
 
 

--- a/src/virtuoso_bridge/resources/.env_template
+++ b/src/virtuoso_bridge/resources/.env_template
@@ -41,6 +41,9 @@ VB_LOCAL_PORT={local_port}
 # Set this no higher than the target sshd MaxSessions value.  Extra local work
 # waits for a session permit instead of opening another SSH connection.
 # VB_SSH_MAX_SESSIONS=10
+# Paramiko backend only: route the first SSH hop through an unauthenticated
+# SOCKS5 proxy.  The proxy resolves the proxied first-hop hostname.
+# VB_SSH_PROXY=socks5://127.0.0.1:10800
 
 # OpenSSH backend only: if your SSH build supports ControlMaster multiplexing,
 # it is enabled by default. To force it for a nonstandard Windows SSH build:

--- a/src/virtuoso_bridge/spectre/runner.py
+++ b/src/virtuoso_bridge/spectre/runner.py
@@ -629,6 +629,7 @@ class SpectreSimulator:
         self._profile = profile
         self._ssh_backend: str | None = None
         self._ssh_max_sessions: int | None = None
+        self._ssh_proxy_url: str | None = None
 
         rh, ru, jh, ju = remote_host, remote_user, jump_host, jump_user
         if remote:
@@ -636,6 +637,7 @@ class SpectreSimulator:
             backend_env = ssh_backend_env_from_os(profile)
             self._ssh_backend = backend_env.backend
             self._ssh_max_sessions = backend_env.max_sessions
+            self._ssh_proxy_url = backend_env.proxy_url
             if rh is None:
                 rh = env.remote_host
             if ru is None:
@@ -1012,6 +1014,7 @@ class SpectreSimulator:
                 persistent_shell=True,
                 backend=self._ssh_backend,
                 max_sessions=self._ssh_max_sessions,
+                proxy_url=self._ssh_proxy_url,
                 verbose=True,
             )
         return self._ssh_runner

--- a/src/virtuoso_bridge/spectre/runner.py
+++ b/src/virtuoso_bridge/spectre/runner.py
@@ -36,6 +36,7 @@ from virtuoso_bridge.transport.ssh import (
     run_remote_task,
     remote_ssh_env_from_os,
     ssh_backend_env_from_os,
+    ssh_proxy_url_from_os,
 )
 
 logger = logging.getLogger(__name__)
@@ -637,7 +638,7 @@ class SpectreSimulator:
             backend_env = ssh_backend_env_from_os(profile)
             self._ssh_backend = backend_env.backend
             self._ssh_max_sessions = backend_env.max_sessions
-            self._ssh_proxy_url = backend_env.proxy_url
+            self._ssh_proxy_url = ssh_proxy_url_from_os(profile)
             if rh is None:
                 rh = env.remote_host
             if ru is None:

--- a/src/virtuoso_bridge/transport/__init__.py
+++ b/src/virtuoso_bridge/transport/__init__.py
@@ -13,6 +13,7 @@ from virtuoso_bridge.transport.ssh import (
     run_remote_task,
     remote_ssh_env_from_os,
     ssh_backend_env_from_os,
+    ssh_proxy_url_from_os,
 )
 
 __all__ = [
@@ -23,6 +24,7 @@ __all__ = [
     "run_remote_task",
     "remote_ssh_env_from_os",
     "ssh_backend_env_from_os",
+    "ssh_proxy_url_from_os",
     "default_virtuoso_bridge_dir",
     "remote_scratch_root",
     "resolve_remote_username",

--- a/src/virtuoso_bridge/transport/paramiko_backend.py
+++ b/src/virtuoso_bridge/transport/paramiko_backend.py
@@ -68,6 +68,12 @@ class _ProxyJump:
     port: int | None
 
 
+@dataclass(frozen=True)
+class _Socks5Proxy:
+    host: str
+    port: int
+
+
 _SSH_PATH_TOKEN_RE = re.compile(r"%([%CdhikLlnpru])")
 _PROXY_TOKEN_RE = re.compile(r"%([%hnpr])")
 
@@ -233,6 +239,7 @@ class ParamikoSessionBackend:
         ssh_cmd: str = "ssh",
         connect_timeout: float,
         max_sessions: int,
+        proxy_url: str | None = None,
     ) -> None:
         if max_sessions < 1:
             raise ValueError("Paramiko max_sessions must be at least 1")
@@ -254,6 +261,17 @@ class ParamikoSessionBackend:
         self._ssh_cmd = ssh_cmd
         self._connect_timeout = float(connect_timeout)
         self._max_sessions = max_sessions
+        self._proxy = self._parse_socks5_proxy(proxy_url)
+        self._socks: Any | None = None
+        if self._proxy is not None:
+            try:
+                import socks
+            except ImportError as exc:
+                raise RuntimeError(
+                    "VB_SSH_PROXY requires PySocks. "
+                    "Install virtuoso-bridge with `uv pip install -e '.[ssh]'`."
+                ) from exc
+            self._socks = socks
         self._session_gate = threading.BoundedSemaphore(max_sessions)
         self._connect_lock = threading.RLock()
         self._jump_client: Any | None = None
@@ -274,6 +292,35 @@ class ParamikoSessionBackend:
     @property
     def max_sessions(self) -> int:
         return self._max_sessions
+
+    @staticmethod
+    def _parse_socks5_proxy(value: str | None) -> _Socks5Proxy | None:
+        if value is None or not value.strip():
+            return None
+        spec = value.strip()
+        try:
+            parsed = urlsplit(spec)
+            hostname = parsed.hostname
+            port = parsed.port
+        except ValueError as exc:
+            raise ValueError("VB_SSH_PROXY contains an invalid URL") from exc
+        if (
+            parsed.scheme.lower() != "socks5"
+            or hostname is None
+            or parsed.path
+            or parsed.query
+            or parsed.fragment
+            or parsed.username is not None
+            or parsed.password is not None
+        ):
+            raise ValueError(
+                "VB_SSH_PROXY must use socks5://host:port without credentials"
+            )
+        if port is None:
+            raise ValueError("VB_SSH_PROXY must include an explicit port")
+        if not 1 <= port <= 65535:
+            raise ValueError("VB_SSH_PROXY contains an invalid port")
+        return _Socks5Proxy(host=hostname, port=port)
 
     def _lookup(
         self,
@@ -544,10 +591,10 @@ class ParamikoSessionBackend:
     ) -> _ProxyJump | None:
         lookup = self._lookup(host, user, port)
         proxy_command = lookup.get("proxycommand")
-        if proxy_command is not None:
+        if proxy_command is not None and self._proxy is None:
             raise ValueError(
                 f"Paramiko backend does not support ProxyCommand for host {host!r}; "
-                "use ProxyJump or VB_JUMP_HOST"
+                "use ProxyJump, VB_JUMP_HOST, or VB_SSH_PROXY"
             )
         raw_proxy_jump = str(lookup.get("proxyjump") or "")
         if raw_proxy_jump:
@@ -629,6 +676,24 @@ class ParamikoSessionBackend:
             and transport.is_authenticated()
         )
 
+    def _open_proxy_socket(
+        self,
+        endpoint: _Endpoint,
+        deadline: _Deadline,
+    ) -> Any | None:
+        proxy = self._proxy
+        if proxy is None:
+            return None
+        assert self._socks is not None
+        return self._socks.create_connection(
+            (endpoint.hostname, endpoint.port),
+            timeout=deadline.remaining(endpoint.hostname),
+            proxy_type=self._socks.SOCKS5,
+            proxy_addr=proxy.host,
+            proxy_port=proxy.port,
+            proxy_rdns=True,
+        )
+
     def _connect_client(
         self,
         endpoint: _Endpoint,
@@ -704,9 +769,16 @@ class ParamikoSessionBackend:
             jump_client = None
             jump_channel = None
             target_client = None
+            proxy_socket = None
             try:
                 if jump_endpoint is not None:
-                    jump_client = self._connect_client(jump_endpoint, deadline)
+                    proxy_socket = self._open_proxy_socket(jump_endpoint, deadline)
+                    jump_client = self._connect_client(
+                        jump_endpoint,
+                        deadline,
+                        sock=proxy_socket,
+                    )
+                    proxy_socket = None
                     jump_transport = jump_client.get_transport()
                     if jump_transport is None:
                         raise OSError("Jump-host SSH transport is unavailable")
@@ -716,11 +788,18 @@ class ParamikoSessionBackend:
                         ("127.0.0.1", 0),
                         timeout=deadline.remaining(target_endpoint.hostname),
                     )
+                else:
+                    proxy_socket = self._open_proxy_socket(target_endpoint, deadline)
                 target_client = self._connect_client(
                     target_endpoint,
                     deadline,
-                    sock=jump_channel,
+                    sock=(
+                        jump_channel
+                        if jump_channel is not None
+                        else proxy_socket
+                    ),
                 )
+                proxy_socket = None
             except Exception:
                 if target_client is not None:
                     target_client.close()
@@ -728,6 +807,8 @@ class ParamikoSessionBackend:
                     jump_channel.close()
                 if jump_client is not None:
                     jump_client.close()
+                if proxy_socket is not None:
+                    proxy_socket.close()
                 raise
 
             self._jump_client = jump_client

--- a/src/virtuoso_bridge/transport/paramiko_backend.py
+++ b/src/virtuoso_bridge/transport/paramiko_backend.py
@@ -334,6 +334,11 @@ class ParamikoSessionBackend:
             return cached
 
         command = [self._ssh_cmd, "-G"]
+        if self._proxy is not None:
+            # ssh -G can otherwise perform local DNS lookups when a user's
+            # config enables hostname canonicalization. The SOCKS5 proxy must
+            # remain the resolver for the proxied first hop.
+            command.extend(["-o", "CanonicalizeHostname=no"])
         if self._ssh_config_path is not None:
             command.extend(["-F", str(self._ssh_config_path)])
         if user is not None:
@@ -676,6 +681,44 @@ class ParamikoSessionBackend:
             and transport.is_authenticated()
         )
 
+    @staticmethod
+    def _resolve_proxy_addresses(
+        proxy: _Socks5Proxy,
+        deadline: _Deadline,
+    ) -> list[tuple[Any, ...]]:
+        command = f"SOCKS5 proxy {proxy.host}:{proxy.port}"
+        results: "queue.Queue[tuple[list[tuple[Any, ...]] | None, Exception | None]]" = (
+            queue.Queue(maxsize=1)
+        )
+
+        def resolve() -> None:
+            try:
+                addresses = socket.getaddrinfo(
+                    proxy.host,
+                    proxy.port,
+                    type=socket.SOCK_STREAM,
+                )
+            except Exception as exc:  # noqa: BLE001 - propagated on caller thread
+                results.put((None, exc))
+            else:
+                results.put((list(addresses), None))
+
+        resolver = threading.Thread(
+            target=resolve,
+            name="virtuoso-bridge-socks5-resolver",
+            daemon=True,
+        )
+        resolver.start()
+        try:
+            addresses, error = results.get(timeout=deadline.remaining(command))
+        except queue.Empty as exc:
+            raise subprocess.TimeoutExpired(command, deadline.timeout) from exc
+        if error is not None:
+            raise error
+        if not addresses:
+            raise OSError(f"Could not resolve {command}")
+        return addresses
+
     def _open_proxy_socket(
         self,
         endpoint: _Endpoint,
@@ -685,14 +728,74 @@ class ParamikoSessionBackend:
         if proxy is None:
             return None
         assert self._socks is not None
-        return self._socks.create_connection(
-            (endpoint.hostname, endpoint.port),
-            timeout=deadline.remaining(endpoint.hostname),
-            proxy_type=self._socks.SOCKS5,
-            proxy_addr=proxy.host,
-            proxy_port=proxy.port,
-            proxy_rdns=True,
+        last_error: OSError | None = None
+        for family, socket_type, protocol, _canonical_name, address in (
+            self._resolve_proxy_addresses(proxy, deadline)
+        ):
+            proxy_socket = None
+            try:
+                proxy_socket = self._socks.socksocket(
+                    family,
+                    socket_type,
+                    protocol,
+                )
+                proxy_socket.settimeout(deadline.remaining(endpoint.hostname))
+                proxy_socket.set_proxy(
+                    proxy_type=self._socks.SOCKS5,
+                    addr=address[0],
+                    port=proxy.port,
+                    rdns=True,
+                )
+                self._connect_proxy_socket(proxy_socket, endpoint, deadline)
+                return proxy_socket
+            except subprocess.TimeoutExpired:
+                if proxy_socket is not None:
+                    proxy_socket.close()
+                raise
+            except OSError as exc:
+                last_error = exc
+                if proxy_socket is not None:
+                    proxy_socket.close()
+            except Exception:
+                if proxy_socket is not None:
+                    proxy_socket.close()
+                raise
+        if last_error is not None:
+            raise last_error
+        raise OSError(f"No usable address found for SOCKS5 proxy {proxy.host}")
+
+    @staticmethod
+    def _connect_proxy_socket(
+        proxy_socket: Any,
+        endpoint: _Endpoint,
+        deadline: _Deadline,
+    ) -> None:
+        results: "queue.Queue[Exception | None]" = queue.Queue(maxsize=1)
+
+        def connect() -> None:
+            try:
+                proxy_socket.connect((endpoint.hostname, endpoint.port))
+            except Exception as exc:  # noqa: BLE001 - propagated on caller thread
+                results.put(exc)
+            else:
+                results.put(None)
+
+        connector = threading.Thread(
+            target=connect,
+            name="virtuoso-bridge-socks5-connector",
+            daemon=True,
         )
+        connector.start()
+        try:
+            error = results.get(timeout=deadline.remaining(endpoint.hostname))
+        except queue.Empty as exc:
+            proxy_socket.close()
+            raise subprocess.TimeoutExpired(
+                endpoint.hostname,
+                deadline.timeout,
+            ) from exc
+        if error is not None:
+            raise error
 
     def _connect_client(
         self,

--- a/src/virtuoso_bridge/transport/ssh.py
+++ b/src/virtuoso_bridge/transport/ssh.py
@@ -104,25 +104,27 @@ class SshBackendEnv(NamedTuple):
 
     backend: str | None
     max_sessions: int | None
-    proxy_url: str | None = None
+
+
+def _profile_or_global_ssh_setting(name: str, profile: str | None) -> str:
+    suffix = f"_{profile}" if profile else ""
+    if suffix:
+        profiled = os.environ.get(f"{name}{suffix}", "").strip()
+        if profiled:
+            return profiled
+    return os.environ.get(name, "").strip()
 
 
 def ssh_backend_env_from_os(profile: str | None = None) -> SshBackendEnv:
     """Read profile-specific SSH backend settings with global fallback."""
     profile = resolve_profile(profile)
     load_vb_env()
-    suffix = f"_{profile}" if profile else ""
 
-    def _profile_or_global(name: str) -> str:
-        if suffix:
-            profiled = os.environ.get(f"{name}{suffix}", "").strip()
-            if profiled:
-                return profiled
-        return os.environ.get(name, "").strip()
-
-    backend = _profile_or_global("VB_SSH_BACKEND") or None
-    proxy_url = _profile_or_global("VB_SSH_PROXY") or None
-    raw_max_sessions = _profile_or_global("VB_SSH_MAX_SESSIONS")
+    backend = _profile_or_global_ssh_setting("VB_SSH_BACKEND", profile) or None
+    raw_max_sessions = _profile_or_global_ssh_setting(
+        "VB_SSH_MAX_SESSIONS",
+        profile,
+    )
     max_sessions: int | None = None
     if raw_max_sessions:
         try:
@@ -131,11 +133,14 @@ def ssh_backend_env_from_os(profile: str | None = None) -> SshBackendEnv:
             raise ValueError("VB_SSH_MAX_SESSIONS must be a positive integer") from exc
         if max_sessions < 1:
             raise ValueError("VB_SSH_MAX_SESSIONS must be a positive integer")
-    return SshBackendEnv(
-        backend=backend,
-        max_sessions=max_sessions,
-        proxy_url=proxy_url,
-    )
+    return SshBackendEnv(backend=backend, max_sessions=max_sessions)
+
+
+def ssh_proxy_url_from_os(profile: str | None = None) -> str | None:
+    """Read the profile-aware Paramiko SOCKS5 proxy URL."""
+    profile = resolve_profile(profile)
+    load_vb_env()
+    return _profile_or_global_ssh_setting("VB_SSH_PROXY", profile) or None
 
 
 def remote_ssh_env_from_os(profile: str | None = None) -> RemoteSshEnv:
@@ -296,8 +301,8 @@ class SSHRunner:
         persistent_shell: bool = False,
         backend: str | None = None,
         max_sessions: int | None = None,
-        proxy_url: str | None = None,
         verbose: bool = False,
+        proxy_url: str | None = None,
     ) -> None:
         load_vb_env()
         _setup_command_log()

--- a/src/virtuoso_bridge/transport/ssh.py
+++ b/src/virtuoso_bridge/transport/ssh.py
@@ -104,6 +104,7 @@ class SshBackendEnv(NamedTuple):
 
     backend: str | None
     max_sessions: int | None
+    proxy_url: str | None = None
 
 
 def ssh_backend_env_from_os(profile: str | None = None) -> SshBackendEnv:
@@ -120,6 +121,7 @@ def ssh_backend_env_from_os(profile: str | None = None) -> SshBackendEnv:
         return os.environ.get(name, "").strip()
 
     backend = _profile_or_global("VB_SSH_BACKEND") or None
+    proxy_url = _profile_or_global("VB_SSH_PROXY") or None
     raw_max_sessions = _profile_or_global("VB_SSH_MAX_SESSIONS")
     max_sessions: int | None = None
     if raw_max_sessions:
@@ -129,7 +131,11 @@ def ssh_backend_env_from_os(profile: str | None = None) -> SshBackendEnv:
             raise ValueError("VB_SSH_MAX_SESSIONS must be a positive integer") from exc
         if max_sessions < 1:
             raise ValueError("VB_SSH_MAX_SESSIONS must be a positive integer")
-    return SshBackendEnv(backend=backend, max_sessions=max_sessions)
+    return SshBackendEnv(
+        backend=backend,
+        max_sessions=max_sessions,
+        proxy_url=proxy_url,
+    )
 
 
 def remote_ssh_env_from_os(profile: str | None = None) -> RemoteSshEnv:
@@ -290,6 +296,7 @@ class SSHRunner:
         persistent_shell: bool = False,
         backend: str | None = None,
         max_sessions: int | None = None,
+        proxy_url: str | None = None,
         verbose: bool = False,
     ) -> None:
         load_vb_env()
@@ -323,6 +330,11 @@ class SSHRunner:
         if max_sessions < 1:
             raise ValueError("VB_SSH_MAX_SESSIONS must be a positive integer")
         self._max_sessions = max_sessions
+        self._proxy_url = (
+            proxy_url
+            if proxy_url is not None
+            else (os.environ.get("VB_SSH_PROXY", "").strip() or None)
+        )
 
         env_ssh_cmd = _tool_override_from_env("VB_SSH_CMD")
         env_scp_cmd = _tool_override_from_env("VB_SCP_CMD")
@@ -398,6 +410,7 @@ class SSHRunner:
                 ssh_cmd=self._ssh_cmd,
                 connect_timeout=connect_timeout,
                 max_sessions=max_sessions,
+                proxy_url=self._proxy_url,
             )
 
     @property

--- a/src/virtuoso_bridge/transport/tunnel.py
+++ b/src/virtuoso_bridge/transport/tunnel.py
@@ -160,6 +160,7 @@ class SSHClient:
         profile: str | None = None,
         ssh_backend: str | None = None,
         ssh_max_sessions: int | None = None,
+        ssh_proxy_url: str | None = None,
     ) -> None:
         self._remote_host = remote_host
         self._remote_user = remote_user
@@ -182,6 +183,7 @@ class SSHClient:
                 persistent_shell=True,
                 backend=ssh_backend,
                 max_sessions=ssh_max_sessions,
+                proxy_url=ssh_proxy_url,
                 verbose=True,
             )
 
@@ -241,6 +243,7 @@ class SSHClient:
             profile=profile,
             ssh_backend=backend_env.backend,
             ssh_max_sessions=backend_env.max_sessions,
+            ssh_proxy_url=backend_env.proxy_url,
         )
 
     # -- properties ---------------------------------------------------------

--- a/src/virtuoso_bridge/transport/tunnel.py
+++ b/src/virtuoso_bridge/transport/tunnel.py
@@ -31,6 +31,7 @@ from virtuoso_bridge.transport.ssh import (
     SSHRunner,
     CommandResult,
     ssh_backend_env_from_os,
+    ssh_proxy_url_from_os,
 )
 
 logger = logging.getLogger(__name__)
@@ -215,6 +216,7 @@ class SSHClient:
         jump_host = os.getenv(f"VB_JUMP_HOST{suffix}", "").strip() or None
         jump_user = os.getenv(f"VB_JUMP_USER{suffix}", "").strip() or None
         backend_env = ssh_backend_env_from_os(profile)
+        ssh_proxy_url = ssh_proxy_url_from_os(profile)
 
         # Port
         from virtuoso_bridge.virtuoso.basic.bridge import _default_remote_port
@@ -243,7 +245,7 @@ class SSHClient:
             profile=profile,
             ssh_backend=backend_env.backend,
             ssh_max_sessions=backend_env.max_sessions,
-            ssh_proxy_url=backend_env.proxy_url,
+            ssh_proxy_url=ssh_proxy_url,
         )
 
     # -- properties ---------------------------------------------------------

--- a/tests/test_paramiko_ssh_backend.py
+++ b/tests/test_paramiko_ssh_backend.py
@@ -26,6 +26,7 @@ from virtuoso_bridge.transport.ssh import (
     SSHRunner,
     SshBackendEnv,
     ssh_backend_env_from_os,
+    ssh_proxy_url_from_os,
 )
 from virtuoso_bridge.transport.transfer import (
     FileDownloadPlan,
@@ -154,6 +155,65 @@ def test_openssh_backend_does_not_parse_paramiko_proxy_setting(monkeypatch) -> N
     assert runner._paramiko_backend is None
 
 
+def test_paramiko_proxy_does_not_change_openssh_port_forward_command(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class _TunnelProcess:
+        pid = 12345
+
+        @staticmethod
+        def poll():
+            return None
+
+    class _TemporaryStderr:
+        name = str(tmp_path / "tunnel-stderr.log")
+
+        def close(self) -> None:
+            Path(self.name).touch()
+
+    def fake_popen(command, **kwargs):
+        captured["command"] = command
+        stderr = kwargs.get("stderr")
+        if hasattr(stderr, "close"):
+            stderr.close()
+        return _TunnelProcess()
+
+    monkeypatch.setattr("virtuoso_bridge.transport.ssh.load_vb_env", lambda: None)
+    monkeypatch.setattr("virtuoso_bridge.transport.ssh._setup_command_log", lambda: None)
+    monkeypatch.setattr(
+        "virtuoso_bridge.transport.paramiko_backend.ParamikoSessionBackend",
+        _DispatchBackend,
+    )
+    monkeypatch.setattr(
+        "virtuoso_bridge.transport.ssh.tempfile.NamedTemporaryFile",
+        lambda **_kwargs: _TemporaryStderr(),
+    )
+    monkeypatch.setattr(
+        "virtuoso_bridge.transport.ssh.subprocess.Popen",
+        fake_popen,
+    )
+
+    runner = SSHRunner(
+        host="compute",
+        user="designer",
+        backend="paramiko",
+        proxy_url="socks5://127.0.0.1:10800",
+    )
+    runner.can_reach_port = lambda _port: True  # type: ignore[method-assign]
+
+    runner.start_port_forward(65080, settle=0, remote_port=65081)
+
+    command = captured["command"]
+    assert isinstance(command, list)
+    assert ["-L", "65080:127.0.0.1:65081"] == command[
+        command.index("-L") : command.index("-L") + 2
+    ]
+    assert "socks5://127.0.0.1:10800" not in command
+
+
 def test_profile_specific_paramiko_settings_reach_ssh_runner(monkeypatch) -> None:
     captured: dict[str, object] = {}
 
@@ -184,15 +244,46 @@ def test_profile_ssh_proxy_uses_global_fallback(monkeypatch) -> None:
     monkeypatch.delenv("VB_SSH_PROXY_worker", raising=False)
     monkeypatch.setenv("VB_SSH_PROXY", "socks5://127.0.0.1:10800")
 
-    settings = ssh_backend_env_from_os("worker")
+    proxy_url = ssh_proxy_url_from_os("worker")
 
-    assert settings.proxy_url == "socks5://127.0.0.1:10800"
+    assert proxy_url == "socks5://127.0.0.1:10800"
 
 
-def test_ssh_backend_env_keeps_two_argument_construction_compatible() -> None:
+def test_ssh_backend_env_keeps_two_value_unpacking_compatible(monkeypatch) -> None:
+    monkeypatch.setattr("virtuoso_bridge.transport.ssh.load_vb_env", lambda: None)
+    monkeypatch.setenv("VB_SSH_BACKEND", "paramiko")
+    monkeypatch.setenv("VB_SSH_MAX_SESSIONS", "10")
     settings = SshBackendEnv("paramiko", 10)
+    backend, max_sessions = settings
+    resolved_backend, resolved_max_sessions = ssh_backend_env_from_os()
 
-    assert settings.proxy_url is None
+    assert (backend, max_sessions) == ("paramiko", 10)
+    assert (resolved_backend, resolved_max_sessions) == ("paramiko", 10)
+
+
+def test_ssh_runner_keeps_legacy_verbose_positional_argument(monkeypatch) -> None:
+    monkeypatch.setattr("virtuoso_bridge.transport.ssh.load_vb_env", lambda: None)
+    monkeypatch.setattr("virtuoso_bridge.transport.ssh._setup_command_log", lambda: None)
+    monkeypatch.delenv("VB_SSH_PROXY", raising=False)
+
+    runner = SSHRunner(
+        "compute",
+        "designer",
+        None,
+        None,
+        None,
+        None,
+        "ssh",
+        600,
+        30,
+        False,
+        "openssh",
+        10,
+        True,
+    )
+
+    assert runner._verbose is True
+    assert runner._proxy_url is None
 
 
 def _configured_backend(
@@ -449,6 +540,40 @@ def test_explicit_socks_proxy_overrides_proxycommand(
     assert backend._jump_endpoint is None
 
 
+def test_socks5_proxy_disables_openssh_hostname_canonicalization(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config = tmp_path / "config"
+    config.touch()
+    calls = _mock_ssh_g(
+        monkeypatch,
+        {
+            ("private-compute", None, None): _resolved_config(
+                hostname="private-compute.internal",
+            ),
+        },
+    )
+
+    _configured_backend(
+        config,
+        host="private-compute",
+        proxy_url="socks5://127.0.0.1:10800",
+    )
+
+    assert calls == [
+        [
+            "ssh",
+            "-G",
+            "-o",
+            "CanonicalizeHostname=no",
+            "-F",
+            str(config),
+            "private-compute",
+        ]
+    ]
+
+
 def test_nested_proxyjump_fails_before_connect(monkeypatch, tmp_path: Path) -> None:
     config = tmp_path / "config"
     config.touch()
@@ -667,9 +792,153 @@ def test_blank_socks5_proxy_preserves_direct_routing() -> None:
     assert ParamikoSessionBackend._parse_socks5_proxy("  ") is None
 
 
+def test_socks5_proxy_dns_resolution_respects_total_deadline(monkeypatch) -> None:
+    resolver_started = threading.Event()
+    release_resolver = threading.Event()
+
+    def blocking_getaddrinfo(*_args, **_kwargs):
+        resolver_started.set()
+        release_resolver.wait(timeout=1)
+        return []
+
+    monkeypatch.setattr(socket, "getaddrinfo", blocking_getaddrinfo)
+    try:
+        with pytest.raises(subprocess.TimeoutExpired):
+            ParamikoSessionBackend._resolve_proxy_addresses(
+                _Socks5Proxy("proxy.example", 1080),
+                _Deadline.start(0.05),
+            )
+    finally:
+        release_resolver.set()
+
+    assert resolver_started.is_set()
+
+
+def test_socks5_proxy_handshake_respects_total_deadline() -> None:
+    release_connector = threading.Event()
+
+    class _BlockingProxySocket:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def connect(self, _destination) -> None:
+            release_connector.wait(timeout=1)
+
+        def close(self) -> None:
+            self.closed = True
+
+    proxy_socket = _BlockingProxySocket()
+    endpoint = _Endpoint(
+        host_alias="compute",
+        hostname="compute.internal",
+        username="designer",
+        port=22,
+        key_filenames=(),
+    )
+    try:
+        with pytest.raises(subprocess.TimeoutExpired):
+            ParamikoSessionBackend._connect_proxy_socket(
+                proxy_socket,
+                endpoint,
+                _Deadline.start(0.05),
+            )
+    finally:
+        release_connector.set()
+
+    assert proxy_socket.closed
+
+
+def test_socks5_proxy_address_attempts_use_remaining_deadline() -> None:
+    class _AddressSocket:
+        def __init__(self, index: int) -> None:
+            self.index = index
+            self.timeout: float | None = None
+            self.proxy_args: dict[str, object] = {}
+            self.closed = False
+
+        def settimeout(self, timeout: float) -> None:
+            self.timeout = timeout
+
+        def set_proxy(self, **kwargs) -> None:
+            self.proxy_args = kwargs
+
+        def connect(self, _destination) -> None:
+            if self.index == 0:
+                time.sleep(0.03)
+                raise OSError("first proxy address failed")
+
+        def close(self) -> None:
+            self.closed = True
+
+    class _AddressSocksModule:
+        SOCKS5 = object()
+
+        def __init__(self) -> None:
+            self.sockets: list[_AddressSocket] = []
+
+        def socksocket(self, _family, _socket_type, _protocol):
+            proxy_socket = _AddressSocket(len(self.sockets))
+            self.sockets.append(proxy_socket)
+            return proxy_socket
+
+    endpoint = _Endpoint(
+        host_alias="compute",
+        hostname="compute.internal",
+        username="designer",
+        port=22,
+        key_filenames=(),
+    )
+    backend = ParamikoSessionBackend.__new__(ParamikoSessionBackend)
+    backend._proxy = _Socks5Proxy("proxy.example", 1080)
+    backend._socks = _AddressSocksModule()
+    backend._resolve_proxy_addresses = lambda _proxy, _deadline: [
+        (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("192.0.2.1", 1080)),
+        (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("192.0.2.2", 1080)),
+    ]
+
+    connected = backend._open_proxy_socket(endpoint, _Deadline.start(0.2))
+
+    first, second = backend._socks.sockets
+    assert connected is second
+    assert first.closed
+    assert first.timeout is not None
+    assert second.timeout is not None
+    assert second.timeout < first.timeout
+    assert second.proxy_args == {
+        "proxy_type": backend._socks.SOCKS5,
+        "addr": "192.0.2.2",
+        "port": 1080,
+        "rdns": True,
+    }
+
+
 class _RoutingSocket:
-    def __init__(self) -> None:
+    def __init__(self, owner=None) -> None:
+        self.owner = owner
         self.closed = False
+        self.timeout: float | None = None
+        self.proxy_args: dict[str, object] = {}
+
+    def settimeout(self, timeout: float) -> None:
+        self.timeout = timeout
+
+    def set_proxy(self, **kwargs) -> None:
+        self.proxy_args = kwargs
+
+    def connect(self, destination: tuple[str, int]) -> None:
+        assert self.owner is not None
+        self.owner.calls.append(
+            (
+                destination,
+                {
+                    "timeout": self.timeout,
+                    "proxy_type": self.proxy_args["proxy_type"],
+                    "proxy_addr": self.proxy_args["addr"],
+                    "proxy_port": self.proxy_args["port"],
+                    "proxy_rdns": self.proxy_args["rdns"],
+                },
+            )
+        )
 
     def close(self) -> None:
         self.closed = True
@@ -710,9 +979,8 @@ class _FakeSocksModule:
         self.calls: list[tuple[tuple[str, int], dict[str, object]]] = []
         self.sockets: list[_RoutingSocket] = []
 
-    def create_connection(self, destination, **kwargs):
-        self.calls.append((destination, kwargs))
-        proxy_socket = _RoutingSocket()
+    def socksocket(self, _family, _socket_type, _protocol):
+        proxy_socket = _RoutingSocket(self)
         self.sockets.append(proxy_socket)
         return proxy_socket
 
@@ -735,6 +1003,9 @@ def _proxy_routing_backend(
     backend._target_client = None
     backend._jump_client = None
     backend._jump_channel = None
+    backend._resolve_proxy_addresses = lambda _proxy, _deadline: [
+        (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.1", 10800))
+    ]
     return backend, socks_module
 
 
@@ -830,6 +1101,34 @@ def test_socks5_proxy_socket_closes_when_ssh_connection_fails() -> None:
         backend.ensure_connected()
 
     assert socks_module.sockets[0].closed
+
+
+def test_socks5_proxy_failure_does_not_fall_back_to_direct_connection() -> None:
+    target = _Endpoint(
+        host_alias="compute",
+        hostname="compute.internal",
+        username="designer",
+        port=22,
+        key_filenames=(),
+    )
+    backend, _socks_module = _proxy_routing_backend(target=target)
+    direct_connect_called = False
+
+    def fail_proxy(_endpoint, _deadline):
+        raise OSError("SOCKS5 proxy refused the connection")
+
+    def connect_client(_endpoint, _deadline, *, sock=None):
+        nonlocal direct_connect_called
+        direct_connect_called = True
+        raise AssertionError("direct SSH connection must not be attempted")
+
+    backend._open_proxy_socket = fail_proxy  # type: ignore[method-assign]
+    backend._connect_client = connect_client  # type: ignore[method-assign]
+
+    with pytest.raises(OSError, match="SOCKS5 proxy refused"):
+        backend.ensure_connected()
+
+    assert not direct_connect_called
 
 
 class _FakeSSHException(Exception):

--- a/tests/test_paramiko_ssh_backend.py
+++ b/tests/test_paramiko_ssh_backend.py
@@ -19,9 +19,14 @@ from virtuoso_bridge.transport.paramiko_backend import (
     ParamikoSessionBackend,
     _Deadline,
     _Endpoint,
+    _Socks5Proxy,
     _default_known_hosts_files,
 )
-from virtuoso_bridge.transport.ssh import SSHRunner
+from virtuoso_bridge.transport.ssh import (
+    SSHRunner,
+    SshBackendEnv,
+    ssh_backend_env_from_os,
+)
 from virtuoso_bridge.transport.transfer import (
     FileDownloadPlan,
     TarDownloadPlan,
@@ -89,10 +94,12 @@ def test_ssh_runner_dispatches_to_explicit_paramiko_backend(
         jump_user="designer",
         backend="paramiko",
         max_sessions=7,
+        proxy_url="socks5://127.0.0.1:10800",
     )
     backend = _DispatchBackend.instance
     assert backend is not None
     assert backend.init_args["max_sessions"] == 7
+    assert backend.init_args["proxy_url"] == "socks5://127.0.0.1:10800"
     assert runner.backend == "paramiko"
     assert runner.max_sessions == 7
     assert not runner._use_control_master
@@ -132,6 +139,21 @@ def test_ssh_runner_dispatches_to_explicit_paramiko_backend(
     assert isinstance(backend.calls[6][1], FileDownloadPlan)
 
 
+def test_openssh_backend_does_not_parse_paramiko_proxy_setting(monkeypatch) -> None:
+    monkeypatch.setattr("virtuoso_bridge.transport.ssh.load_vb_env", lambda: None)
+    monkeypatch.setattr("virtuoso_bridge.transport.ssh._setup_command_log", lambda: None)
+
+    runner = SSHRunner(
+        host="compute",
+        user="designer",
+        backend="openssh",
+        proxy_url="not-a-proxy-url",
+    )
+
+    assert runner.backend == "openssh"
+    assert runner._paramiko_backend is None
+
+
 def test_profile_specific_paramiko_settings_reach_ssh_runner(monkeypatch) -> None:
     captured: dict[str, object] = {}
 
@@ -147,12 +169,30 @@ def test_profile_specific_paramiko_settings_reach_ssh_runner(monkeypatch) -> Non
     monkeypatch.setenv("VB_JUMP_HOST_worker", "bastion")
     monkeypatch.setenv("VB_SSH_BACKEND_worker", "paramiko")
     monkeypatch.setenv("VB_SSH_MAX_SESSIONS_worker", "255")
+    monkeypatch.setenv("VB_SSH_PROXY_worker", "socks5://127.0.0.1:10800")
 
     client = SSHClient.from_env(profile="worker")
 
     assert client.ssh_runner is not None
     assert captured["backend"] == "paramiko"
     assert captured["max_sessions"] == 255
+    assert captured["proxy_url"] == "socks5://127.0.0.1:10800"
+
+
+def test_profile_ssh_proxy_uses_global_fallback(monkeypatch) -> None:
+    monkeypatch.setattr("virtuoso_bridge.transport.ssh.load_vb_env", lambda: None)
+    monkeypatch.delenv("VB_SSH_PROXY_worker", raising=False)
+    monkeypatch.setenv("VB_SSH_PROXY", "socks5://127.0.0.1:10800")
+
+    settings = ssh_backend_env_from_os("worker")
+
+    assert settings.proxy_url == "socks5://127.0.0.1:10800"
+
+
+def test_ssh_backend_env_keeps_two_argument_construction_compatible() -> None:
+    settings = SshBackendEnv("paramiko", 10)
+
+    assert settings.proxy_url is None
 
 
 def _configured_backend(
@@ -163,6 +203,7 @@ def _configured_backend(
     jump_host: str | None = None,
     jump_user: str | None = None,
     ssh_key_path: Path | None = None,
+    proxy_url: str | None = None,
 ) -> ParamikoSessionBackend:
     return ParamikoSessionBackend(
         host=host,
@@ -174,6 +215,7 @@ def _configured_backend(
         ssh_cmd="ssh",
         connect_timeout=5,
         max_sessions=10,
+        proxy_url=proxy_url,
     )
 
 
@@ -380,6 +422,33 @@ def test_unsupported_paramiko_config_routing_fails_before_connect(
         _configured_backend(config)
 
 
+def test_explicit_socks_proxy_overrides_proxycommand(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config = tmp_path / "config"
+    config.touch()
+    _mock_ssh_g(
+        monkeypatch,
+        {
+            ("compute", None, None): _resolved_config(
+                proxycommand=(
+                    "ncat --proxy 127.0.0.1:10800 "
+                    "--proxy-type socks5 %h %p"
+                )
+            ),
+        },
+    )
+
+    backend = _configured_backend(
+        config,
+        proxy_url="socks5://127.0.0.1:10800",
+    )
+
+    assert backend._proxy == _Socks5Proxy("127.0.0.1", 10800)
+    assert backend._jump_endpoint is None
+
+
 def test_nested_proxyjump_fails_before_connect(monkeypatch, tmp_path: Path) -> None:
     config = tmp_path / "config"
     config.touch()
@@ -554,6 +623,213 @@ def test_proxyjump_token_expansion_preserves_url_percent_encoding() -> None:
     )
 
     assert expanded == "ssh://jump%40realm@compute.internal:2201"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("socks5://127.0.0.1:10800", ("127.0.0.1", 10800)),
+        ("socks5://proxy.example:1080", ("proxy.example", 1080)),
+        ("socks5://[2001:db8::1]:1080", ("2001:db8::1", 1080)),
+    ],
+)
+def test_socks5_proxy_parser_accepts_explicit_host_and_port(
+    value: str,
+    expected: tuple[str, int],
+) -> None:
+    parsed = ParamikoSessionBackend._parse_socks5_proxy(value)
+
+    assert parsed is not None
+    assert (parsed.host, parsed.port) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "http://127.0.0.1:1080",
+        "socks5://127.0.0.1",
+        "socks5://127.0.0.1:0",
+        "socks5://127.0.0.1:65536",
+        "socks5://user:password@127.0.0.1:1080",
+        "socks5://127.0.0.1:1080/route",
+        "socks5://127.0.0.1:1080?rdns=false",
+        "socks5://127.0.0.1:invalid",
+        "socks5://[::1:1080",
+    ],
+)
+def test_socks5_proxy_parser_rejects_unsupported_values(value: str) -> None:
+    with pytest.raises(ValueError, match="VB_SSH_PROXY"):
+        ParamikoSessionBackend._parse_socks5_proxy(value)
+
+
+def test_blank_socks5_proxy_preserves_direct_routing() -> None:
+    assert ParamikoSessionBackend._parse_socks5_proxy(None) is None
+    assert ParamikoSessionBackend._parse_socks5_proxy("  ") is None
+
+
+class _RoutingSocket:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _RoutingTransport:
+    def __init__(self, channel: object | None = None) -> None:
+        self.channel = channel
+        self.open_channel_calls: list[tuple] = []
+
+    def is_active(self) -> bool:
+        return True
+
+    def is_authenticated(self) -> bool:
+        return True
+
+    def open_channel(self, *args, **kwargs):
+        self.open_channel_calls.append((args, kwargs))
+        return self.channel
+
+
+class _RoutingClient:
+    def __init__(self, transport: _RoutingTransport) -> None:
+        self.transport = transport
+        self.closed = False
+
+    def get_transport(self) -> _RoutingTransport:
+        return self.transport
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeSocksModule:
+    SOCKS5 = object()
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[tuple[str, int], dict[str, object]]] = []
+        self.sockets: list[_RoutingSocket] = []
+
+    def create_connection(self, destination, **kwargs):
+        self.calls.append((destination, kwargs))
+        proxy_socket = _RoutingSocket()
+        self.sockets.append(proxy_socket)
+        return proxy_socket
+
+
+def _proxy_routing_backend(
+    *,
+    target: _Endpoint,
+    jump: _Endpoint | None = None,
+) -> tuple[ParamikoSessionBackend, _FakeSocksModule]:
+    backend = ParamikoSessionBackend.__new__(ParamikoSessionBackend)
+    socks_module = _FakeSocksModule()
+    backend._proxy = _Socks5Proxy("127.0.0.1", 10800)
+    backend._socks = socks_module
+    backend._host = target.host_alias
+    backend._connect_timeout = 5.0
+    backend._max_sessions = 8
+    backend._connect_lock = threading.RLock()
+    backend._target_endpoint = target
+    backend._jump_endpoint = jump
+    backend._target_client = None
+    backend._jump_client = None
+    backend._jump_channel = None
+    return backend, socks_module
+
+
+def test_socks5_proxy_connects_target_once_and_reuses_transport() -> None:
+    target = _Endpoint(
+        host_alias="compute",
+        hostname="compute.internal",
+        username="designer",
+        port=2201,
+        key_filenames=(),
+        host_key_alias="recorded-compute",
+    )
+    backend, socks_module = _proxy_routing_backend(target=target)
+    target_client = _RoutingClient(_RoutingTransport())
+    connect_calls: list[tuple[_Endpoint, object | None]] = []
+
+    def connect_client(endpoint, _deadline, *, sock=None):
+        connect_calls.append((endpoint, sock))
+        return target_client
+
+    backend._connect_client = connect_client  # type: ignore[method-assign]
+
+    backend.ensure_connected()
+    backend.ensure_connected()
+
+    assert len(socks_module.calls) == 1
+    destination, proxy_args = socks_module.calls[0]
+    assert destination == ("compute.internal", 2201)
+    assert proxy_args["proxy_type"] is socks_module.SOCKS5
+    assert proxy_args["proxy_addr"] == "127.0.0.1"
+    assert proxy_args["proxy_port"] == 10800
+    assert proxy_args["proxy_rdns"] is True
+    assert connect_calls == [(target, socks_module.sockets[0])]
+
+
+def test_socks5_proxy_connects_only_the_jump_host_first_hop() -> None:
+    target = _Endpoint(
+        host_alias="compute",
+        hostname="compute.internal",
+        username="designer",
+        port=22,
+        key_filenames=(),
+    )
+    jump = _Endpoint(
+        host_alias="bastion",
+        hostname="bastion.internal",
+        username="designer",
+        port=2202,
+        key_filenames=(),
+    )
+    backend, socks_module = _proxy_routing_backend(target=target, jump=jump)
+    jump_channel = _RoutingSocket()
+    jump_transport = _RoutingTransport(jump_channel)
+    jump_client = _RoutingClient(jump_transport)
+    target_client = _RoutingClient(_RoutingTransport())
+    connect_calls: list[tuple[_Endpoint, object | None]] = []
+
+    def connect_client(endpoint, _deadline, *, sock=None):
+        connect_calls.append((endpoint, sock))
+        return jump_client if endpoint is jump else target_client
+
+    backend._connect_client = connect_client  # type: ignore[method-assign]
+
+    backend.ensure_connected()
+
+    assert socks_module.calls[0][0] == ("bastion.internal", 2202)
+    assert connect_calls == [
+        (jump, socks_module.sockets[0]),
+        (target, jump_channel),
+    ]
+    assert jump_transport.open_channel_calls[0][0][:2] == (
+        "direct-tcpip",
+        ("compute.internal", 22),
+    )
+
+
+def test_socks5_proxy_socket_closes_when_ssh_connection_fails() -> None:
+    target = _Endpoint(
+        host_alias="compute",
+        hostname="compute.internal",
+        username="designer",
+        port=22,
+        key_filenames=(),
+    )
+    backend, socks_module = _proxy_routing_backend(target=target)
+
+    def connect_client(_endpoint, _deadline, *, sock=None):
+        raise OSError("SSH handshake failed")
+
+    backend._connect_client = connect_client  # type: ignore[method-assign]
+
+    with pytest.raises(OSError, match="SSH handshake failed"):
+        backend.ensure_connected()
+
+    assert socks_module.sockets[0].closed
 
 
 class _FakeSSHException(Exception):

--- a/tests/test_profile_resolver.py
+++ b/tests/test_profile_resolver.py
@@ -261,6 +261,45 @@ def test_spectre_simulator_direct_constructor_uses_resolved_profile(monkeypatch,
     assert captured["proxy_url"] == "socks5://127.0.0.1:10800"
 
 
+def test_spectre_simulator_from_env_preserves_profile_ssh_runner(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    _isolate_profile_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("VB_REMOTE_HOST_worker", "compute")
+    monkeypatch.setenv("VB_REMOTE_USER_worker", "designer")
+    monkeypatch.setenv("VB_SSH_BACKEND_worker", "paramiko")
+    monkeypatch.setenv("VB_SSH_PROXY_worker", "socks5://127.0.0.1:10800")
+    monkeypatch.setattr("virtuoso_bridge.spectre.runner.load_vb_env", lambda: None)
+    expected_runner = object()
+    calls: list[tuple[bool, str | None]] = []
+
+    class _Client:
+        ssh_runner = expected_runner
+
+    class _SSHClient:
+        @staticmethod
+        def is_running(profile=None):
+            return profile == "worker"
+
+        @staticmethod
+        def from_env(*, keep_remote_files=False, profile=None):
+            calls.append((keep_remote_files, profile))
+            return _Client()
+
+    monkeypatch.setattr("virtuoso_bridge.transport.tunnel.SSHClient", _SSHClient)
+
+    simulator = SpectreSimulator.from_env(
+        profile="worker",
+        keep_remote_files=True,
+    )
+
+    assert simulator._ssh_runner is expected_runner
+    assert simulator._profile == "worker"
+    assert simulator._remote_host == "compute"
+    assert calls == [(True, "worker")]
+
+
 def test_cli_profile_bind_show_clear(monkeypatch, tmp_path, capsys) -> None:
     _isolate_profile_env(monkeypatch, tmp_path)
     monkeypatch.setenv("VIRTUAL_ENV", str(tmp_path / ".venv"))

--- a/tests/test_profile_resolver.py
+++ b/tests/test_profile_resolver.py
@@ -236,6 +236,7 @@ def test_spectre_simulator_direct_constructor_uses_resolved_profile(monkeypatch,
     monkeypatch.setenv("VB_REMOTE_USER_t28_io", "designer")
     monkeypatch.setenv("VB_SSH_BACKEND_t28_io", "paramiko")
     monkeypatch.setenv("VB_SSH_MAX_SESSIONS_t28_io", "255")
+    monkeypatch.setenv("VB_SSH_PROXY_t28_io", "socks5://127.0.0.1:10800")
     monkeypatch.setattr("virtuoso_bridge.spectre.runner.load_vb_env", lambda: None)
     monkeypatch.setattr("virtuoso_bridge.transport.ssh.load_vb_env", lambda: None)
     captured: dict[str, object] = {}
@@ -257,6 +258,7 @@ def test_spectre_simulator_direct_constructor_uses_resolved_profile(monkeypatch,
     assert sim._remote_user == "designer"
     assert captured["backend"] == "paramiko"
     assert captured["max_sessions"] == 255
+    assert captured["proxy_url"] == "socks5://127.0.0.1:10800"
 
 
 def test_cli_profile_bind_show_clear(monkeypatch, tmp_path, capsys) -> None:

--- a/tests/test_x11_window_discovery.py
+++ b/tests/test_x11_window_discovery.py
@@ -196,6 +196,7 @@ def test_make_ssh_runner_uses_profile_backend_settings(monkeypatch) -> None:
     monkeypatch.setenv("VB_REMOTE_USER_worker", "designer")
     monkeypatch.setenv("VB_SSH_BACKEND_worker", "paramiko")
     monkeypatch.setenv("VB_SSH_MAX_SESSIONS_worker", "255")
+    monkeypatch.setenv("VB_SSH_PROXY_worker", "socks5://127.0.0.1:10800")
     monkeypatch.setattr("virtuoso_bridge.transport.ssh.load_vb_env", lambda: None)
     monkeypatch.setattr("virtuoso_bridge.transport.ssh.SSHRunner", _CapturedRunner)
 
@@ -205,6 +206,7 @@ def test_make_ssh_runner_uses_profile_backend_settings(monkeypatch) -> None:
     assert user == "designer"
     assert captured["backend"] == "paramiko"
     assert captured["max_sessions"] == 255
+    assert captured["proxy_url"] == "socks5://127.0.0.1:10800"
 
 
 def test_helper_exports_auto_detected_display(monkeypatch, capsys) -> None:


### PR DESCRIPTION
## Summary

- add profile-aware `VB_SSH_PROXY=socks5://host:port` support to the Paramiko command and file-transfer backend
- route direct target connections, or only the first jump-host hop, through SOCKS5 with remote DNS
- preserve the shared authenticated Paramiko Transport, bounded session pooling, known-hosts verification, and `HostKeyAlias`
- let an explicit `VB_SSH_PROXY` override SSH config `ProxyCommand`, with no fallback to a direct or independent OpenSSH connection
- add PySocks to the `ssh` and `dev` extras and document the configuration and scope

## Compatibility and scope

- when `VB_SSH_PROXY` is unset, existing Paramiko behavior is unchanged
- the OpenSSH backend ignores `VB_SSH_PROXY`
- the local `-L` tunnel managed by `virtuoso-bridge start` remains OpenSSH-based
- existing two-value `SshBackendEnv` unpacking and positional `SSHRunner(..., verbose)` calls remain compatible
- the initial implementation supports unauthenticated `socks5://host:port` URLs; proxy credentials and other proxy protocols are intentionally out of scope

## Hardening

- force `CanonicalizeHostname=no` during proxied SSH config lookup so the first-hop hostname is not resolved locally before SOCKS5
- apply one total connection deadline across proxy DNS resolution, multiple proxy addresses, and the SOCKS5 handshake
- close unowned proxy sockets on all connection failures
- fail closed when the proxy is unavailable

## Testing

- Python 3.11: `121 passed, 4 skipped` across the SSH/profile/transfer-focused suite
- Python 3.9: `121 passed, 4 skipped` across the same suite
- full Windows suite: `836 passed, 11 skipped, 31 failed`; the 31 failures match the clean upstream baseline and are existing Windows/environment failures
- real SOCKS5 integration on Windows 11 covered:
  - direct target and one-hop jump-host routing
  - proxy-side hostname resolution
  - 20 concurrent sessions sharing one Paramiko Transport
  - text, recursive directory, and binary round trips
  - Spectre discovery through the configured runner
  - an unavailable proxy returning failure without direct fallback

Closes #141
