### PR TITLE
fix: expose ocnPrint precision/width params in export_waveform

### DIFF
--- a/src/virtuoso_bridge/virtuoso/maestro/reader/runs.py
+++ b/src/virtuoso_bridge/virtuoso/maestro/reader/runs.py
@@ -333,8 +333,8 @@ def export_waveform(
     *,
     analysis: str = "ac",
     history: str = "",
-    precision: int = 6,
-    width: int = 14,
+    precision: int | None = None,
+    width: int | None = None,
 ) -> str:
     """Export a waveform via OCEAN to a local text file.
 
@@ -344,12 +344,31 @@ def export_waveform(
         local_path: where to save locally
         analysis: which analysis to select ("ac", "tran", "noise", etc.)
         history: explicit history name; auto-detected if empty
-        precision: ocnPrint significant digits (1-16)
-            Note: only prints `precision` digits if `width` >= `precision`.
-        width: ocnPrint column width in characters
+        precision: optional ocnPrint significant digits (1-16).  Omitted by
+            default so the user's OCEAN setup remains authoritative.
+        width: optional ocnPrint column width in characters (at least 4).
+            To display every requested significant digit, use a width greater
+            than or equal to precision.
 
     Returns the local file path.
     """
+    if precision is not None:
+        if type(precision) is not int:
+            raise TypeError("precision must be an int or None")
+        if not 1 <= precision <= 16:
+            raise ValueError("precision must be between 1 and 16")
+    if width is not None:
+        if type(width) is not int:
+            raise TypeError("width must be an int or None")
+        if width < 4:
+            raise ValueError("width must be at least 4")
+
+    format_args = ""
+    if precision is not None:
+        format_args += f" ?precision {precision}"
+    if width is not None:
+        format_args += f" ?width {width}"
+
     # Auto-detect history name from the current results dir.
     # The path shape is `.../maestro/results/maestro/{history}/...` where
     # `{history}` can be any name Cadence wrote — Interactive.N, sweep_*,
@@ -386,7 +405,7 @@ def export_waveform(
     client.execute_skill(f'selectResults("{analysis}")')
     client.execute_skill(
         f'ocnPrint({expression} '
-        f'?numberNotation \'scientific ?precision {precision} ?width {width} ?numSpaces 1 '
+        f'?numberNotation \'scientific{format_args} ?numSpaces 1 '
         f'?output "{remote_path}")')
 
     client.download_file(remote_path, local_path)

--- a/src/virtuoso_bridge/virtuoso/maestro/reader/runs.py
+++ b/src/virtuoso_bridge/virtuoso/maestro/reader/runs.py
@@ -333,6 +333,8 @@ def export_waveform(
     *,
     analysis: str = "ac",
     history: str = "",
+    precision: int = 6,
+    width: int = 14,
 ) -> str:
     """Export a waveform via OCEAN to a local text file.
 
@@ -342,6 +344,9 @@ def export_waveform(
         local_path: where to save locally
         analysis: which analysis to select ("ac", "tran", "noise", etc.)
         history: explicit history name; auto-detected if empty
+        precision: ocnPrint significant digits (1-16)
+            Note: only prints `precision` digits if `width` >= `precision`.
+        width: ocnPrint column width in characters
 
     Returns the local file path.
     """
@@ -381,7 +386,7 @@ def export_waveform(
     client.execute_skill(f'selectResults("{analysis}")')
     client.execute_skill(
         f'ocnPrint({expression} '
-        f'?numberNotation \'scientific ?numSpaces 1 '
+        f'?numberNotation \'scientific ?precision {precision} ?width {width} ?numSpaces 1 '
         f'?output "{remote_path}")')
 
     client.download_file(remote_path, local_path)

--- a/tests/test_maestro_read_results.py
+++ b/tests/test_maestro_read_results.py
@@ -26,6 +26,7 @@ import pytest
 
 from virtuoso_bridge.virtuoso.maestro.reader.runs import (
     _parse_detail_csv,
+    export_waveform,
     read_results,
 )
 
@@ -198,3 +199,78 @@ def test_read_results_logs_when_test_lookup_fails(caplog):
     assert out == {}
     assert any("maeGetSetup returned no test" in r.message
                for r in caplog.records)
+
+
+def _waveform_client(history: str = "Interactive.7") -> _FakeClient:
+    return _FakeClient(
+        skill_responses=[
+            "t",
+            f'"/tmp/maestro/results/maestro/{history}/psf/"',
+            "t",
+        ],
+        on_download=lambda *_: None,
+    )
+
+
+def test_export_waveform_preserves_ocean_format_defaults():
+    client = _waveform_client()
+
+    export_waveform(
+        client,
+        session="sess_1",
+        expression='v("/OUT")',
+        local_path="wave.txt",
+        history="Interactive.7",
+    )
+
+    ocn_print = next(call for call in client.skill_calls
+                     if call.startswith("ocnPrint("))
+    assert "?precision" not in ocn_print
+    assert "?width" not in ocn_print
+
+
+def test_export_waveform_passes_explicit_format_options():
+    client = _waveform_client()
+
+    export_waveform(
+        client,
+        session="sess_1",
+        expression='v("/OUT")',
+        local_path="wave.txt",
+        history="Interactive.7",
+        precision=12,
+        width=20,
+    )
+
+    ocn_print = next(call for call in client.skill_calls
+                     if call.startswith("ocnPrint("))
+    assert "?precision 12" in ocn_print
+    assert "?width 20" in ocn_print
+
+
+@pytest.mark.parametrize(
+    ("option", "value", "error"),
+    [
+        ("precision", True, TypeError),
+        ("precision", "6", TypeError),
+        ("precision", 0, ValueError),
+        ("precision", 17, ValueError),
+        ("width", False, TypeError),
+        ("width", 14.0, TypeError),
+        ("width", 3, ValueError),
+    ],
+)
+def test_export_waveform_rejects_invalid_format_options(option, value, error):
+    client = _waveform_client()
+
+    with pytest.raises(error):
+        export_waveform(
+            client,
+            session="sess_1",
+            expression='v("/OUT")',
+            local_path="wave.txt",
+            history="Interactive.7",
+            **{option: value},
+        )
+
+    assert client.skill_calls == []


### PR DESCRIPTION
Adds optional `precision` and `width` arguments to `export_waveform`, passed through to the underlying `ocnPrint` call. Defaults match `ocnPrint`'s own defaults, so this is fully backward compatible.

From Long He.