### PR TITLE
fix: expose ocnPrint numberNotation param in export_waveform

### DIFF
--- a/src/virtuoso_bridge/virtuoso/maestro/reader/runs.py
+++ b/src/virtuoso_bridge/virtuoso/maestro/reader/runs.py
@@ -335,6 +335,7 @@ def export_waveform(
     history: str = "",
     precision: int | None = None,
     width: int | None = None,
+    number_notation: str | None = None,
 ) -> str:
     """Export a waveform via OCEAN to a local text file.
 
@@ -349,6 +350,10 @@ def export_waveform(
         width: optional ocnPrint column width in characters (at least 4).
             To display every requested significant digit, use a width greater
             than or equal to precision.
+        number_notation: optional ocnPrint number format ('suffix,
+            'engineering, 'scientific, or 'none).  Defaults to 'scientific
+            for backward compatibility.  'none skips per-value formatting
+            and is significantly faster on large exports.
 
     Returns the local file path.
     """
@@ -362,8 +367,11 @@ def export_waveform(
             raise TypeError("width must be an int or None")
         if width < 4:
             raise ValueError("width must be at least 4")
+    valid_notations = {"suffix", "engineering", "scientific", "none"}
+    if number_notation is not None and number_notation not in valid_notations:
+        raise ValueError(f"number_notation must be one of {sorted(valid_notations)}")
 
-    format_args = ""
+    format_args = f" ?numberNotation '{number_notation or 'scientific'}"
     if precision is not None:
         format_args += f" ?precision {precision}"
     if width is not None:
@@ -404,8 +412,7 @@ def export_waveform(
     client.execute_skill(f'openResults("{results_dir}")')
     client.execute_skill(f'selectResults("{analysis}")')
     client.execute_skill(
-        f'ocnPrint({expression} '
-        f'?numberNotation \'scientific{format_args} ?numSpaces 1 '
+        f'ocnPrint({expression}{format_args} ?numSpaces 1 '
         f'?output "{remote_path}")')
 
     client.download_file(remote_path, local_path)

--- a/src/virtuoso_bridge/virtuoso/maestro/reader/runs.py
+++ b/src/virtuoso_bridge/virtuoso/maestro/reader/runs.py
@@ -368,8 +368,13 @@ def export_waveform(
         if width < 4:
             raise ValueError("width must be at least 4")
     valid_notations = {"suffix", "engineering", "scientific", "none"}
-    if number_notation is not None and number_notation not in valid_notations:
-        raise ValueError(f"number_notation must be one of {sorted(valid_notations)}")
+    if number_notation is not None:
+        if type(number_notation) is not str:
+            raise TypeError("number_notation must be a str or None")
+        if number_notation not in valid_notations:
+            raise ValueError(
+                f"number_notation must be one of {sorted(valid_notations)}"
+            )
 
     format_args = f" ?numberNotation '{number_notation or 'scientific'}"
     if precision is not None:

--- a/tests/test_maestro_read_results.py
+++ b/tests/test_maestro_read_results.py
@@ -225,6 +225,7 @@ def test_export_waveform_preserves_ocean_format_defaults():
 
     ocn_print = next(call for call in client.skill_calls
                      if call.startswith("ocnPrint("))
+    assert "?numberNotation 'scientific" in ocn_print
     assert "?precision" not in ocn_print
     assert "?width" not in ocn_print
 
@@ -240,12 +241,35 @@ def test_export_waveform_passes_explicit_format_options():
         history="Interactive.7",
         precision=12,
         width=20,
+        number_notation="none",
     )
 
     ocn_print = next(call for call in client.skill_calls
                      if call.startswith("ocnPrint("))
     assert "?precision 12" in ocn_print
     assert "?width 20" in ocn_print
+    assert "?numberNotation 'none" in ocn_print
+
+
+@pytest.mark.parametrize(
+    "notation",
+    ["suffix", "engineering", "scientific", "none"],
+)
+def test_export_waveform_accepts_supported_number_notations(notation):
+    client = _waveform_client()
+
+    export_waveform(
+        client,
+        session="sess_1",
+        expression='v("/OUT")',
+        local_path="wave.txt",
+        history="Interactive.7",
+        number_notation=notation,
+    )
+
+    ocn_print = next(call for call in client.skill_calls
+                     if call.startswith("ocnPrint("))
+    assert f"?numberNotation '{notation}" in ocn_print
 
 
 @pytest.mark.parametrize(
@@ -258,6 +282,9 @@ def test_export_waveform_passes_explicit_format_options():
         ("width", False, TypeError),
         ("width", 14.0, TypeError),
         ("width", 3, ValueError),
+        ("number_notation", True, TypeError),
+        ("number_notation", ["none"], TypeError),
+        ("number_notation", "automatic", ValueError),
     ],
 )
 def test_export_waveform_rejects_invalid_format_options(option, value, error):


### PR DESCRIPTION
Adds an optional `number_notation` argument to `export_waveform`, passed through to `ocnPrint`'s `?numberNotation`. Defaults to `'scientific'` for backward compatibility.

`'none'` skips ocnPrint's per-value number formatting, which is dramatically faster on large exports (measured ~55x on a 24k-row export).
