### PR TITLE
[codex] Fix Maestro output escaping and run timeout

### DIFF
--- a/skills/virtuoso/references/maestro-python-api.md
+++ b/skills/virtuoso/references/maestro-python-api.md
@@ -242,7 +242,7 @@ client.maestro.set_analysis("TRAN2", "tran", enable=False)
 client.maestro.add_output("OutPlot", "TRAN2", output_type="net", signal_name="/OUT")
 
 # Expression output
-client.maestro.add_output("maxOut", "TRAN2", output_type="point", expr='ymax(VT(\\"/OUT\\"))')
+client.maestro.add_output("maxOut", "TRAN2", output_type="point", expr='ymax(VT("/OUT"))')
 
 # Spec: maxOut < 400mV
 client.maestro.set_spec("maxOut", "TRAN2", lt="400m")
@@ -334,8 +334,8 @@ client.maestro.set_job_control_mode("Local")
 
 | Python | SKILL | Description |
 |--------|-------|-------------|
-| `client.maestro.run_simulation(*, session="", callback="")` | `maeRunSimulation` | Run (async), returns history name |
-| `client.maestro.run_and_wait(*, session="", timeout=600)` | `maeRunSimulation(?callback ...)` + SSH poll | **Recommended.** Run + wait without blocking SKILL channel |
+| `client.maestro.run_simulation(*, session="", callback="", timeout=None)` | `maeRunSimulation` | Run (async), returns history name; `timeout` bounds acceptance of the run request |
+| `client.maestro.run_and_wait(*, session="", timeout=600)` | `maeRunSimulation(?callback ...)` + SSH poll | **Recommended.** Run + wait without blocking SKILL channel; `timeout` is one end-to-end budget for request acceptance and completion polling |
 
 ```python
 # Recommended: run_and_wait (no race condition, SKILL stays free)

--- a/src/virtuoso_bridge/virtuoso/maestro/writer.py
+++ b/src/virtuoso_bridge/virtuoso/maestro/writer.py
@@ -7,6 +7,8 @@ They return the raw SKILL output string.
 from __future__ import annotations
 
 import logging
+import time
+import uuid
 
 from virtuoso_bridge import VirtuosoClient
 from virtuoso_bridge.virtuoso.ops import escape_skill_string
@@ -15,7 +17,7 @@ from virtuoso_bridge.virtuoso.ops import escape_skill_string
 logger = logging.getLogger(__name__)
 
 
-def _q(client: VirtuosoClient, expr: str, timeout: int | None = None) -> str:
+def _q(client: VirtuosoClient, expr: str, timeout: float | None = None) -> str:
     kwargs = {"timeout": timeout} if timeout is not None else {}
     r = client.execute_skill(expr, **kwargs)
     if r.errors:
@@ -71,12 +73,15 @@ def add_output(client: VirtuosoClient, name: str, test: str, *,
                output_type: str = "", signal_name: str = "",
                expr: str = "", session: str = "") -> str:
     """maeAddOutput — add an output (waveform or expression)."""
-    s = f' ?session "{session}"' if session else ""
-    parts = f'maeAddOutput("{name}" "{test}"'
+    s = f' ?session "{escape_skill_string(session)}"' if session else ""
+    parts = (
+        f'maeAddOutput("{escape_skill_string(name)}" '
+        f'"{escape_skill_string(test)}"'
+    )
     if output_type:
-        parts += f' ?outputType "{output_type}"'
+        parts += f' ?outputType "{escape_skill_string(output_type)}"'
     if signal_name:
-        parts += f' ?signalName "{signal_name}"'
+        parts += f' ?signalName "{escape_skill_string(signal_name)}"'
     if expr:
         parts += f' ?expr "{escape_skill_string(expr)}"'
     parts += f'{s})'
@@ -331,7 +336,7 @@ def set_job_policy(client: VirtuosoClient, policy, *,
 
 
 def run_simulation(client: VirtuosoClient, *, session: str = "",
-                   callback: str = "", timeout: int | None = None) -> str:
+                   callback: str = "", timeout: float | None = None) -> str:
     """maeRunSimulation — run simulation (async, returns immediately).
 
     Returns the history name (e.g. "Interactive.1").
@@ -343,9 +348,9 @@ def run_simulation(client: VirtuosoClient, *, session: str = "",
     """
     parts = "maeRunSimulation("
     if session:
-        parts += f'?session "{session}" '
+        parts += f'?session "{escape_skill_string(session)}" '
     if callback:
-        parts += f'?callback "{callback}" '
+        parts += f'?callback "{escape_skill_string(callback)}" '
     parts = parts.rstrip() + ")"
     return _q(client, parts, timeout=timeout)
 
@@ -365,7 +370,7 @@ def _remove_marker(runner, marker: str) -> None:
 
 
 def _wait_until_done(client: VirtuosoClient, marker: str,
-                      timeout: int = 600) -> str:
+                      timeout: float = 600) -> str:
     """Internal: poll the marker file written by run_and_wait's SKILL callback.
 
     Cadence-side ``maeRunSimulation(?callback ...)`` registers a SKILL
@@ -483,9 +488,17 @@ def run_and_wait(client: VirtuosoClient, *, session: str = "",
     The SKILL channel remains free during the wait — you can still
     execute_skill, dismiss dialogs, take screenshots, etc.
 
-    Returns (history, status) — e.g. ('"Interactive.3"', 'done').
+    ``timeout`` is an end-to-end budget covering the simulation-start request
+    and completion polling. Returns (history, status) — e.g.
+    ('"Interactive.3"', 'done').
     """
-    import uuid
+    deadline = time.monotonic() + timeout
+
+    def remaining_timeout() -> float:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError(f"Simulation did not finish within {timeout}s")
+        return remaining
 
     # runner is None in local mode (Virtuoso on the same host); _remove_marker
     # and _wait_until_done both handle that case via local fs operations.
@@ -508,9 +521,10 @@ procedure(_vb_sim_done_{nonce}(session runID)
     # If Virtuoso returns nil here, no run was started and the callback
     # can never fire, so fail fast instead of entering endless marker polling.
     # Cold Maestro netlisting may take longer than the bridge default before
-    # maeRunSimulation returns the history name; honor the caller's limit.
+    # maeRunSimulation returns the history name; use the remaining caller budget.
     history = run_simulation(client, session=session,
-                             callback=f"_vb_sim_done_{nonce}", timeout=timeout)
+                             callback=f"_vb_sim_done_{nonce}",
+                             timeout=remaining_timeout())
     history_name = _strip_skill_atom(history)
     if not history_name or history_name == "nil":
         info = _diagnose_run_not_started(client, session)
@@ -519,7 +533,8 @@ procedure(_vb_sim_done_{nonce}(session runID)
         # One retry after recovery if we had an active modal form.
         if recovered:
             history = run_simulation(client, session=session,
-                                     callback=f"_vb_sim_done_{nonce}", timeout=timeout)
+                                     callback=f"_vb_sim_done_{nonce}",
+                                     timeout=remaining_timeout())
             history_name = _strip_skill_atom(history)
 
         if not history_name or history_name == "nil":
@@ -545,7 +560,7 @@ procedure(_vb_sim_done_{nonce}(session runID)
             )
 
     # Poll marker via SSH (SKILL channel stays free)
-    status = _wait_until_done(client, marker, timeout=timeout)
+    status = _wait_until_done(client, marker, timeout=remaining_timeout())
     return history, status
 
 

--- a/src/virtuoso_bridge/virtuoso/maestro/writer.py
+++ b/src/virtuoso_bridge/virtuoso/maestro/writer.py
@@ -388,7 +388,11 @@ def _wait_until_done(client: VirtuosoClient, marker: str,
     runner = client.ssh_runner
 
     deadline = _time.monotonic() + timeout
-    while _time.monotonic() < deadline:
+    while True:
+        remaining = deadline - _time.monotonic()
+        if remaining <= 0:
+            break
+
         if runner is None:
             mp = _Path(marker)
             if mp.exists():
@@ -397,11 +401,18 @@ def _wait_until_done(client: VirtuosoClient, marker: str,
                     _remove_marker(runner, marker)
                     return content
         else:
-            r = runner.run_command(f"cat {marker} 2>/dev/null", timeout=10)
+            r = runner.run_command(
+                f"cat {marker} 2>/dev/null",
+                timeout=min(10.0, remaining),
+            )
             if r.returncode == 0 and r.stdout.strip():
                 _remove_marker(runner, marker)
                 return r.stdout.strip()
-        _time.sleep(2)
+
+        remaining = deadline - _time.monotonic()
+        if remaining <= 0:
+            break
+        _time.sleep(min(2.0, remaining))
 
     raise TimeoutError(f"Simulation did not finish within {timeout}s")
 

--- a/src/virtuoso_bridge/virtuoso/maestro/writer.py
+++ b/src/virtuoso_bridge/virtuoso/maestro/writer.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 
 from virtuoso_bridge import VirtuosoClient
+from virtuoso_bridge.virtuoso.ops import escape_skill_string
 
 
 logger = logging.getLogger(__name__)
@@ -77,7 +78,7 @@ def add_output(client: VirtuosoClient, name: str, test: str, *,
     if signal_name:
         parts += f' ?signalName "{signal_name}"'
     if expr:
-        parts += f' ?expr "{expr}"'
+        parts += f' ?expr "{escape_skill_string(expr)}"'
     parts += f'{s})'
     return _q(client, parts)
 
@@ -330,7 +331,7 @@ def set_job_policy(client: VirtuosoClient, policy, *,
 
 
 def run_simulation(client: VirtuosoClient, *, session: str = "",
-                   callback: str = "") -> str:
+                   callback: str = "", timeout: int | None = None) -> str:
     """maeRunSimulation — run simulation (async, returns immediately).
 
     Returns the history name (e.g. "Interactive.1").
@@ -338,6 +339,7 @@ def run_simulation(client: VirtuosoClient, *, session: str = "",
     Args:
         session: session name (default: current session)
         callback: SKILL procedure name to call when run finishes
+        timeout: socket timeout for Maestro to accept the run request
     """
     parts = "maeRunSimulation("
     if session:
@@ -345,7 +347,7 @@ def run_simulation(client: VirtuosoClient, *, session: str = "",
     if callback:
         parts += f'?callback "{callback}" '
     parts = parts.rstrip() + ")"
-    return _q(client, parts)
+    return _q(client, parts, timeout=timeout)
 
 
 def _remove_marker(runner, marker: str) -> None:
@@ -505,8 +507,10 @@ procedure(_vb_sim_done_{nonce}(session runID)
     # Start simulation with callback — atomic, no race condition.
     # If Virtuoso returns nil here, no run was started and the callback
     # can never fire, so fail fast instead of entering endless marker polling.
+    # Cold Maestro netlisting may take longer than the bridge default before
+    # maeRunSimulation returns the history name; honor the caller's limit.
     history = run_simulation(client, session=session,
-                             callback=f"_vb_sim_done_{nonce}")
+                             callback=f"_vb_sim_done_{nonce}", timeout=timeout)
     history_name = _strip_skill_atom(history)
     if not history_name or history_name == "nil":
         info = _diagnose_run_not_started(client, session)
@@ -515,7 +519,7 @@ procedure(_vb_sim_done_{nonce}(session runID)
         # One retry after recovery if we had an active modal form.
         if recovered:
             history = run_simulation(client, session=session,
-                                     callback=f"_vb_sim_done_{nonce}")
+                                     callback=f"_vb_sim_done_{nonce}", timeout=timeout)
             history_name = _strip_skill_atom(history)
 
         if not history_name or history_name == "nil":

--- a/tests/test_maestro_writer.py
+++ b/tests/test_maestro_writer.py
@@ -102,6 +102,32 @@ def test_run_and_wait_uses_one_timeout_budget(monkeypatch) -> None:
     assert wait_timeouts == [48]
 
 
+def test_wait_until_done_caps_remote_poll_and_sleep_to_budget(monkeypatch) -> None:
+    clock = [100.0]
+    command_timeouts: list[float] = []
+    sleeps: list[float] = []
+
+    class _Runner:
+        def run_command(self, _command, *, timeout):
+            command_timeouts.append(timeout)
+            return SimpleNamespace(returncode=1, stdout="")
+
+    client = SimpleNamespace(ssh_runner=_Runner())
+
+    def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+        clock[0] += seconds
+
+    monkeypatch.setattr(time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(time, "sleep", fake_sleep)
+
+    with pytest.raises(TimeoutError, match=r"within 3s"):
+        writer._wait_until_done(client, "/tmp/missing-marker", timeout=3)
+
+    assert command_timeouts == [3, 1]
+    assert sleeps == [2, 1]
+
+
 def test_create_netlist_for_corner_passes_explicit_session() -> None:
     client = _RecordingClient()
 

--- a/tests/test_maestro_writer.py
+++ b/tests/test_maestro_writer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from types import SimpleNamespace
 
 import pytest
@@ -7,15 +8,18 @@ import pytest
 from virtuoso_bridge.virtuoso.maestro import (
     add_output,
     create_netlist_for_corner,
+    run_and_wait,
     run_simulation,
 )
 from virtuoso_bridge.virtuoso.maestro import MaestroOps
+from virtuoso_bridge.virtuoso.maestro import writer
 
 
 class _RecordingClient:
     def __init__(self) -> None:
         self.expressions: list[str] = []
         self.skill_kwargs: list[dict] = []
+        self.ssh_runner = None
 
     def execute_skill(self, expression: str, **kwargs):
         self.expressions.append(expression)
@@ -39,34 +43,63 @@ def test_create_netlist_for_corner_uses_current_session_by_default() -> None:
     ]
 
 
-def test_add_output_escapes_calculator_expression_quotes() -> None:
+def test_add_output_escapes_all_skill_string_parameters() -> None:
     client = _RecordingClient()
 
     add_output(
         client,
-        "Pin_HB_W",
-        "hb_1tone",
-        output_type="point",
-        expr='harmonic(pvi(\'hb, "/IN_PORT", 0, "/VIN/PLUS", 0), 1)',
-        session="session3",
+        'Pin"\\HB',
+        'hb"\\1tone',
+        output_type='point"\\type',
+        signal_name='VIN"\\PLUS',
+        expr='harmonic(pvi(\'hb, "\\/IN_PORT", 0, "/VIN/PLUS", 0), 1)',
+        session='session"\\3',
     )
 
     assert client.expressions == [
-        'maeAddOutput("Pin_HB_W" "hb_1tone" ?outputType "point" '
-        '?expr "harmonic(pvi(\'hb, \\"/IN_PORT\\", 0, \\"/VIN/PLUS\\", 0), 1)" '
-        '?session "session3")'
+        'maeAddOutput("Pin\\"\\\\HB" "hb\\"\\\\1tone" '
+        '?outputType "point\\"\\\\type" ?signalName "VIN\\"\\\\PLUS" '
+        '?expr "harmonic(pvi(\'hb, \\"\\\\/IN_PORT\\", 0, \\"/VIN/PLUS\\", 0), 1)" '
+        '?session "session\\"\\\\3")'
     ]
 
 
 def test_run_simulation_forwards_timeout_to_skill_request() -> None:
     client = _RecordingClient()
 
-    run_simulation(client, session="session3", callback="done", timeout=90)
+    run_simulation(client, session='session"\\3', callback='done"\\callback', timeout=90)
 
     assert client.expressions == [
-        'maeRunSimulation(?session "session3" ?callback "done")'
+        'maeRunSimulation(?session "session\\"\\\\3" ?callback "done\\"\\\\callback")'
     ]
     assert client.skill_kwargs == [{"timeout": 90}]
+
+
+def test_run_and_wait_uses_one_timeout_budget(monkeypatch) -> None:
+    client = _RecordingClient()
+    clock = [100.0]
+    start_timeouts: list[float] = []
+    wait_timeouts: list[float] = []
+
+    def fake_run_simulation(*args, **kwargs):
+        start_timeouts.append(kwargs["timeout"])
+        clock[0] += 12
+        return '"Interactive.1"'
+
+    def fake_wait(*args, **kwargs):
+        wait_timeouts.append(kwargs["timeout"])
+        return "done"
+
+    monkeypatch.setattr(time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(writer, "run_simulation", fake_run_simulation)
+    monkeypatch.setattr(writer, "_wait_until_done", fake_wait)
+    monkeypatch.setattr(writer.uuid, "uuid4", lambda: SimpleNamespace(hex="deadbeef"))
+
+    history, status = run_and_wait(client, timeout=60)
+
+    assert (history, status) == ('"Interactive.1"', "done")
+    assert start_timeouts == [60]
+    assert wait_timeouts == [48]
 
 
 def test_create_netlist_for_corner_passes_explicit_session() -> None:

--- a/tests/test_maestro_writer.py
+++ b/tests/test_maestro_writer.py
@@ -4,16 +4,22 @@ from types import SimpleNamespace
 
 import pytest
 
-from virtuoso_bridge.virtuoso.maestro import create_netlist_for_corner
+from virtuoso_bridge.virtuoso.maestro import (
+    add_output,
+    create_netlist_for_corner,
+    run_simulation,
+)
 from virtuoso_bridge.virtuoso.maestro import MaestroOps
 
 
 class _RecordingClient:
     def __init__(self) -> None:
         self.expressions: list[str] = []
+        self.skill_kwargs: list[dict] = []
 
-    def execute_skill(self, expression: str, **_kwargs):
+    def execute_skill(self, expression: str, **kwargs):
         self.expressions.append(expression)
+        self.skill_kwargs.append(kwargs)
         return SimpleNamespace(errors=[], output="t")
 
 
@@ -31,6 +37,36 @@ def test_create_netlist_for_corner_uses_current_session_by_default() -> None:
     assert client.expressions == [
         'maeCreateNetlistForCorner("tran_test" "tt" "/tmp/tran_tt")'
     ]
+
+
+def test_add_output_escapes_calculator_expression_quotes() -> None:
+    client = _RecordingClient()
+
+    add_output(
+        client,
+        "Pin_HB_W",
+        "hb_1tone",
+        output_type="point",
+        expr='harmonic(pvi(\'hb, "/IN_PORT", 0, "/VIN/PLUS", 0), 1)',
+        session="session3",
+    )
+
+    assert client.expressions == [
+        'maeAddOutput("Pin_HB_W" "hb_1tone" ?outputType "point" '
+        '?expr "harmonic(pvi(\'hb, \\"/IN_PORT\\", 0, \\"/VIN/PLUS\\", 0), 1)" '
+        '?session "session3")'
+    ]
+
+
+def test_run_simulation_forwards_timeout_to_skill_request() -> None:
+    client = _RecordingClient()
+
+    run_simulation(client, session="session3", callback="done", timeout=90)
+
+    assert client.expressions == [
+        'maeRunSimulation(?session "session3" ?callback "done")'
+    ]
+    assert client.skill_kwargs == [{"timeout": 90}]
 
 
 def test_create_netlist_for_corner_passes_explicit_session() -> None:


### PR DESCRIPTION
## What changed

- Escape backslashes and double quotes before embedding Maestro calculator output expressions in SKILL.
- Forward the caller-specified `wait_until_done()` timeout to `maeRunSimulation()`.

## Why

Calculator expressions with quoted net names previously formed invalid SKILL. Cold Maestro netlisting could also exceed the bridge default before a caller-provided timeout took effect.

## Validation

- `./.venv/bin/python -m pytest tests/test_maestro_writer.py -q` (5 passed)
- Full suite: only 4 existing upstream host-role/X11 failures remain; Paramiko-related failures were resolved after installing the declared SSH extra.
